### PR TITLE
feat: Floating Action Button 추가

### DIFF
--- a/src/assets/common/makegroupfab.svg
+++ b/src/assets/common/makegroupfab.svg
@@ -1,0 +1,11 @@
+<svg width="51" height="50" viewBox="0 0 51 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<foreignObject x="-4.75" y="-5" width="60" height="60"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.5px);clip-path:url(#bgblur_0_3261_96569_clip_path);height:100%;width:100%"></div></foreignObject><g data-figma-bg-blur-radius="5">
+<circle cx="25.25" cy="25" r="25" fill="#3D3D3D"/>
+<circle cx="25.25" cy="25" r="24" stroke="#A7FFB4" stroke-opacity="0.5" stroke-width="2"/>
+</g>
+<path d="M23.4561 17H16.9561V33H32.9561V26.5" stroke="#A7FFB4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M29.2061 20.75V23C29.2061 23.4142 29.5418 23.75 29.9561 23.75C30.3703 23.75 30.7061 23.4142 30.7061 23V20.75H32.9561C33.3703 20.75 33.7061 20.4142 33.7061 20C33.7061 19.5858 33.3703 19.25 32.9561 19.25H30.7061V17C30.7061 16.5858 30.3703 16.25 29.9561 16.25C29.5418 16.25 29.2061 16.5858 29.2061 17V19.25H26.9561C26.5418 19.25 26.2061 19.5858 26.2061 20C26.2061 20.4142 26.5418 20.75 26.9561 20.75H29.2061Z" fill="#A7FFB4"/>
+<defs>
+<clipPath id="bgblur_0_3261_96569_clip_path" transform="translate(4.75 5)"><circle cx="25.25" cy="25" r="25"/>
+</clipPath></defs>
+</svg>

--- a/src/assets/common/writefab.svg
+++ b/src/assets/common/writefab.svg
@@ -1,0 +1,11 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<foreignObject x="-5" y="-5" width="60" height="60"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.5px);clip-path:url(#bgblur_0_1226_35438_clip_path);height:100%;width:100%"></div></foreignObject><g data-figma-bg-blur-radius="5">
+<circle cx="25" cy="25" r="25" fill="#3D3D3D"/>
+<circle cx="25" cy="25" r="24" stroke="#A7FFB4" stroke-opacity="0.5" stroke-width="2"/>
+</g>
+<path d="M24.7061 33H33.7061" stroke="#A7FFB4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M29.1104 16.6169C29.5054 16.2219 30.0411 16 30.5998 16C30.8764 16 31.1503 16.0545 31.4058 16.1603C31.6614 16.2662 31.8936 16.4213 32.0891 16.6169C32.2847 16.8125 32.4399 17.0447 32.5457 17.3002C32.6516 17.5558 32.7061 17.8297 32.7061 18.1063C32.7061 18.3829 32.6516 18.6568 32.5457 18.9123C32.4399 19.1679 32.2847 19.4001 32.0891 19.5957L19.6777 32.0071L15.7061 33L16.699 29.0283L29.1104 16.6169Z" stroke="#A7FFB4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<clipPath id="bgblur_0_1226_35438_clip_path" transform="translate(5 5)"><circle cx="25" cy="25" r="25"/>
+</clipPath></defs>
+</svg>

--- a/src/components/common/Fab.tsx
+++ b/src/components/common/Fab.tsx
@@ -21,7 +21,7 @@ const Fab = ({ src, path }: FabProps) => {
   };
   return (
     <Button onClick={handleClick}>
-      <img src={src} />
+      <img src={src} alt="FAB" />
     </Button>
   );
 };

--- a/src/components/common/Fab.tsx
+++ b/src/components/common/Fab.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+import type { FabProps } from '../../types/fab';
+
+const Button = styled.div`
+  position: absolute;
+  right: 20px;
+  bottom: 105px;
+  img {
+    cursor: pointer;
+  }
+`;
+
+const Fab = ({ src, path }: FabProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    if (path) {
+      navigate(path);
+    }
+  };
+  return (
+    <Button onClick={handleClick}>
+      <img src={src} />
+    </Button>
+  );
+};
+
+export default Fab;

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -1,5 +1,7 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
+import Fab from './Fab';
+import type { FabProps } from '../../types/fab';
 import FeedIcon from '../../assets/navbar/feed.svg';
 import GroupIcon from '../../assets/navbar/group.svg';
 import SearchIcon from '../../assets/navbar/search.svg';
@@ -10,6 +12,10 @@ import SearchIconActive from '../../assets/navbar/search-active.svg';
 import MyIconActive from '../../assets/navbar/my-active.svg';
 
 const NavWrapper = styled.div`
+  position: relative;
+`;
+
+const NavContainer = styled.div`
   position: fixed;
   bottom: 0;
   left: 0;
@@ -66,23 +72,26 @@ const items: RouteItem[] = [
   { path: '/my', label: '내 정보', icon: MyIcon, activeIcon: MyIconActive },
 ];
 
-const NavBar = () => {
+const NavBar = ({ src, path }: FabProps) => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
   return (
     <NavWrapper>
-      {items.map(item => {
-        const isActive = pathname === item.path;
-        const src = isActive ? item.activeIcon : item.icon;
+      <NavContainer>
+        {items.map(item => {
+          const isActive = pathname === item.path;
+          const src = isActive ? item.activeIcon : item.icon;
 
-        return (
-          <NavItem key={item.path} active={isActive} onClick={() => navigate(item.path)}>
-            <img src={src} alt={item.label} />
-            <div>{item.label}</div>
-          </NavItem>
-        );
-      })}
+          return (
+            <NavItem key={item.path} active={isActive} onClick={() => navigate(item.path)}>
+              <img src={src} alt={item.label} />
+              <div>{item.label}</div>
+            </NavItem>
+          );
+        })}
+        <Fab src={src} path={path} />
+      </NavContainer>
     </NavWrapper>
   );
 };

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -81,11 +81,11 @@ const NavBar = ({ src, path }: FabProps) => {
       <NavContainer>
         {items.map(item => {
           const isActive = pathname === item.path;
-          const src = isActive ? item.activeIcon : item.icon;
+          const iconSrc = isActive ? item.activeIcon : item.icon;
 
           return (
             <NavItem key={item.path} active={isActive} onClick={() => navigate(item.path)}>
-              <img src={src} alt={item.label} />
+              <img src={iconSrc} alt={item.label} />
               <div>{item.label}</div>
             </NavItem>
           );

--- a/src/components/group/MyGroupBox.tsx
+++ b/src/components/group/MyGroupBox.tsx
@@ -62,7 +62,7 @@ const Container = styled.div`
 const Header = styled.div`
   display: flex;
   align-items: center;
-  margin: 20px 16px;
+  margin: 20px;
 `;
 
 const Title = styled.h2`

--- a/src/pages/feed/Feed.tsx
+++ b/src/pages/feed/Feed.tsx
@@ -5,7 +5,8 @@ import TabBar from '../../components/feed/TabBar';
 import MyFeed from '../../components/feed/MyFeed';
 import TotalFeed from '../../components/feed/TotalFeed';
 import type { PostData } from '../../types/post';
-
+import MainHeader from '@/components/common/MainHeader';
+import writefab from '../../assets/common/writefab.svg';
 const Container = styled.div`
   min-width: 320px;
   max-width: 767px;
@@ -57,14 +58,14 @@ const Feed = () => {
 
   return (
     <Container>
-      {/* MainHeader.tsx */}
+      <MainHeader type="home" />
       <TabBar tabs={tabs} activeTab={activeTab} onTabClick={setActiveTab} />
       {activeTab === '피드' ? (
         <TotalFeed showHeader={true} posts={mockPosts} isMyFeed={false} />
       ) : (
         <MyFeed showHeader={false} posts={mockPosts} isMyFeed={true} />
       )}
-      <NavBar />
+      <NavBar src={writefab} path="/" />
     </Container>
   );
 };

--- a/src/pages/group/Group.tsx
+++ b/src/pages/group/Group.tsx
@@ -9,6 +9,7 @@ import { RecruitingGroupCarousel, type Section } from '@/components/group/Recrui
 import { useState } from 'react';
 import { MyGroupModal } from '@/components/group/MyGroupModal';
 import CompletedGroupModal from '@/components/group/CompletedGroupModal';
+import makegroupfab from '../../assets/common/makegroupfab.svg';
 
 const dummyMyGroups: GroupType[] = [
   {
@@ -133,7 +134,7 @@ const Group = () => {
       <MyGroupBox groups={dummyMyGroups} onMyGroupsClick={openMyGroupModal}></MyGroupBox>
       <Blank height={'10px'} margin={'32px 0'}></Blank>
       <RecruitingGroupCarousel sections={sections} />
-      <NavBar />
+      <NavBar src={makegroupfab} path="/group/create" />
     </Wrapper>
   );
 };

--- a/src/types/fab.ts
+++ b/src/types/fab.ts
@@ -1,0 +1,4 @@
+export interface FabProps {
+  src?: string;
+  path?: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#23 : [UI] 피드 페이지 (사용자 검색, 구독)

## 📝작업 내용
Fab 컴포넌트를 개별 컴포넌트로 분리하여 NavBar 내부에 포함했습니다.
뷰포트가 아닌 NavBar 기준으로 버튼 위치를 제어할 수 있어 반응형 대응이 쉽게 구현했습니다.
또한, 재사용성을 고려해 FabProps에 버튼 이미지 경로(src)와 클릭 시 이동할 경로(path)를 props로 정의했습니다.

### 스크린샷
- 피드 페이지 글 작성 fab
<img width="804" alt="image" src="https://github.com/user-attachments/assets/c5a50ff8-d966-4f7b-a35e-50832a2078bc" />
- 모임방 메인 페이지 모임방 생성 fab
<img width="877" alt="image" src="https://github.com/user-attachments/assets/b41fe944-c192-4ef8-8b82-29aa058c9445" />

## 💬리뷰 요구사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 화면 우측 하단에 고정된 플로팅 액션 버튼(Fab)이 추가되었습니다. 해당 버튼은 이미지를 표시하며, 클릭 시 지정된 경로로 이동합니다.
  * 네비게이션 바(NavBar)에 Fab 버튼이 통합되어, 페이지별로 다른 이미지와 이동 경로를 지원합니다.

* **스타일**
  * 그룹 박스 헤더의 마진이 모든 방향에 균일하게 적용되도록 조정되었습니다.

* **기타**
  * 일부 페이지에서 Fab 버튼에 사용할 이미지 및 경로가 새롭게 지정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->