### PR TITLE
feat: 더보기 모달 / 팝업 모달 구현 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import Router from './pages';
 import { Global } from '@emotion/react';
 import { globalStyles } from './styles/global/global';
+import ModalContainer from './components/common/Modal/ModalContainer';
 
 const App = () => {
   return (
     <>
       <Global styles={globalStyles} />
       <Router />
+      <ModalContainer />
     </>
   );
 };

--- a/src/components/common/Modal/ConfirmModal.tsx
+++ b/src/components/common/Modal/ConfirmModal.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+import { colors, typography } from '@/styles/global/global';
+import type { ConfirmModalProps } from '@/stores/useModalStore';
+
+const ConfirmModal = ({ title, disc, onConfirm, onClose }: ConfirmModalProps) => {
+  return (
+    <Container>
+      <div className="title">{title}</div>
+      <div className="disc">{disc}</div>
+      <ButtonContainer>
+        <Button variant="no" onClick={onClose}>
+          아니요
+        </Button>
+        <Button variant="yes" onClick={onConfirm}>
+          예
+        </Button>
+      </ButtonContainer>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 320px;
+  height: 182px;
+  padding: 20px;
+  justify-content: space-between;
+  border-radius: 12px;
+  background-color: ${colors.darkgrey.main};
+
+  .title {
+    color: ${colors.white};
+    font-size: ${typography.fontSize.lg};
+    font-weight: ${typography.fontWeight.medium};
+    line-height: 24px;
+  }
+
+  .disc {
+    color: ${colors.white};
+    font-size: ${typography.fontSize.sm};
+    font-weight: ${typography.fontWeight.regular};
+    line-height: normal;
+  }
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+`;
+
+const Button = styled.div<{ variant: 'yes' | 'no' }>`
+  width: 130px;
+  height: 44px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  color: ${colors.white};
+  font-size: ${typography.fontSize.base};
+  font-weight: ${typography.fontWeight.semibold};
+  text-align: center;
+  line-height: 24px;
+  background-color: ${({ variant }) => (variant === 'yes' ? colors.purple.main : colors.grey[300])};
+  cursor: pointer;
+`;
+
+export default ConfirmModal;

--- a/src/components/common/Modal/ModalContainer.tsx
+++ b/src/components/common/Modal/ModalContainer.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { useModalStore } from '../../../stores/useModalStore';
+import ConfirmModal from './ConfirmModal';
+import MoreMenu from './MoreMenu';
+import styled from '@emotion/styled';
+import type { ConfirmModalProps, MoreMenuProps } from '../../../stores/useModalStore';
+
+const ModalContainer = () => {
+  const { modalType, modalProps, isModalOpen, closeModal } = useModalStore();
+
+  useEffect(() => {
+    document.body.style.overflow = isModalOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isModalOpen]);
+
+  if (!modalType) return null;
+
+  const renderModal = () => {
+    switch (modalType) {
+      case 'confirm':
+        return <ConfirmModal {...(modalProps as ConfirmModalProps)} onClose={closeModal} />;
+      case 'moremenu':
+        return <MoreMenu {...(modalProps as MoreMenuProps)} onClose={closeModal} />;
+      default:
+        return null;
+    }
+  };
+
+  return <Wrapper>{renderModal()}</Wrapper>;
+};
+const Wrapper = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 320px;
+  max-width: 767px;
+  height: 100vh;
+  margin: 0 auto;
+  background-color: rgba(18, 18, 18, 0.1);
+  backdrop-filter: blur(2.5px);
+  z-index: 1000;
+`;
+
+export default ModalContainer;

--- a/src/components/common/Modal/MoreMenu.tsx
+++ b/src/components/common/Modal/MoreMenu.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled';
+import { colors, typography } from '@/styles/global/global';
+import type { MoreMenuProps } from '@/stores/useModalStore';
+
+const MoreMenu = ({ onEdit, onDelete, onClose }: MoreMenuProps) => {
+  return (
+    <Overlay onClick={onClose}>
+      <Container onClick={e => e.stopPropagation()}>
+        <Button variant="edit" onClick={onEdit}>
+          수정하기
+        </Button>
+        <Button variant="delete" onClick={onDelete}>
+          삭제하기
+        </Button>
+      </Container>
+    </Overlay>
+  );
+};
+
+const Overlay = styled.div`
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100vh;
+  z-index: 999;
+`;
+
+const Container = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  display: flex;
+  flex-direction: column;
+  min-width: 320px;
+  max-width: 767px;
+  width: 100%;
+  height: 141px;
+  padding: 20px;
+  border-radius: 12px 12px 0px 0px;
+  background-color: ${colors.darkgrey.main};
+  z-index: 1001;
+`;
+
+const Button = styled.div<{ variant: 'edit' | 'delete' }>`
+  display: flex;
+  height: 50px;
+  align-items: center;
+  color: ${({ variant }) => (variant === 'edit' ? colors.white : colors.red)};
+  font-size: ${typography.fontSize.base};
+  font-weight: ${typography.fontWeight.semibold};
+  line-height: 24px;
+  border-bottom: 1px solid ${colors.grey[400]};
+  cursor: pointer;
+
+  &:first-of-type {
+    padding: 8px 12px 16px 12px;
+  }
+
+  &:last-of-type {
+    padding: 16px 12px 8px 12px;
+    border-bottom: none;
+  }
+`;
+
+export default MoreMenu;

--- a/src/components/feed/FollowList.tsx
+++ b/src/components/feed/FollowList.tsx
@@ -32,7 +32,7 @@ const FollowList = () => {
   };
 
   const handleMoreClick = () => {
-    navigate('/feed/followlist');
+    navigate('/follow/followlist');
   };
 
   const handleProfileClick = (userId: number) => {

--- a/src/components/feed/MyFollower.tsx
+++ b/src/components/feed/MyFollower.tsx
@@ -70,7 +70,7 @@ const MyFollower = () => {
   ];
 
   const handleMoreClick = () => {
-    navigate('/feed/followerlist');
+    navigate('/follow/followerlist');
   };
 
   return (

--- a/src/components/feed/UserProfileItem.tsx
+++ b/src/components/feed/UserProfileItem.tsx
@@ -1,18 +1,8 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import styled from '@emotion/styled';
 import rightArrow from '../../assets/feed/rightArrow.svg';
-
-export interface UserProfileItemProps {
-  profileImgUrl: string;
-  userName: string;
-  userTitle: string;
-  titleColor: string;
-  followerCount?: number;
-  isFollowed?: boolean;
-  userId: number;
-  isLast?: boolean;
-}
+import type { UserProfileItemProps } from '@/types/user';
 
 const UserProfileItem = ({
   profileImgUrl,
@@ -23,13 +13,13 @@ const UserProfileItem = ({
   isFollowed = false,
   userId,
   isLast,
+  type = 'followlist',
 }: UserProfileItemProps) => {
-  const { pathname } = useLocation();
   const navigate = useNavigate();
   const [followed, setFollowed] = useState(isFollowed);
 
   const handleProfileClick = () => {
-    navigate(`/feed/${userId}`);
+    navigate(`/otherfeed/${userId}`);
   };
 
   const toggleFollow = (e: React.MouseEvent) => {
@@ -41,11 +31,6 @@ const UserProfileItem = ({
     }
     setFollowed(prev => !prev);
     console.log(`${userName} - ${followed ? '팔로우 취소' : '팔로우 요청'}`);
-  };
-
-  const handleFollowerListClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    navigate(`/feed/followerlist/${userId}`);
   };
 
   return (
@@ -60,13 +45,13 @@ const UserProfileItem = ({
             </div>
           </div>
         </div>
-        {pathname === '/feed/followlist' && (
+        {type === 'followlist' && (
           <div className="followbutton" onClick={toggleFollow}>
             {followed ? '띱 취소' : '띱 하기'}
           </div>
         )}
-        {pathname === '/feed/followerlist' && (
-          <div className="followlistbutton" onClick={handleFollowerListClick}>
+        {type === 'followerlist' && (
+          <div className="followlistbutton">
             <div>{followerCount}명이 띱하는 중</div>
             <img src={rightArrow} />
           </div>

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -53,7 +53,7 @@ const SearchBarWrapper = styled.div`
   border-radius: 12px;
   width: calc(100% - 40px);
   margin: 76px 20px 16px 20px;
-  padding: 16px 20px;
+  padding: 8px 12px;
   box-sizing: border-box;
 
   .delete-btn {
@@ -75,6 +75,7 @@ const Input = styled.input`
   font-size: 14px;
   padding: 8px 0;
   box-sizing: border-box;
+  caret-color: var(--color-neongreen);
 
   &::placeholder {
     color: var(--color-grey-300);

--- a/src/data/userData.ts
+++ b/src/data/userData.ts
@@ -1,0 +1,38 @@
+import type { UserProfileItemProps } from '@/types/user';
+
+export const mockUserList: UserProfileItemProps[] = [
+  {
+    profileImgUrl: 'https://placehold.co/36x36',
+    userName: 'ThipOther',
+    userTitle: '칭호칭호',
+    titleColor: '#FF8BAC',
+    followerCount: 15,
+    userId: 9,
+  },
+  {
+    profileImgUrl: 'https://placehold.co/36x36',
+    userName: '하위',
+    userTitle: '칭호칭호',
+    titleColor: '#FF8BAC',
+    followerCount: 15,
+    userId: 1,
+    isFollowed: true,
+  },
+  {
+    profileImgUrl: 'https://placehold.co/36x36',
+    userName: '책읽으러왔음',
+    userTitle: '공식 인플루언서',
+    titleColor: '#A0F8E8',
+    followerCount: 15,
+    userId: 2,
+    isFollowed: false,
+  },
+  {
+    profileImgUrl: 'https://placehold.co/36x36',
+    userName: 'thip01',
+    userTitle: '작가',
+    titleColor: '#A0F8E8',
+    followerCount: 7,
+    userId: 3,
+  },
+];

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,20 @@
+import { useModalStore } from '@/stores/useModalStore';
+import type { ConfirmModalProps, MoreMenuProps } from '@/stores/useModalStore';
+
+export const useModal = () => {
+  const { openModal, closeModal } = useModalStore();
+
+  const openConfirm = (props: ConfirmModalProps) => {
+    openModal('confirm', props);
+  };
+
+  const openMoreMenu = (props: MoreMenuProps) => {
+    openModal('moremenu', props);
+  };
+
+  return {
+    openConfirm,
+    openMoreMenu,
+    closeModal,
+  };
+};

--- a/src/pages/feed/Feed.tsx
+++ b/src/pages/feed/Feed.tsx
@@ -7,6 +7,7 @@ import TotalFeed from '../../components/feed/TotalFeed';
 import MainHeader from '@/components/common/MainHeader';
 import writefab from '../../assets/common/writefab.svg';
 import { mockPosts } from '@/data/postData';
+import { useNavigate } from 'react-router-dom';
 
 const Container = styled.div`
   min-width: 320px;
@@ -17,7 +18,12 @@ const Container = styled.div`
 const tabs = ['피드', '내 피드'];
 
 const Feed = () => {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState(tabs[0]);
+
+  const handleSearchButton = () => {
+    navigate('/feed/search');
+  };
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -25,7 +31,7 @@ const Feed = () => {
 
   return (
     <Container>
-      <MainHeader type="home" />
+      <MainHeader type="home" leftButtonClick={handleSearchButton} />
       <TabBar tabs={tabs} activeTab={activeTab} onTabClick={setActiveTab} />
       {activeTab === '피드' ? (
         <TotalFeed showHeader={true} posts={mockPosts} isMyFeed={false} />

--- a/src/pages/feed/FeedDetailPage.tsx
+++ b/src/pages/feed/FeedDetailPage.tsx
@@ -8,15 +8,32 @@ import moreIcon from '../../assets/common/more.svg';
 import ReplyList from '@/components/common/Post/ReplyList';
 import { mockFeedPost, mockCommentList } from '@/data/postData';
 import MessageInput from '@/components/today-words/MessageInput';
+import { useModalStore } from '@/stores/useModalStore';
 
 const FeedDetailPage = () => {
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
+  const { openModal } = useModalStore();
+
   const handleBackClick = () => {
     navigate(-1);
   };
-  const handleMoreClick = () => {};
 
+  const handleMoreClick = () => {
+    openModal('moremenu', {
+      onEdit: () => {
+        console.log('수정하기 클릭');
+      },
+      onDelete: () => {
+        console.log('삭제하기 클릭');
+        openModal('confirm', {
+          title: '이 피드를 삭제하시겠어요?',
+          disc: '삭제 후에는 되돌릴 수 없어요',
+          onConfirm: () => console.log('확인 클릭'),
+        });
+      },
+    });
+  };
   const handleSend = () => {
     if (!message.trim()) return;
     console.log('작성한 댓글 내용:', message);

--- a/src/pages/feed/FollowerListPage.tsx
+++ b/src/pages/feed/FollowerListPage.tsx
@@ -3,47 +3,12 @@ import styled from '@emotion/styled';
 import TitleHeader from '@/components/common/TitleHeader';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import UserProfileItem from '@/components/feed/UserProfileItem';
-import type { UserProfileItemProps } from '@/components/feed/UserProfileItem';
-
-const mockUserList: UserProfileItemProps[] = [
-  {
-    profileImgUrl: 'https://placehold.co/36x36',
-    userName: 'ThipOther',
-    userTitle: '칭호칭호',
-    titleColor: '#FF8BAC',
-    followerCount: 15,
-    userId: 1,
-  },
-  {
-    profileImgUrl: 'https://placehold.co/36x36',
-    userName: '하위',
-    userTitle: '칭호칭호',
-    titleColor: '#FF8BAC',
-    followerCount: 15,
-    userId: 1,
-    isFollowed: true,
-  },
-  {
-    profileImgUrl: 'https://placehold.co/36x36',
-    userName: '책읽으러왔음',
-    userTitle: '공식 인플루언서',
-    titleColor: '#A0F8E8',
-    userId: 2,
-    isFollowed: false,
-  },
-  {
-    profileImgUrl: 'https://placehold.co/36x36',
-    userName: 'thip01',
-    userTitle: '작가',
-    titleColor: '#A0F8E8',
-    followerCount: 7,
-    userId: 3,
-  },
-];
+import { mockUserList } from '@/data/userData';
+import type { UserProfileType } from '@/types/user';
 
 const FollowerListPage = () => {
   const navigate = useNavigate();
-  const { type } = useParams();
+  const { type } = useParams<{ type: UserProfileType }>();
   const title = type === 'followerlist' ? '띱 목록' : '내 띱 목록';
   const handleBackClick = () => {
     navigate(-1);
@@ -56,7 +21,12 @@ const FollowerListPage = () => {
       <TotalBar>전체 {totalCount}</TotalBar>
       <UserProfileList>
         {mockUserList.map((user, index) => (
-          <UserProfileItem key={index} {...user} isLast={index === mockUserList.length - 1} />
+          <UserProfileItem
+            key={index}
+            {...user}
+            type={type as UserProfileType}
+            isLast={index === mockUserList.length - 1}
+          />
         ))}
       </UserProfileList>
     </Wrapper>

--- a/src/pages/feed/UserSearch.tsx
+++ b/src/pages/feed/UserSearch.tsx
@@ -1,0 +1,137 @@
+import NavBar from '@/components/common/NavBar';
+import TitleHeader from '@/components/common/TitleHeader';
+import RecentSearchTabs from '@/components/search/RecentSearchTabs';
+import SearchBar from '@/components/search/SearchBar';
+import { colors } from '@/styles/global/global';
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
+import leftArrow from '../../assets/common/leftArrow.svg';
+import { mockUserList } from '@/data/userData';
+import { UserSearchResult } from './UserSearchResult';
+import { useNavigate } from 'react-router-dom';
+
+const UserSearch = () => {
+  const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
+  const [isSearched, setIsSearched] = useState(false);
+
+  const [recentSearches, setRecentSearches] = useState<string[]>([
+    '닉네임',
+    '작가',
+    '하위',
+    'Thip',
+    '책벌레',
+  ]);
+
+  const handleChange = (value: string) => {
+    setSearchTerm(value);
+    setIsSearched(false);
+    setIsSearching(value.trim() !== '');
+  };
+
+  const handleSearch = (term: string) => {
+    if (!term.trim()) return;
+    setIsSearching(true);
+    setIsSearched(true);
+    setRecentSearches(prev => {
+      const filtered = prev.filter(t => t !== term);
+      return [term, ...filtered].slice(0, 5);
+    });
+  };
+
+  const handleDelete = (recentSearch: string) => {
+    setRecentSearches(prev => prev.filter(t => t !== recentSearch));
+  };
+
+  const handleRecentSearchClick = (recentSearch: string) => {
+    setSearchTerm(recentSearch);
+    setIsSearched(true);
+    setIsSearching(true);
+  };
+
+  const handleBackButton = () => {
+    navigate(-1);
+  };
+
+  useEffect(() => {
+    if (searchTerm.trim() === '') {
+      setIsSearching(false);
+      setIsSearched(false);
+    }
+  }, [searchTerm]);
+
+  return (
+    <Wrapper>
+      <TitleHeader
+        title="사용자 찾기"
+        leftIcon={<img src={leftArrow} alt="뒤로 가기" />}
+        onLeftClick={handleBackButton}
+      />
+      <SearchBarContainer>
+        <SearchBar
+          placeholder="내가 찾는 사용자를 검색해보세요."
+          value={searchTerm}
+          onChange={handleChange}
+          onSearch={() => handleSearch(searchTerm.trim())}
+          isSearched={isSearched}
+        />
+      </SearchBarContainer>
+      <Content>
+        {isSearching ? (
+          <>
+            (
+            {isSearched ? (
+              <UserSearchResult
+                type={'searched'}
+                searchedUserList={mockUserList}
+              ></UserSearchResult>
+            ) : (
+              <UserSearchResult
+                type={'searching'}
+                searchedUserList={mockUserList}
+              ></UserSearchResult>
+            )}
+            )
+          </>
+        ) : (
+          <>
+            <RecentSearchTabs
+              recentSearches={recentSearches}
+              handleDelete={handleDelete}
+              handleRecentSearchClick={handleRecentSearchClick}
+            />
+          </>
+        )}
+      </Content>
+      <NavBar />
+    </Wrapper>
+  );
+};
+
+export default UserSearch;
+
+const Wrapper = styled.div`
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  min-width: 320px;
+  max-width: 767px;
+  height: 100vh;
+  margin: 0 auto;
+  background: ${colors.black.main};
+`;
+
+const SearchBarContainer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  max-width: 767px;
+  margin: 0 auto;
+  background: ${colors.black.main};
+`;
+
+const Content = styled.div`
+  margin-top: 132px;
+`;

--- a/src/pages/feed/UserSearchResult.tsx
+++ b/src/pages/feed/UserSearchResult.tsx
@@ -1,0 +1,65 @@
+import type { UserProfileItemProps } from '@/types/user';
+import styled from '@emotion/styled';
+import { colors, typography } from '@/styles/global/global';
+import UserProfileItem from '@/components/feed/UserProfileItem';
+
+interface UserSearchResultProps {
+  type: 'searching' | 'searched';
+  searchedUserList: UserProfileItemProps[];
+}
+
+export function UserSearchResult({ type, searchedUserList }: UserSearchResultProps) {
+  const isEmptySearchedUserList = () => {
+    if (searchedUserList.length === 0) return true;
+    else return false;
+  };
+
+  return (
+    <Wrapper>
+      <List>
+        {type === 'searching' ? <></> : <ResultHeader>전체 {searchedUserList.length}</ResultHeader>}
+
+        {isEmptySearchedUserList() ? (
+          <EmptyWrapper></EmptyWrapper>
+        ) : (
+          searchedUserList.map((user, index) => (
+            <UserProfileItem
+              key={user.userId}
+              {...user}
+              type="followerlist"
+              isLast={index === searchedUserList.length - 1}
+            />
+          ))
+        )}
+      </List>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 20px;
+  margin-bottom: 72px;
+`;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ResultHeader = styled.div`
+  font-size: ${typography.fontSize.sm};
+  font-weight: ${typography.fontWeight.medium};
+  color: ${colors.white};
+  padding-bottom: 8px;
+  border-bottom: 1px solid ${colors.darkgrey.dark};
+`;
+
+const EmptyWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 60vh;
+`;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,6 +20,7 @@ import FollowerListPage from './feed/FollowerListPage';
 import TodayWords from './today-words/TodayWords';
 import FeedDetailPage from './feed/FeedDetailPage';
 import ScrollToTop from '@/components/common/ScrollToTop';
+import UserSearch from './feed/UserSearch';
 
 const Router = () => {
   const router = createBrowserRouter(
@@ -35,6 +36,7 @@ const Router = () => {
         <Route path="group" element={<Group />} />
         <Route path="groupsearch" element={<GroupSearch />} />
         <Route path="feed" element={<Feed />} />
+        <Route path="feed/search" element={<UserSearch />} />
         <Route path="feed/:feedId" element={<FeedDetailPage />} />
         <Route path="search" element={<Search />} />
         <Route path="search/applybook" element={<ApplyBook />} />

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+
+export type ModalType = 'confirm' | 'moremenu' | null;
+
+// 모달별 Props 정의
+export interface ConfirmModalProps {
+  title: string;
+  disc: string;
+  onConfirm?: () => void;
+  onClose?: () => void;
+}
+
+export interface MoreMenuProps {
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onClose?: () => void;
+}
+
+interface ModalState {
+  modalType: ModalType;
+  modalProps?: ConfirmModalProps | MoreMenuProps;
+  isModalOpen: boolean;
+  openModal: (type: ModalType, props?: ConfirmModalProps | MoreMenuProps) => void;
+  closeModal: () => void;
+}
+
+export const useModalStore = create<ModalState>(set => ({
+  modalType: null,
+  modalProps: {},
+  isModalOpen: false,
+  openModal: (type, props) => set({ modalType: type, modalProps: props, isModalOpen: true }),
+  closeModal: () => set({ modalType: null, modalProps: {}, isModalOpen: false }),
+}));

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,13 @@
+export type UserProfileType = 'followlist' | 'followerlist';
+
+export interface UserProfileItemProps {
+  profileImgUrl: string;
+  userName: string;
+  userTitle: string;
+  titleColor: string;
+  followerCount?: number;
+  isFollowed?: boolean;
+  userId: number;
+  isLast?: boolean;
+  type?: UserProfileType;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
close#23 [UI] 피드페이지 구현

## 📝작업 내용
- ConfirmModal.tsx (예/아니오 모달)
<img width="2346" height="1958" alt="image" src="https://github.com/user-attachments/assets/8f5a0565-d7d4-4c4d-962d-ea18a10123b5" />
- MoreMenu.tsx (더보기 모달)
<img width="904" height="987" alt="image" src="https://github.com/user-attachments/assets/56c8050c-8507-40ae-a167-5d9574b0fbcd" />
 
1. Zustand 스토어를 활용해서 어떤 모달이 열렸는지 (modalType), 모달에 전달할 데이터 (modalProps)를 전역에서 관리하게끔 했습니다.
2. 각기 다른 형태별 모달 컴포넌트를 구현했습니다. (ConfirmModal, MoreMenu)
3. 전역상태를 보고 ModalContainer를 통해 모달을 렌더링하게끔 했습니다.
4. FeedDetailPage 에서 모달이 열리게끔 적용했습니다.

## 💬리뷰 요구사항
우선, 모달 자체가 화면 젤 위에서 렌더링 되고 있기 때문에 모달 컴포넌트 자체를 분리해서 쓰는건 맞다고 생각해서 전역으로 모달을 관리해야겠다고 생각했습니다. 전역에서 모달의 isModalOpen 여부를 파악해 열리고 닫히게끔 처리했습니다. 컴포넌트와 비즈니스 로직의 분리, 모달의 확장성을 고려해 전반적인 코드를 구현했습니다. 

우선 이렇게 구현하는게 괜찮은 것 같은지 여러분들의 생각이 궁금합니다.
그리고 지금처럼 openModal을 직접 호출해서 사용하는게 아니라, useModal (일단해당  코드는 PR에 포함되어 있습니다. 적용만 하지 않은 상태입니다.) 로 훅을 따로 빼서 사용하는게 더 좋을지 궁금합니다! 뭔가 엄청난 차이가 아닌 것 같은데 훅을 따로 또 빼려니 코드만 더 많아지는거 같아서 의문이 들었습니다.