### PR TITLE
feat: 독서메이트 목록 페이지 구현

### DIFF
--- a/src/assets/member/right-chevron.svg
+++ b/src/assets/member/right-chevron.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.54 18L22.54 12L16.54 6" stroke="#FEFEFE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/members/MemberList.styled.ts
+++ b/src/components/members/MemberList.styled.ts
@@ -20,6 +20,11 @@ export const MemberItem = styled.div`
     background-color: ${colors.darkgrey['50']};
   }
 
+  &:focus-visible {
+    outline: 2px solid ${semanticColors.text.point.green};
+    outline-offset: -2px;
+  }
+
   &::after {
     content: '';
     position: absolute;

--- a/src/components/members/MemberList.styled.ts
+++ b/src/components/members/MemberList.styled.ts
@@ -1,0 +1,80 @@
+import styled from '@emotion/styled';
+import { colors, typography, semanticColors } from '../../styles/global/global';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const MemberItem = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  position: relative;
+
+  &:hover {
+    background-color: ${colors.darkgrey['50']};
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 20px;
+    right: 20px;
+    height: 1px;
+    background-color: ${colors.darkgrey.dark};
+  }
+
+  &:last-child::after {
+    display: none;
+  }
+`;
+
+export const ProfileSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+`;
+
+export const ProfileImage = styled.div`
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background-color: ${colors.grey['400']};
+  flex-shrink: 0;
+`;
+
+export const MemberInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const MemberName = styled.div`
+  color: ${semanticColors.text.primary};
+  font-size: ${typography.fontSize.sm};
+  font-weight: ${typography.fontWeight.medium};
+`;
+
+export const MemberRole = styled.div`
+  color: ${semanticColors.text.point.green};
+  font-size: ${typography.fontSize.xs};
+  font-weight: ${typography.fontWeight.regular};
+`;
+
+export const MemberStatus = styled.div`
+  color: white;
+  font-size: 11px;
+  font-weight: ${typography.fontWeight.regular};
+`;
+
+export const ChevronIcon = styled.img`
+  width: 24px;
+  height: 24px;
+`;

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import type { KeyboardEvent } from 'react';
 import rightChevron from '../../assets/member/right-chevron.svg';
 import type { Member } from '../../mocks/members.mock';
 import {
@@ -26,14 +27,7 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
       onMemberClick(memberId);
     } else {
       // 기본 동작: 개별 유저 페이지로 이동
-      navigate(`/user/${memberId}`);
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent, memberId: string) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleMemberClick(memberId);
+      navigate(`/otherfeed/${memberId}`);
     }
   };
 
@@ -45,7 +39,12 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
           role="button"
           tabIndex={0}
           onClick={() => handleMemberClick(member.id)}
-          onKeyDown={e => handleKeyDown(e, member.id)}
+          onKeyDown={(e: KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleMemberClick(member.id);
+            }
+          }}
         >
           <ProfileSection>
             <ProfileImage />

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -30,10 +30,23 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent, memberId: string) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleMemberClick(memberId);
+    }
+  };
+
   return (
     <Container>
       {members.map(member => (
-        <MemberItem key={member.id} onClick={() => handleMemberClick(member.id)}>
+        <MemberItem
+          key={member.id}
+          role="button"
+          tabIndex={0}
+          onClick={() => handleMemberClick(member.id)}
+          onKeyDown={e => handleKeyDown(e, member.id)}
+        >
           <ProfileSection>
             <ProfileImage />
             <MemberInfo>

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -53,7 +53,9 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
               <MemberRole>{member.role}</MemberRole>
             </MemberInfo>
           </ProfileSection>
-          <MemberStatus>{member.followers}</MemberStatus>
+          <MemberStatus>
+            {`${(member.followersCount ?? 0).toLocaleString()}명이 띱 하는 중`}
+          </MemberStatus>
           <ChevronIcon src={rightChevron} alt="이동" />
         </MemberItem>
       ))}

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -1,0 +1,52 @@
+import { useNavigate } from 'react-router-dom';
+import rightChevron from '../../assets/member/right-chevron.svg';
+import type { Member } from '../../mocks/members.mock';
+import {
+  Container,
+  MemberItem,
+  ProfileSection,
+  ProfileImage,
+  MemberInfo,
+  MemberName,
+  MemberRole,
+  MemberStatus,
+  ChevronIcon,
+} from './MemberList.styled';
+
+interface MemberListProps {
+  members: Member[];
+  onMemberClick?: (memberId: string) => void;
+}
+
+const MemberList = ({ members, onMemberClick }: MemberListProps) => {
+  const navigate = useNavigate();
+
+  const handleMemberClick = (memberId: string) => {
+    if (onMemberClick) {
+      onMemberClick(memberId);
+    } else {
+      // 기본 동작: 개별 유저 페이지로 이동
+      navigate(`/user/${memberId}`);
+    }
+  };
+
+  return (
+    <Container>
+      {members.map(member => (
+        <MemberItem key={member.id} onClick={() => handleMemberClick(member.id)}>
+          <ProfileSection>
+            <ProfileImage />
+            <MemberInfo>
+              <MemberName>{member.nickname}</MemberName>
+              <MemberRole>{member.role}</MemberRole>
+            </MemberInfo>
+          </ProfileSection>
+          <MemberStatus>{member.followers}</MemberStatus>
+          <ChevronIcon src={rightChevron} alt="이동" />
+        </MemberItem>
+      ))}
+    </Container>
+  );
+};
+
+export default MemberList;

--- a/src/mocks/members.mock.ts
+++ b/src/mocks/members.mock.ts
@@ -4,7 +4,7 @@ export interface Member {
   role: string;
   profileImage: string;
   points: number;
-  followers: string;
+  followersCount: number;
 }
 
 export const mockMembers: Member[] = [
@@ -14,7 +14,7 @@ export const mockMembers: Member[] = [
     role: '칭호칭호',
     profileImage: '', // 빈 문자열로 기본 이미지 처리
     points: 0,
-    followers: '00명이 띱 하는 중',
+    followersCount: 0,
   },
   {
     id: '2',
@@ -22,7 +22,7 @@ export const mockMembers: Member[] = [
     role: '공식 인플루언서',
     profileImage: '',
     points: 0,
-    followers: '00명이 띱 하는 중',
+    followersCount: 0,
   },
   {
     id: '3',
@@ -30,7 +30,7 @@ export const mockMembers: Member[] = [
     role: '청춘청춘',
     profileImage: '',
     points: 0,
-    followers: '00명이 띱 하는 중',
+    followersCount: 0,
   },
   {
     id: '4',
@@ -38,7 +38,7 @@ export const mockMembers: Member[] = [
     role: '작가',
     profileImage: '',
     points: 0,
-    followers: '00명이 띱 하는 중',
+    followersCount: 0,
   },
   {
     id: '5',
@@ -46,7 +46,7 @@ export const mockMembers: Member[] = [
     role: '작가',
     profileImage: '',
     points: 0,
-    followers: '00명이 띱 하는 중',
+    followersCount: 0,
   },
   {
     id: '6',
@@ -54,7 +54,7 @@ export const mockMembers: Member[] = [
     role: '작가',
     profileImage: '',
     points: 0,
-    followers: '00명이 띱 하는 중',
+    followersCount: 0,
   },
   {
     id: '7',
@@ -62,6 +62,6 @@ export const mockMembers: Member[] = [
     role: '작가',
     profileImage: '',
     points: 0,
-    followers: '00명이 띱 하는 중',
+    followersCount: 0,
   },
 ];

--- a/src/mocks/members.mock.ts
+++ b/src/mocks/members.mock.ts
@@ -1,0 +1,67 @@
+export interface Member {
+  id: string;
+  nickname: string;
+  role: string;
+  profileImage: string;
+  points: number;
+  followers: string;
+}
+
+export const mockMembers: Member[] = [
+  {
+    id: '1',
+    nickname: 'Thiper',
+    role: '칭호칭호',
+    profileImage: '', // 빈 문자열로 기본 이미지 처리
+    points: 0,
+    followers: '00명이 띱 하는 중',
+  },
+  {
+    id: '2',
+    nickname: 'thipthip',
+    role: '공식 인플루언서',
+    profileImage: '',
+    points: 0,
+    followers: '00명이 띱 하는 중',
+  },
+  {
+    id: '3',
+    nickname: 'Thiper',
+    role: '청춘청춘',
+    profileImage: '',
+    points: 0,
+    followers: '00명이 띱 하는 중',
+  },
+  {
+    id: '4',
+    nickname: 'thip01',
+    role: '작가',
+    profileImage: '',
+    points: 0,
+    followers: '00명이 띱 하는 중',
+  },
+  {
+    id: '5',
+    nickname: 'thip01',
+    role: '작가',
+    profileImage: '',
+    points: 0,
+    followers: '00명이 띱 하는 중',
+  },
+  {
+    id: '6',
+    nickname: 'thip01',
+    role: '작가',
+    profileImage: '',
+    points: 0,
+    followers: '00명이 띱 하는 중',
+  },
+  {
+    id: '7',
+    nickname: 'thip01',
+    role: '작가',
+    profileImage: '',
+    points: 0,
+    followers: '00명이 띱 하는 중',
+  },
+];

--- a/src/pages/groupMembers/GroupMembers.styled.ts
+++ b/src/pages/groupMembers/GroupMembers.styled.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+import { colors } from '../../styles/global/global';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-top: 56px;
+  min-width: 320px;
+  max-width: 767px;
+  min-height: 100vh;
+  margin: 0 auto;
+  background-color: ${colors.black.main};
+`;

--- a/src/pages/groupMembers/GroupMembers.tsx
+++ b/src/pages/groupMembers/GroupMembers.tsx
@@ -1,0 +1,34 @@
+import { useNavigate } from 'react-router-dom';
+import TitleHeader from '../../components/common/TitleHeader';
+import MemberList from '../../components/members/MemberList';
+import leftArrow from '../../assets/common/leftArrow.svg';
+import { mockMembers } from '../../mocks/members.mock';
+import { Wrapper } from './GroupMembers.styled';
+
+const GroupMembers = () => {
+  const navigate = useNavigate();
+
+  const handleBackClick = () => {
+    navigate(-1);
+  };
+
+  const handleMemberClick = (memberId: string) => {
+    // 특정 사용자 페이지로 이동
+    navigate(`/user/${memberId}`);
+  };
+
+  return (
+    <>
+      <TitleHeader
+        leftIcon={<img src={leftArrow} alt="뒤로가기" />}
+        title="독서메이트"
+        onLeftClick={handleBackClick}
+      />
+      <Wrapper>
+        <MemberList members={mockMembers} onMemberClick={handleMemberClick} />
+      </Wrapper>
+    </>
+  );
+};
+
+export default GroupMembers;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -36,6 +36,7 @@ import WithdrawDonePage from './mypage/WithdrawDonePage';
 import EditPage from './mypage/EditPage';
 import Notice from './notice/Notice';
 import ParticipatedGroupDetail from './groupDetail/ParticipatedGroupDetail';
+import GroupMembers from './groupMembers/GroupMembers';
 
 const Router = () => {
   const router = createBrowserRouter(
@@ -53,6 +54,7 @@ const Router = () => {
         <Route path="group/search" element={<GroupSearch />} />
         <Route path="group/detail" element={<GroupDetail />} />
         <Route path="group/detail/joined" element={<ParticipatedGroupDetail />} />
+        <Route path="group/members" element={<GroupMembers />} />
         <Route path="memory" element={<Memory />} />
         <Route path="memory/record/write" element={<RecordWrite />} />
         <Route path="memory/poll/write" element={<PollWrite />} />


### PR DESCRIPTION
## #️⃣ 연관된 이슈

따로 등록하지 않았습니다.

## 📝 작업 내용
기존 `ParticipatedGroupDetail.tsx`에서 독서메이트 클릭 시 이동할 수 있는 독서메이트 목록 화면을 새롭게 개발했습니다.

## 📄 주요 구현 사항
**1. 독서메이트 목록 페이지 구현**
- `src/pages/groupmembers/GroupMembers.tsx` 페이지 생성

**2. MemberList 컴포넌트 개발**
- `src/components/members/MemberList.tsx` 컴포넌트 분리
- props로 members 배열과 onMemberClick 콜백 함수를 받아 사용 가능
- 콜백이 없으면 기본적으로 `/user/${memberId}` 경로로 이동하도록 구현

**3. 목업 데이터 및 타입 정의**
- `src/mocks/members.mock.ts`에 Member 인터페이스와 mockMembers 배열 생성
- 프로필 이미지, 닉네임, 역할(칭호), 팔로워 수 정보 포함

## 스크린샷

https://github.com/user-attachments/assets/52a13c47-b6b0-4c1d-9a87-10e38cba59d8


## 💬리뷰 요구사항(선택)

딱히 없습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 그룹 멤버 목록 페이지가 추가되었습니다.
  * 멤버 리스트에 프로필 이미지, 닉네임, 역할, 팔로워 수, 상태 등이 표시됩니다.
  * 멤버 클릭 시 개별 멤버 페이지로 이동하거나, 커스텀 클릭 핸들러를 사용할 수 있습니다.

* **스타일**
  * 멤버 리스트와 그룹 멤버 페이지에 대한 새로운 스타일이 적용되었습니다.

* **테스트/모킹 데이터**
  * 다양한 멤버 정보가 포함된 목업 데이터가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->