### PR TITLE
feat: 새 글 작성 API 연동

### DIFF
--- a/src/api/feeds/createFeed.ts
+++ b/src/api/feeds/createFeed.ts
@@ -1,0 +1,59 @@
+import { apiClient } from '../index';
+
+// 피드 작성 요청 바디 타입
+export interface CreateFeedRequest {
+  request: {
+    isbn: string;
+    contentBody: string;
+    isPublic: boolean;
+    tagList: string[];
+  };
+  images: string[]; // 이미지 URL들의 배열 (별도로 업로드된 이미지 URL들)
+}
+
+// 피드 작성 응답 데이터 타입
+export interface CreateFeedData {
+  feedId: number;
+}
+
+// API 응답 타입
+export interface CreateFeedResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data?: CreateFeedData; // 성공 시에만 존재
+}
+
+// 피드 작성 API 함수
+export const createFeed = async (feedData: CreateFeedRequest) => {
+  const response = await apiClient.post<CreateFeedResponse>('/feeds', feedData);
+  return response.data;
+};
+
+/*
+사용 방법:
+
+const feedData: CreateFeedRequest = {
+  request: {
+    isbn: "9780306406157",
+    contentBody: "이 책은 정말 좋습니다!",
+    isPublic: true,
+    tagList: ["한국소설", "외국소설", "AI"]
+  },
+  images: ["string"] // 업로드된 이미지 URL들
+};
+
+try {
+  const result = await createFeed(feedData);
+  if (result.isSuccess) {
+    console.log('피드 작성 성공:', result.data?.feedId);
+    // 성공 처리 로직
+  } else {
+    console.log('피드 작성 실패:', result.message);
+    // 실패 처리 로직
+  }
+} catch (error) {
+  console.error('API 호출 오류:', error);
+  // 에러 처리 로직
+}
+*/

--- a/src/api/feeds/getFeedDetail.ts
+++ b/src/api/feeds/getFeedDetail.ts
@@ -13,7 +13,7 @@ export interface FeedDetailData {
   bookTitle: string;
   bookAuthor: string;
   contentBody: string;
-  contentsUrl: string[];
+  contentUrls: string[];
   likeCount: number;
   commentCount: number;
   isSaved: boolean;
@@ -23,7 +23,7 @@ export interface FeedDetailData {
 
 // API 응답 타입
 export interface FeedDetailResponse {
-  success: boolean;
+  isSuccess: boolean;
   code: number;
   message: string;
   data: FeedDetailData;

--- a/src/api/feeds/getMyFeed.ts
+++ b/src/api/feeds/getMyFeed.ts
@@ -10,7 +10,7 @@ export interface MyFeedData {
 
 // API 응답 타입
 export interface MyFeedResponse {
-  success: boolean;
+  isSuccess: boolean;
   code: number;
   message: string;
   data: MyFeedData;

--- a/src/api/feeds/getOtherFeed.ts
+++ b/src/api/feeds/getOtherFeed.ts
@@ -8,7 +8,7 @@ export interface OtherFeedItem {
   bookTitle: string;
   bookAuthor: string;
   contentBody: string;
-  contentsUrl: string[];
+  contentUrls: string[];
   likeCount: number;
   commentCount: number;
   isSaved: boolean;
@@ -21,7 +21,7 @@ export interface OtherFeedData {
 
 // API 응답 타입
 export interface OtherFeedResponse {
-  success: boolean;
+  isSuccess: boolean;
   code: number;
   message: string;
   data: OtherFeedData;

--- a/src/api/feeds/getTotalFeed.ts
+++ b/src/api/feeds/getTotalFeed.ts
@@ -10,7 +10,7 @@ export interface TotalFeedData {
 
 // API 응답 타입
 export interface TotalFeedResponse {
-  success: boolean;
+  isSuccess: boolean;
   code: number;
   message: string;
   data: TotalFeedData;

--- a/src/api/images/uploadImage.ts
+++ b/src/api/images/uploadImage.ts
@@ -1,11 +1,11 @@
 import { apiClient } from '../index';
 
-// 이미지 업로드 응답 데이터 타입
+/** 단일 이미지 업로드 성공 시 데이터 */
 export interface UploadImageData {
   imageUrl: string;
 }
 
-// API 응답 타입
+/** 서버 공통 응답 타입 */
 export interface UploadImageResponse {
   isSuccess: boolean;
   code: number;
@@ -13,59 +13,116 @@ export interface UploadImageResponse {
   data?: UploadImageData; // 성공 시에만 존재
 }
 
-// 단일 이미지 업로드 API 함수
-export const uploadImage = async (file: File) => {
+/** 내부 유틸: 허용 확장자 */
+const IMAGE_EXT_REGEX = /\.(jpe?g|png|gif)$/i;
+/** 가이드 최대 업로드 개수 (서버는 FEED 생성 시 최대 3장 제약) */
+export const MAX_IMAGES = 3;
+
+/** 파일 사전 검증: 빈 파일 / 확장자 */
+function validateFile(file: File) {
+  if (!file || file.size === 0) {
+    // 서버 코드 170001과 의미 일치
+    throw new Error('업로드하려는 이미지가 비어있습니다.');
+  }
+  if (!IMAGE_EXT_REGEX.test(file.name)) {
+    // 서버 코드 170003과 의미 일치
+    throw new Error('파일 형식은 jpg, jpeg, png, gif만 가능합니다.');
+  }
+}
+
+/** 단일 이미지 업로드 */
+export const uploadImage = async (
+  file: File,
+  options?: { signal?: AbortSignal },
+): Promise<UploadImageResponse> => {
+  // 사전 검증
+  validateFile(file);
+
   const formData = new FormData();
+  // 서버가 단일 업로드에서 기대하는 필드명이 image라면 유지
   formData.append('image', file);
 
-  const response = await apiClient.post<UploadImageResponse>('/images/upload', formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
+  const { data } = await apiClient.post<UploadImageResponse>('/images/upload', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+    signal: options?.signal,
   });
 
-  return response.data;
+  return data;
 };
 
-// 다중 이미지 업로드 API 함수
-export const uploadMultipleImages = async (files: File[]) => {
-  const uploadPromises = files.map(file => uploadImage(file));
-
-  try {
-    const results = await Promise.all(uploadPromises);
-
-    // 모든 업로드가 성공한 경우에만 URL 반환
-    const successResults = results.filter(result => result.isSuccess);
-
-    if (successResults.length !== files.length) {
-      throw new Error('일부 이미지 업로드에 실패했습니다.');
-    }
-
-    return successResults.map(result => result.data!.imageUrl);
-  } catch (error) {
-    console.error('이미지 업로드 실패:', error);
-    throw error;
+/**
+ * 다중 이미지 업로드
+ * - 전부 성공하면 URL 배열 반환
+ * - 하나라도 실패하면 실패 내역을 포함해 throw
+ */
+export const uploadMultipleImages = async (
+  files: File[],
+  options?: { signal?: AbortSignal; enforceMax?: boolean },
+): Promise<string[]> => {
+  // 개수 제한(선택) – FEED 생성 정책에 맞춰 사전 차단하고 싶을 때 사용
+  if (options?.enforceMax && files.length > MAX_IMAGES) {
+    throw new Error(`이미지는 최대 ${MAX_IMAGES}장까지 업로드할 수 있습니다.`);
   }
+
+  // 파일별 사전 검증
+  files.forEach(validateFile);
+
+  // 병렬 업로드 (각 요청 독립)
+  const results = await Promise.allSettled(
+    files.map(file => uploadImage(file, { signal: options?.signal })),
+  );
+
+  const successUrls: string[] = [];
+  const failures: { index: number; reason: string }[] = [];
+
+  results.forEach((res, idx) => {
+    if (res.status === 'fulfilled') {
+      const value = res.value;
+      if (value.isSuccess && value.data?.imageUrl) {
+        successUrls.push(value.data.imageUrl);
+      } else {
+        failures.push({
+          index: idx,
+          reason: value.message || '파일 업로드에 실패하였습니다.',
+        });
+      }
+    } else {
+      failures.push({
+        index: idx,
+        reason: (res.reason as Error)?.message || '네트워크 오류로 파일 업로드에 실패하였습니다.',
+      });
+    }
+  });
+
+  if (failures.length > 0) {
+    // 어떤 항목이 왜 실패했는지 상세 메시지
+    const detail = failures.map(f => `#${f.index + 1}: ${f.reason}`).join(' / ');
+    throw new Error(`일부 이미지 업로드에 실패했습니다. (${detail})`);
+  }
+
+  return successUrls;
 };
 
 /*
-사용 방법:
+사용 예시:
 
-// 단일 이미지 업로드
+// 단일
 try {
-  const result = await uploadImage(file);
-  if (result.isSuccess) {
-    console.log('업로드된 이미지 URL:', result.data?.imageUrl);
+  const res = await uploadImage(file);
+  if (res.isSuccess) {
+    console.log('업로드된 URL:', res.data?.imageUrl);
+  } else {
+    console.error('실패:', res.message);
   }
-} catch (error) {
-  console.error('이미지 업로드 실패:', error);
+} catch (e) {
+  console.error('오류:', e);
 }
 
-// 다중 이미지 업로드
+// 다중
 try {
-  const imageUrls = await uploadMultipleImages(files);
-  console.log('업로드된 이미지 URLs:', imageUrls);
-} catch (error) {
-  console.error('다중 이미지 업로드 실패:', error);
+  const urls = await uploadMultipleImages(files, { enforceMax: true });
+  console.log('업로드된 URL들:', urls);
+} catch (e) {
+  console.error('다중 업로드 실패:', e);
 }
 */

--- a/src/api/images/uploadImage.ts
+++ b/src/api/images/uploadImage.ts
@@ -1,0 +1,71 @@
+import { apiClient } from '../index';
+
+// 이미지 업로드 응답 데이터 타입
+export interface UploadImageData {
+  imageUrl: string;
+}
+
+// API 응답 타입
+export interface UploadImageResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data?: UploadImageData; // 성공 시에만 존재
+}
+
+// 단일 이미지 업로드 API 함수
+export const uploadImage = async (file: File) => {
+  const formData = new FormData();
+  formData.append('image', file);
+
+  const response = await apiClient.post<UploadImageResponse>('/images/upload', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return response.data;
+};
+
+// 다중 이미지 업로드 API 함수
+export const uploadMultipleImages = async (files: File[]) => {
+  const uploadPromises = files.map(file => uploadImage(file));
+
+  try {
+    const results = await Promise.all(uploadPromises);
+
+    // 모든 업로드가 성공한 경우에만 URL 반환
+    const successResults = results.filter(result => result.isSuccess);
+
+    if (successResults.length !== files.length) {
+      throw new Error('일부 이미지 업로드에 실패했습니다.');
+    }
+
+    return successResults.map(result => result.data!.imageUrl);
+  } catch (error) {
+    console.error('이미지 업로드 실패:', error);
+    throw error;
+  }
+};
+
+/*
+사용 방법:
+
+// 단일 이미지 업로드
+try {
+  const result = await uploadImage(file);
+  if (result.isSuccess) {
+    console.log('업로드된 이미지 URL:', result.data?.imageUrl);
+  }
+} catch (error) {
+  console.error('이미지 업로드 실패:', error);
+}
+
+// 다중 이미지 업로드
+try {
+  const imageUrls = await uploadMultipleImages(files);
+  console.log('업로드된 이미지 URLs:', imageUrls);
+} catch (error) {
+  console.error('다중 이미지 업로드 실패:', error);
+}
+*/

--- a/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
@@ -43,7 +43,7 @@ const mockSavedBooks: Book[] = [
     title: '토마토 컵라면',
     author: '작가명',
     cover: '/src/assets/books/tomato.svg',
-    isbn: '9781234567890',
+    isbn: '9780374500016',
   },
   {
     id: 2,

--- a/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
@@ -26,6 +26,7 @@ interface Book {
   title: string;
   author: string;
   cover: string;
+  isbn: string;
 }
 
 interface BookSearchBottomSheetProps {
@@ -36,25 +37,27 @@ interface BookSearchBottomSheetProps {
 
 type TabType = 'saved' | 'group';
 
-// Mock Data
 const mockSavedBooks: Book[] = [
   {
     id: 1,
     title: '토마토 컵라면',
     author: '작가명',
     cover: '/src/assets/books/tomato.svg',
+    isbn: '9781234567890',
   },
   {
     id: 2,
     title: '사슴',
     author: '작가명',
     cover: '/src/assets/books/deer.svg',
+    isbn: '9781234567891',
   },
   {
     id: 3,
     title: '호르몬 체인지',
     author: '작가명',
     cover: '/src/assets/books/hormone.svg',
+    isbn: '9781234567892',
   },
 ];
 
@@ -64,18 +67,21 @@ const mockGroupBooks: Book[] = [
     title: '단 한번의 삶',
     author: '작가명',
     cover: '/src/assets/books/life.svg',
+    isbn: '9781234567893',
   },
   {
     id: 5,
     title: '호르몬 체인지',
     author: '작가명',
     cover: '/src/assets/books/hormone.svg',
+    isbn: '9781234567892',
   },
   {
     id: 6,
     title: '토마토 컵라면',
     author: '작가명',
     cover: '/src/assets/books/tomato.svg',
+    isbn: '9781234567890',
   },
 ];
 

--- a/src/components/common/Post/PostBody.tsx
+++ b/src/components/common/Post/PostBody.tsx
@@ -50,10 +50,10 @@ const PostBody = ({
   bookAuthor,
   contentBody,
   feedId,
-  contentsUrl = [],
+  contentUrls = [],
 }: PostBodyProps) => {
   const navigate = useNavigate();
-  const hasImage = contentsUrl.length > 0;
+  const hasImage = contentUrls.length > 0;
 
   const handlePostClick = (feedId: number) => {
     // if (!isClickable) return;
@@ -68,7 +68,7 @@ const PostBody = ({
         <div className="content">{contentBody}</div>
         {hasImage && (
           <div className="imgContainer">
-            {contentsUrl.map((src: string, i: number) => (
+            {contentUrls.map((src: string, i: number) => (
               <img key={i} src={src} />
             ))}
           </div>

--- a/src/components/feed/FeedDetailPostBody.tsx
+++ b/src/components/feed/FeedDetailPostBody.tsx
@@ -81,13 +81,13 @@ const FeedDetailPostBody = ({
   isbn,
   bookAuthor,
   contentBody,
-  contentsUrl = [],
+  contentUrls = [],
   tags = [],
 }: FeedDetailPostBodyProps) => {
   const [isImageViewerOpen, setIsImageViewerOpen] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
-  const hasImage = contentsUrl.length > 0;
+  const hasImage = contentUrls.length > 0;
   const hasTag = tags.length > 0;
 
   const handleImageClick = (index: number) => {
@@ -106,7 +106,7 @@ const FeedDetailPostBody = ({
         <div className="content">{contentBody}</div>
         {hasImage && (
           <div className="imgContainer">
-            {contentsUrl.map((src: string, i: number) => (
+            {contentUrls.map((src: string, i: number) => (
               <img key={i} src={src} alt={`이미지 ${i + 1}`} onClick={() => handleImageClick(i)} />
             ))}
           </div>
@@ -126,7 +126,7 @@ const FeedDetailPostBody = ({
       </PostContent>
       {isImageViewerOpen && (
         <ImageViewer
-          images={contentsUrl}
+          images={contentUrls}
           initialIndex={selectedImageIndex}
           isOpen={isImageViewerOpen}
           onClose={handleCloseImageViewer}

--- a/src/data/postData.ts
+++ b/src/data/postData.ts
@@ -14,7 +14,7 @@ export const mockPosts: PostData[] = [
     bookTitle: '제목입니다',
     bookAuthor: '작가입니다',
     contentBody: '내용입니다…',
-    contentsUrl: ['https://placehold.co/100x100', 'https://placehold.co/100x100'],
+    contentUrls: ['https://placehold.co/100x100', 'https://placehold.co/100x100'],
     likeCount: 125,
     commentCount: 125,
     isSaved: false,
@@ -33,7 +33,7 @@ export const mockPosts: PostData[] = [
     bookAuthor: '작가입니다',
     contentBody:
       '내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다',
-    contentsUrl: [],
+    contentUrls: [],
     likeCount: 125,
     commentCount: 125,
     isSaved: true,
@@ -52,7 +52,7 @@ export const mockPosts: PostData[] = [
     bookAuthor: '작가입니다',
     contentBody:
       '내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다',
-    contentsUrl: [],
+    contentUrls: [],
     likeCount: 125,
     commentCount: 125,
     isSaved: false,
@@ -74,7 +74,7 @@ export const mockFeedPost: FeedPostProps = {
   bookAuthor: '한강',
   contentBody:
     '정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.정말 인상 깊게 읽은 책이에요.',
-  contentsUrl: [test2, 'https://placehold.co/300x300', test],
+  contentUrls: [test2, 'https://placehold.co/300x300', test],
   likeCount: 15,
   commentCount: 2,
   isSaved: true,

--- a/src/hooks/useCreateFeed.ts
+++ b/src/hooks/useCreateFeed.ts
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import { createFeed, type CreateFeedRequest } from '@/api/feeds/createFeed';
+import { usePopupActions } from './usePopupActions';
+
+interface UseCreateFeedProps {
+  onSuccess?: (feedId: number) => void;
+}
+
+export const useCreateFeed = (options?: UseCreateFeedProps) => {
+  const [loading, setLoading] = useState(false);
+  const { openSnackbar, closePopup } = usePopupActions();
+
+  const createNewFeed = async (feedData: CreateFeedRequest) => {
+    try {
+      setLoading(true);
+
+      const response = await createFeed(feedData);
+
+      if (response.isSuccess) {
+        openSnackbar({
+          message: '피드가 작성되었습니다.',
+          variant: 'top',
+          onClose: closePopup,
+        });
+
+        // 성공 콜백 호출
+        if (options?.onSuccess && response.data?.feedId) {
+          options.onSuccess(response.data.feedId);
+        }
+
+        return {
+          success: true,
+          feedId: response.data?.feedId,
+        };
+      } else {
+        openSnackbar({
+          message: response.message || '피드 작성에 실패했습니다.',
+          variant: 'top',
+          onClose: closePopup,
+        });
+
+        return {
+          success: false,
+          error: response.message,
+        };
+      }
+    } catch (error) {
+      console.error('피드 작성 실패:', error);
+
+      openSnackbar({
+        message: '피드 작성 중 오류가 발생했습니다.',
+        variant: 'top',
+        onClose: closePopup,
+      });
+
+      return {
+        success: false,
+        error: '피드 작성 중 오류가 발생했습니다.',
+      };
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    createNewFeed,
+    loading,
+  };
+};

--- a/src/hooks/useCreateFeed.ts
+++ b/src/hooks/useCreateFeed.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { createFeed, type CreateFeedRequest } from '@/api/feeds/createFeed';
+import { createFeed, type CreateFeedBody, type CreateFeedResponse } from '@/api/feeds/createFeed';
 import { usePopupActions } from './usePopupActions';
 
 interface UseCreateFeedProps {
@@ -10,60 +10,100 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
   const [loading, setLoading] = useState(false);
   const { openSnackbar, closePopup } = usePopupActions();
 
-  const createNewFeed = async (feedData: CreateFeedRequest) => {
+  const createNewFeed = async (body: CreateFeedBody, images?: File[]) => {
     try {
       setLoading(true);
 
-      const response = await createFeed(feedData);
+      // ===== 클라이언트 선검증 (선택값일 때만 검사) =====
+      if (body.tagList) {
+        // 최대 5개
+        if (body.tagList.length > 5) {
+          openSnackbar({
+            message: '태그는 최대 5개까지 입력할 수 있어요.',
+            variant: 'top',
+            onClose: closePopup,
+          });
+          return { success: false as const };
+        }
+        // 중복 제거 체크
+        const trimmed = body.tagList.map(t => t.trim()).filter(Boolean);
+        const uniq = new Set(trimmed);
+        if (uniq.size !== trimmed.length) {
+          openSnackbar({
+            message: '태그는 중복될 수 없어요.',
+            variant: 'top',
+            onClose: closePopup,
+          });
+          return { success: false as const };
+        }
+      }
 
-      if (response.isSuccess) {
+      if (images && images.length > 0) {
+        // 최대 3장
+        if (images.length > 3) {
+          openSnackbar({
+            message: '이미지는 최대 3장까지 업로드할 수 있어요.',
+            variant: 'top',
+            onClose: closePopup,
+          });
+          return { success: false as const };
+        }
+        // 빈 파일 금지
+        if (images.some(f => f.size === 0)) {
+          openSnackbar({
+            message: '빈 이미지 파일이 포함되어 있어요.',
+            variant: 'top',
+            onClose: closePopup,
+          });
+          return { success: false as const };
+        }
+        // 확장자 제한
+        const extOk = (name: string) => /\.(jpe?g|png|gif)$/i.test(name);
+        if (images.some(f => !extOk(f.name))) {
+          openSnackbar({
+            message: '파일 형식은 jpg, jpeg, png, gif만 가능해요.',
+            variant: 'top',
+            onClose: closePopup,
+          });
+          return { success: false as const };
+        }
+      }
+      // ===== 선검증 끝 =====
+
+      const res: CreateFeedResponse = await createFeed(body, images);
+
+      if (res.isSuccess) {
         openSnackbar({
           message: '피드가 작성되었습니다.',
           variant: 'top',
           onClose: closePopup,
         });
 
-        // 성공 콜백 호출
-        if (options?.onSuccess && response.data?.feedId) {
-          options.onSuccess(response.data.feedId);
+        if (options?.onSuccess) {
+          options.onSuccess(res.data.feedId);
         }
 
-        return {
-          success: true,
-          feedId: response.data?.feedId,
-        };
+        return { success: true as const, feedId: res.data.feedId };
       } else {
         openSnackbar({
-          message: response.message || '피드 작성에 실패했습니다.',
+          message: res.message || '피드 작성에 실패했습니다.',
           variant: 'top',
           onClose: closePopup,
         });
-
-        return {
-          success: false,
-          error: response.message,
-        };
+        return { success: false as const, error: res.message };
       }
     } catch (error) {
       console.error('피드 작성 실패:', error);
-
       openSnackbar({
         message: '피드 작성 중 오류가 발생했습니다.',
         variant: 'top',
         onClose: closePopup,
       });
-
-      return {
-        success: false,
-        error: '피드 작성 중 오류가 발생했습니다.',
-      };
+      return { success: false as const, error: '피드 작성 중 오류가 발생했습니다.' };
     } finally {
       setLoading(false);
     }
   };
 
-  return {
-    createNewFeed,
-    loading,
-  };
+  return { createNewFeed, loading };
 };

--- a/src/mocks/searchBook.mock.ts
+++ b/src/mocks/searchBook.mock.ts
@@ -46,7 +46,7 @@ export const mockSearchBook = {
       bookTitle: '제목입니다',
       bookAuthor: '작가입니다',
       contentBody: '내용입니다…',
-      contentUrl: ['https://placehold.co/100x100', 'https://placehold.co/100x100'],
+      contentUrls: ['https://placehold.co/100x100', 'https://placehold.co/100x100'],
       likeCount: 125,
       commentCount: 125,
       isSaved: false,
@@ -65,7 +65,7 @@ export const mockSearchBook = {
       bookAuthor: '작가입니다',
       contentBody:
         '내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다',
-      contentUrl: [],
+      contentUrls: [],
       likeCount: 125,
       commentCount: 125,
       isSaved: true,

--- a/src/mocks/searchBook.mock.ts
+++ b/src/mocks/searchBook.mock.ts
@@ -46,7 +46,7 @@ export const mockSearchBook = {
       bookTitle: '제목입니다',
       bookAuthor: '작가입니다',
       contentBody: '내용입니다…',
-      contentsUrl: ['https://placehold.co/100x100', 'https://placehold.co/100x100'],
+      contentUrl: ['https://placehold.co/100x100', 'https://placehold.co/100x100'],
       likeCount: 125,
       commentCount: 125,
       isSaved: false,
@@ -65,7 +65,7 @@ export const mockSearchBook = {
       bookAuthor: '작가입니다',
       contentBody:
         '내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다',
-      contentsUrl: [],
+      contentUrl: [],
       likeCount: 125,
       commentCount: 125,
       isSaved: true,

--- a/src/pages/post/CreatePost.tsx
+++ b/src/pages/post/CreatePost.tsx
@@ -10,12 +10,15 @@ import TagSelectionSection from '../../components/createpost/TagSelectionSection
 import leftarrow from '../../assets/common/leftArrow.svg';
 import { Container } from './CreatePost.styled';
 import { Section } from '../group/CommonSection.styled';
+import { useCreateFeed } from '@/hooks/useCreateFeed';
+import { usePopupActions } from '@/hooks/usePopupActions';
 
 interface Book {
   id: number;
   title: string;
   author: string;
   cover: string;
+  isbn?: string;
 }
 
 const CreatePost = () => {
@@ -27,28 +30,93 @@ const CreatePost = () => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [isBookSearchOpen, setIsBookSearchOpen] = useState(false);
 
+  const { openSnackbar, closePopup } = usePopupActions();
+  const { createNewFeed, loading } = useCreateFeed({
+    onSuccess: feedId => {
+      console.log('피드 작성 성공! 피드 ID:', feedId);
+      // 피드 페이지로 이동
+      navigate('/feed');
+    },
+  });
+
   const handleBackClick = () => {
     navigate(-1);
   };
 
-  const handleCompleteClick = () => {
+  // 이미지 업로드 함수
+  const uploadImages = async (files: File[]): Promise<string[]> => {
+    if (files.length === 0) return [];
+
+    try {
+      // 이미지 업로드 API 사용 (실제 구현 시 import 추가 필요)
+      // import { uploadMultipleImages } from '@/api/images/uploadImage';
+      // return await uploadMultipleImages(files);
+
+      // 임시로 base64 변환 사용 (개발용)
+      const promises = files.map(file => {
+        return new Promise<string>(resolve => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.readAsDataURL(file);
+        });
+      });
+      return Promise.all(promises);
+    } catch (error) {
+      console.error('이미지 업로드 실패:', error);
+      throw new Error('이미지 업로드에 실패했습니다.');
+    }
+  };
+
+  const handleCompleteClick = async () => {
     // 필수 항목 검증
     if (!isFormValid) {
-      console.log('필수 항목을 입력해주세요.');
+      openSnackbar({
+        message: '책 선택과 글 내용을 입력해주세요.',
+        variant: 'top',
+        onClose: closePopup,
+      });
       return;
     }
 
-    // 글 작성 완료 로직
-    console.log('글 작성 완료');
-    console.log('필수 - 선택된 책:', selectedBook);
-    console.log('필수 - 글 내용:', postContent);
-    console.log('선택 - 선택된 사진:', selectedPhotos);
-    console.log('선택 - 공개 설정:', isPrivate ? '비공개' : '공개');
-    console.log('선택 - 선택된 태그:', selectedTags);
+    if (!selectedBook?.isbn) {
+      openSnackbar({
+        message: 'ISBN 정보가 없는 책입니다. 다른 책을 선택해주세요.',
+        variant: 'top',
+        onClose: closePopup,
+      });
+      return;
+    }
 
-    // TODO: API 호출하여 글 등록
-    // 완료 후 이전 페이지로 이동
-    navigate(-1);
+    try {
+      // 선택된 사진들을 업로드
+      let imageUrls: string[] = [];
+      if (selectedPhotos.length > 0) {
+        imageUrls = await uploadImages(selectedPhotos);
+        console.log('이미지 업로드 완료:', imageUrls.length, '개');
+      }
+
+      const feedData = {
+        request: {
+          isbn: selectedBook.isbn,
+          contentBody: postContent.trim(),
+          isPublic: !isPrivate, // UI에서는 "비공개" 토글이므로 반대로 처리
+          tagList: selectedTags,
+        },
+        images: imageUrls,
+      };
+
+      console.log('피드 작성 요청 데이터:', feedData);
+
+      // 피드 작성 API 호출
+      await createNewFeed(feedData);
+    } catch (error) {
+      console.error('피드 작성 실패:', error);
+      openSnackbar({
+        message: '피드 작성 중 오류가 발생했습니다.',
+        variant: 'top',
+        onClose: closePopup,
+      });
+    }
   };
 
   const handleBookSearchOpen = () => {
@@ -65,6 +133,7 @@ const CreatePost = () => {
 
   const handleBookSelect = (book: Book) => {
     setSelectedBook(book);
+    setIsBookSearchOpen(false);
   };
 
   const handlePhotoAdd = (files: File[]) => {
@@ -91,10 +160,10 @@ const CreatePost = () => {
       <TitleHeader
         leftIcon={<img src={leftarrow} alt="뒤로가기" />}
         title="새 글"
-        rightButton="완료"
+        rightButton={loading ? '작성 중...' : '완료'}
         onLeftClick={handleBackClick}
         onRightClick={handleCompleteClick}
-        isNextActive={isFormValid}
+        isNextActive={isFormValid && !loading}
       />
       <Container>
         <BookSelectionSection

--- a/src/pages/post/CreatePost.tsx
+++ b/src/pages/post/CreatePost.tsx
@@ -73,7 +73,6 @@ const CreatePost = () => {
     }
 
     const candidates = makeIsbnCandidates(selectedBook!.isbn);
-    console.log('[CreatePost] ISBN candidates:', candidates);
 
     // images: 선택값 (없으면 undefined 전달 → FormData에 미첨부)
     const filesOrUndefined = selectedPhotos.length ? selectedPhotos : undefined;
@@ -87,8 +86,6 @@ const CreatePost = () => {
         isPublic: !isPrivate,
         ...(selectedTags.length ? { tagList: selectedTags } : {}),
       };
-
-      console.log(`[CreatePost] Try #${i + 1} with ISBN:`, isbnToSend);
 
       try {
         const result = await createNewFeed(body, filesOrUndefined);

--- a/src/pages/post/CreatePost.tsx
+++ b/src/pages/post/CreatePost.tsx
@@ -18,7 +18,7 @@ interface Book {
   title: string;
   author: string;
   cover: string;
-  isbn?: string;
+  isbn: string;
 }
 
 const CreatePost = () => {
@@ -72,15 +72,6 @@ const CreatePost = () => {
     if (!isFormValid) {
       openSnackbar({
         message: '책 선택과 글 내용을 입력해주세요.',
-        variant: 'top',
-        onClose: closePopup,
-      });
-      return;
-    }
-
-    if (!selectedBook?.isbn) {
-      openSnackbar({
-        message: 'ISBN 정보가 없는 책입니다. 다른 책을 선택해주세요.',
         variant: 'top',
         onClose: closePopup,
       });

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -9,7 +9,7 @@ export interface PostData {
   bookTitle: string;
   bookAuthor: string;
   contentBody: string;
-  contentsUrl: string[];
+  contentUrls: string[];
   likeCount: number;
   commentCount: number;
   isSaved?: boolean;
@@ -34,7 +34,7 @@ export interface FeedPostProps extends PostData {
 
 export type PostBodyProps = Pick<
   PostData,
-  'bookTitle' | 'bookAuthor' | 'contentBody' | 'feedId' | 'contentsUrl' | 'isbn'
+  'bookTitle' | 'bookAuthor' | 'contentBody' | 'feedId' | 'contentUrls' | 'isbn'
 >;
 
 // 대댓글(SubReply)

--- a/src/utils/isbn.ts
+++ b/src/utils/isbn.ts
@@ -1,0 +1,23 @@
+export const normalizeIsbn = (raw: string) => raw.replace(/[^0-9Xx]/g, '').toUpperCase();
+
+export const isIsbn10 = (isbn: string) => /^[0-9]{9}[0-9X]$/.test(isbn);
+export const isIsbn13 = (isbn: string) => /^[0-9]{13}$/.test(isbn);
+
+/** ISBN-10 → ISBN-13 변환 (prefix 978 + 체크디지트 재계산) */
+export const isbn10to13 = (isbn10: string) => {
+  const core = '978' + isbn10.slice(0, 9); // 기존 체크디지트 제외
+  const sum = core
+    .split('')
+    .map(Number)
+    .reduce((acc, n, i) => acc + n * (i % 2 === 0 ? 1 : 3), 0);
+  const check = (10 - (sum % 10)) % 10;
+  return core + String(check);
+};
+
+/** 하이픈/공백 제거 → 10이면 13으로 변환 → 최종 13자리 숫자 반환 */
+export const ensureIsbn13 = (raw: string): string | null => {
+  const n = normalizeIsbn(raw);
+  if (isIsbn13(n)) return n;
+  if (isIsbn10(n)) return isbn10to13(n);
+  return null;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈
#94 

## 📝작업 내용

새 글 작성 기능의 완전한 구현과 피드에서 이미지가 표시되지 않는 문제를 해결했습니다.

**주요 해결 과정:**
**1. 새 글 작성 API 연동 구현**
- multipart/form-data 형식으로 텍스트와 이미지를 함께 전송하는 구조 구현
- ISBN 다중 후보 시도 로직으로 책 검색 성공률 향상 (ISBN-13 → ISBN-10 → 정규화 순서)
- FormData 구조: request(JSON) + images(File[]) 형태로 서버 명세에 맞춤

**2. 피드 이미지 렌더링 문제 해결**
- **핵심 문제 발견:** 서버는 contentUrls(복수형)로 응답하는데 클라이언트는 contentsUrl(단수형)으로 파싱하려고 해서 이미지 데이터가 undefined가 됨
- **API 응답 타입 통일:** 모든 피드 관련 API에서 success → isSuccess로 변경하여 서버 응답과 일치
- **타입 정의 수정:** PostData, FeedDetailData 등 모든 관련 인터페이스에서 contentsUrl → contentUrls로 변경

**3. 사용자 경험 개선**
- 로딩 중 중복 실행 방지
- 이미지 개수 제한 (최대 3개) 및 알림
- 태그 개수 제한 (최대 5개) 및 검증

**기술적 세부사항:**
- 이미지는 File 객체로 직접 FormData에 추가하여 전송
- ISBN 정규화 로직으로 하이픈/공백 제거 및 체크디지트 검증
- React Hook을 통한 상태 관리 및 에러 처리 캡슐화

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
**타입 정의 일관성:** contentUrls vs contentsUrl 처럼 서버 응답과 클라이언트 타입 정의가 불일치하는 다른 필드들이 있는지 확인해주시면 좋겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 게시물 작성에 이미지 업로드 지원(여러 장 병렬 업로드, 확장자/용량 유효성 검사).
  - 새 피드 작성 플로우 추가: 스낵바 피드백, 완료 버튼 로딩 표시, 중복 제출 방지.
  - ISBN 정규화·검증·변환 유틸과 다중 후보 자동 재시도로 등록 성공률 개선.
  - 도서 선택 항목에 ISBN 정보 추가.

- Refactor
  - 명명 일관화: contentsUrl → contentUrls, success → isSuccess. 앱 전반의 데이터/컴포넌트/응답 필드에 반영.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->