### PR TITLE
feat: 새 글 수정 API 연동

### DIFF
--- a/src/api/feeds/getFeedDetail.ts
+++ b/src/api/feeds/getFeedDetail.ts
@@ -6,7 +6,7 @@ export interface FeedDetailData {
   creatorId: number;
   creatorNickname: string;
   creatorProfileImageUrl: string;
-  aliasName: string;
+  alias: string;
   aliasColor: string;
   postDate: string;
   isbn: string;
@@ -18,6 +18,7 @@ export interface FeedDetailData {
   commentCount: number;
   isSaved: boolean;
   isLiked: boolean;
+  isPublic: boolean;
   tagList: string[];
 }
 
@@ -40,4 +41,5 @@ export const getFeedDetail = async (feedId: number) => {
 const feedDetail = await getFeedDetail(123);
 console.log(feedDetail.data.feedId); // 123
 console.log(feedDetail.data.tagList); // ["태그1", "태그2"]
+console.log(feedDetail.data.isPublic); // true or false
 */

--- a/src/api/feeds/updateFeed.ts
+++ b/src/api/feeds/updateFeed.ts
@@ -34,18 +34,33 @@ export const updateFeed = async (
   feedId: number,
   body: UpdateFeedBody,
 ): Promise<UpdateFeedResponse> => {
-  const form = new FormData();
-
-  // request 파트(JSON) - 필수
-  form.append('request', new Blob([JSON.stringify(body)], { type: 'application/json' }));
-
-  // 수정 모드에서는 새 이미지 추가 불가
-
-  const { data } = await apiClient.patch<UpdateFeedResponse>(`/feeds/${feedId}`, form, {
-    headers: { 'Content-Type': 'multipart/form-data' },
+  // FormData 대신 JSON으로 시도
+  console.log('수정 API 요청 (JSON):', {
+    url: `/feeds/${feedId}`,
+    body: body,
   });
 
-  return data;
+  try {
+    const { data } = await apiClient.patch<UpdateFeedResponse>(`/feeds/${feedId}`, body, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    console.log('수정 API 응답:', data);
+    return data;
+  } catch (error) {
+    console.error('수정 API 에러:', error);
+
+    // FormData로 재시도
+    console.log('FormData로 재시도...');
+    const form = new FormData();
+    form.append('request', new Blob([JSON.stringify(body)], { type: 'application/json' }));
+
+    const { data } = await apiClient.patch<UpdateFeedResponse>(`/feeds/${feedId}`, form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+
+    return data;
+  }
 };
 
 /*

--- a/src/api/feeds/updateFeed.ts
+++ b/src/api/feeds/updateFeed.ts
@@ -1,0 +1,82 @@
+import { apiClient } from '../index';
+
+/** 피드 수정 요청 바디 타입 */
+export interface UpdateFeedBody {
+  contentBody: string;
+  isPublic: boolean;
+  tagList?: string[]; // 선택 필드
+  remainImageUrls?: string[]; // 기존 이미지 중 유지할 URL들
+}
+
+/** 성공 응답 */
+export interface UpdateFeedSuccess {
+  isSuccess: true;
+  code: number;
+  message: string;
+}
+
+/** 실패 응답 */
+export interface UpdateFeedFail {
+  isSuccess: false;
+  code: number;
+  message: string;
+}
+
+export type UpdateFeedResponse = UpdateFeedSuccess | UpdateFeedFail;
+
+/**
+ * 피드 수정 API
+ * - multipart/form-data
+ *   - request: application/json (Blob로 감싸 전송)
+ *   - 이미지 추가는 불가능, 기존 이미지 삭제만 가능
+ */
+export const updateFeed = async (
+  feedId: number,
+  body: UpdateFeedBody,
+): Promise<UpdateFeedResponse> => {
+  const form = new FormData();
+
+  // request 파트(JSON) - 필수
+  form.append('request', new Blob([JSON.stringify(body)], { type: 'application/json' }));
+
+  // 수정 모드에서는 새 이미지 추가 불가
+
+  const { data } = await apiClient.patch<UpdateFeedResponse>(`/feeds/${feedId}`, form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+
+  return data;
+};
+
+/*
+사용 예시:
+
+// 기존 이미지 일부 유지 (새 이미지 추가는 불가)
+const updateBody: UpdateFeedBody = {
+  contentBody: "수정된 글 내용입니다!",
+  isPublic: true,
+  tagList: ["한국소설", "책추천", "역사"],
+  remainImageUrls: ["https://img.domain.com/1.jpg"] // 기존 이미지 중 유지할 것들
+};
+
+try {
+  const result = await updateFeed(123, updateBody);
+  if (result.isSuccess) {
+    console.log('피드 수정 성공:', result.message);
+  } else {
+    console.error('피드 수정 실패:', result.message);
+  }
+} catch (error) {
+  console.error('네트워크 오류:', error);
+}
+
+// 모든 이미지 삭제 후 텍스트만 수정
+const textOnlyUpdate: UpdateFeedBody = {
+  contentBody: "텍스트만 수정",
+  isPublic: false,
+  tagList: [],
+  remainImageUrls: [] // 모든 기존 이미지 삭제
+};
+
+const result = await updateFeed(123, textOnlyUpdate);
+*/

--- a/src/api/feeds/updateFeed.ts
+++ b/src/api/feeds/updateFeed.ts
@@ -4,8 +4,8 @@ import { apiClient } from '../index';
 export interface UpdateFeedBody {
   contentBody: string;
   isPublic: boolean;
-  tagList?: string[]; // 선택 필드
-  remainImageUrls?: string[]; // 기존 이미지 중 유지할 URL들
+  tagList?: string[];
+  remainImageUrls?: string[];
 }
 
 /** 성공 응답 */
@@ -34,24 +34,15 @@ export const updateFeed = async (
   feedId: number,
   body: UpdateFeedBody,
 ): Promise<UpdateFeedResponse> => {
-  // FormData 대신 JSON으로 시도
-  console.log('수정 API 요청 (JSON):', {
-    url: `/feeds/${feedId}`,
-    body: body,
-  });
-
   try {
     const { data } = await apiClient.patch<UpdateFeedResponse>(`/feeds/${feedId}`, body, {
       headers: { 'Content-Type': 'application/json' },
     });
 
-    console.log('수정 API 응답:', data);
     return data;
   } catch (error) {
     console.error('수정 API 에러:', error);
 
-    // FormData로 재시도
-    console.log('FormData로 재시도...');
     const form = new FormData();
     form.append('request', new Blob([JSON.stringify(body)], { type: 'application/json' }));
 

--- a/src/components/creategroup/BookSelectionSection.tsx
+++ b/src/components/creategroup/BookSelectionSection.tsx
@@ -36,7 +36,25 @@ const BookSelectionSection = ({
           <>
             <SelectedBookContainer>
               <SelectedBookCover>
-                <img src={selectedBook.cover} alt={selectedBook.title} />
+                {selectedBook.cover && selectedBook.cover.trim() !== '' ? (
+                  <img src={selectedBook.cover} alt={selectedBook.title} />
+                ) : (
+                  <div
+                    style={{
+                      width: '60px',
+                      height: '80px',
+                      backgroundColor: '#333',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: '10px',
+                      color: '#999',
+                      borderRadius: '4px',
+                    }}
+                  >
+                    책표지
+                  </div>
+                )}
               </SelectedBookCover>
               <SelectedBookInfo>
                 <SelectedBookTitle>{selectedBook.title}</SelectedBookTitle>

--- a/src/components/creategroup/BookSelectionSection.tsx
+++ b/src/components/creategroup/BookSelectionSection.tsx
@@ -16,19 +16,21 @@ interface BookSelectionSectionProps {
   selectedBook: { cover: string; title: string; author: string } | null;
   onSearchClick: () => void;
   onChangeClick: () => void;
+  readOnly?: boolean;
 }
 
 const BookSelectionSection = ({
   selectedBook,
   onSearchClick,
   onChangeClick,
+  readOnly = false,
 }: BookSelectionSectionProps) => {
   return (
     <Section>
       <SectionTitle>책 선택</SectionTitle>
       <SearchBox
         hasSelectedBook={!!selectedBook}
-        onClick={selectedBook ? undefined : onSearchClick}
+        onClick={selectedBook || readOnly ? undefined : onSearchClick}
       >
         {selectedBook ? (
           <>
@@ -41,14 +43,16 @@ const BookSelectionSection = ({
                 <SelectedBookAuthor>{selectedBook.author} 저</SelectedBookAuthor>
               </SelectedBookInfo>
             </SelectedBookContainer>
-            <ChangeButton onClick={onChangeClick}>변경</ChangeButton>
+            {!readOnly && <ChangeButton onClick={onChangeClick}>변경</ChangeButton>}
           </>
         ) : (
           <>
             <SearchIcon>
               <img src={searchIcon} alt="검색" />
             </SearchIcon>
-            <span style={{ color: semanticColors.text.secondary }}>검색해서 찾기</span>
+            <span style={{ color: semanticColors.text.secondary }}>
+              {readOnly ? '책 정보' : '검색해서 찾기'}
+            </span>
           </>
         )}
       </SearchBox>

--- a/src/components/createpost/PhotoSection.tsx
+++ b/src/components/createpost/PhotoSection.tsx
@@ -13,13 +13,13 @@ import plusDisabledIcon from '../../assets/post/plus-disabled.svg';
 import closeIcon from '../../assets/post/close.svg';
 
 interface PhotoSectionProps {
-  photos: File[]; // 새로 추가할 이미지들
+  photos: File[];
   onPhotoAdd: (files: File[]) => void;
   onPhotoRemove: (index: number) => void;
-  existingImageUrls?: string[]; // 기존 이미지 URL들 (수정 시에만 사용)
-  onExistingImageRemove?: (imageUrl: string) => void; // 기존 이미지 제거 함수 (수정 시에만 사용)
-  readOnly?: boolean; // 읽기 전용 모드
-  isEditMode?: boolean; // 수정 모드 (사진 추가 버튼 숨김)
+  existingImageUrls?: string[];
+  onExistingImageRemove?: (imageUrl: string) => void;
+  readOnly?: boolean;
+  isEditMode?: boolean;
 }
 
 const PhotoSection = ({
@@ -61,14 +61,12 @@ const PhotoSection = ({
       <SectionTitle>사진 추가</SectionTitle>
       <PhotoContainer>
         <PhotoGrid>
-          {/* 새 이미지 추가 버튼 - 수정 모드에서는 숨김 */}
           {!readOnly && !isEditMode && (
             <AddPhotoButton onClick={handleFileInputClick} disabled={isDisabled}>
               <img src={isDisabled ? plusDisabledIcon : plusIcon} alt="사진 추가" />
             </AddPhotoButton>
           )}
 
-          {/* 기존 이미지들 (수정 모드에서만 표시) */}
           {existingImageUrls.map((imageUrl, index) => (
             <div
               key={`existing-${index}`}
@@ -83,7 +81,6 @@ const PhotoSection = ({
             </div>
           ))}
 
-          {/* 새로 추가된 이미지들 */}
           {photos.map((photo, index) => (
             <div
               key={`new-${index}`}

--- a/src/components/createpost/PhotoSection.tsx
+++ b/src/components/createpost/PhotoSection.tsx
@@ -13,19 +13,34 @@ import plusDisabledIcon from '../../assets/post/plus-disabled.svg';
 import closeIcon from '../../assets/post/close.svg';
 
 interface PhotoSectionProps {
-  photos: File[];
+  photos: File[]; // 새로 추가할 이미지들
   onPhotoAdd: (files: File[]) => void;
   onPhotoRemove: (index: number) => void;
+  existingImageUrls?: string[]; // 기존 이미지 URL들 (수정 시에만 사용)
+  onExistingImageRemove?: (imageUrl: string) => void; // 기존 이미지 제거 함수 (수정 시에만 사용)
+  readOnly?: boolean; // 읽기 전용 모드
+  isEditMode?: boolean; // 수정 모드 (사진 추가 버튼 숨김)
 }
 
-const PhotoSection = ({ photos, onPhotoAdd, onPhotoRemove }: PhotoSectionProps) => {
+const PhotoSection = ({
+  photos,
+  onPhotoAdd,
+  onPhotoRemove,
+  existingImageUrls = [],
+  onExistingImageRemove,
+  readOnly = false,
+  isEditMode = false,
+}: PhotoSectionProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileInputClick = () => {
+    if (readOnly || isEditMode) return;
     fileInputRef.current?.click();
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (readOnly || isEditMode) return;
+
     const files = Array.from(e.target.files || []);
     if (files.length > 0) {
       onPhotoAdd(files);
@@ -38,34 +53,64 @@ const PhotoSection = ({ photos, onPhotoAdd, onPhotoRemove }: PhotoSectionProps) 
     return URL.createObjectURL(file);
   };
 
-  const isDisabled = photos.length >= 3;
+  const totalImageCount = existingImageUrls.length + photos.length;
+  const isDisabled = totalImageCount >= 3 || readOnly || isEditMode;
 
   return (
     <Section>
       <SectionTitle>사진 추가</SectionTitle>
       <PhotoContainer>
         <PhotoGrid>
-          <AddPhotoButton onClick={handleFileInputClick} disabled={isDisabled}>
-            <img src={isDisabled ? plusDisabledIcon : plusIcon} alt="사진 추가" />
-          </AddPhotoButton>
+          {/* 새 이미지 추가 버튼 - 수정 모드에서는 숨김 */}
+          {!readOnly && !isEditMode && (
+            <AddPhotoButton onClick={handleFileInputClick} disabled={isDisabled}>
+              <img src={isDisabled ? plusDisabledIcon : plusIcon} alt="사진 추가" />
+            </AddPhotoButton>
+          )}
+
+          {/* 기존 이미지들 (수정 모드에서만 표시) */}
+          {existingImageUrls.map((imageUrl, index) => (
+            <div
+              key={`existing-${index}`}
+              style={{ position: 'relative', width: '80px', height: '80px' }}
+            >
+              <PhotoImage src={imageUrl} alt={`기존 이미지 ${index + 1}`} />
+              {!readOnly && onExistingImageRemove && (
+                <RemoveButton onClick={() => onExistingImageRemove(imageUrl)}>
+                  <img src={closeIcon} alt="삭제" />
+                </RemoveButton>
+              )}
+            </div>
+          ))}
+
+          {/* 새로 추가된 이미지들 */}
           {photos.map((photo, index) => (
-            <div key={index} style={{ position: 'relative', width: '80px', height: '80px' }}>
-              <PhotoImage src={createImageUrl(photo)} alt={`선택된 사진 ${index + 1}`} />
-              <RemoveButton onClick={() => onPhotoRemove(index)}>
-                <img src={closeIcon} alt="삭제" />
-              </RemoveButton>
+            <div
+              key={`new-${index}`}
+              style={{ position: 'relative', width: '80px', height: '80px' }}
+            >
+              <PhotoImage src={createImageUrl(photo)} alt={`새 이미지 ${index + 1}`} />
+              {!readOnly && (
+                <RemoveButton onClick={() => onPhotoRemove(index)}>
+                  <img src={closeIcon} alt="삭제" />
+                </RemoveButton>
+              )}
             </div>
           ))}
         </PhotoGrid>
-        <PhotoCount>{photos.length}/3개</PhotoCount>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          multiple
-          style={{ display: 'none' }}
-          onChange={handleFileChange}
-        />
+
+        <PhotoCount>{totalImageCount}/3개</PhotoCount>
+
+        {!readOnly && !isEditMode && (
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+          />
+        )}
       </PhotoContainer>
     </Section>
   );

--- a/src/hooks/useUpdateFeed.ts
+++ b/src/hooks/useUpdateFeed.ts
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { updateFeed, type UpdateFeedBody, type UpdateFeedResponse } from '@/api/feeds/updateFeed';
+import { usePopupActions } from './usePopupActions';
+
+interface UseUpdateFeedProps {
+  onSuccess?: (feedId: number) => void;
+}
+
+export const useUpdateFeed = (options?: UseUpdateFeedProps) => {
+  const [loading, setLoading] = useState(false);
+  const { openSnackbar, closePopup } = usePopupActions();
+
+  const updateExistingFeed = async (feedId: number, body: UpdateFeedBody) => {
+    try {
+      setLoading(true);
+
+      // ===== 클라이언트 선검증 =====
+      if (body.tagList) {
+        // 최대 5개
+        if (body.tagList.length > 5) {
+          openSnackbar({
+            message: '태그는 최대 5개까지 입력할 수 있어요.',
+            variant: 'top',
+            onClose: closePopup,
+          });
+          return { success: false as const };
+        }
+        // 중복 제거 체크
+        const trimmed = body.tagList.map(t => t.trim()).filter(Boolean);
+        const uniq = new Set(trimmed);
+        if (uniq.size !== trimmed.length) {
+          openSnackbar({
+            message: '태그는 중복될 수 없어요.',
+            variant: 'top',
+            onClose: closePopup,
+          });
+          return { success: false as const };
+        }
+      }
+      // ===== 선검증 끝 =====
+
+      const res: UpdateFeedResponse = await updateFeed(feedId, body);
+
+      if (res.isSuccess) {
+        openSnackbar({
+          message: '피드가 수정되었습니다.',
+          variant: 'top',
+          onClose: closePopup,
+        });
+
+        if (options?.onSuccess) {
+          options.onSuccess(feedId);
+        }
+
+        return { success: true as const, feedId };
+      } else {
+        openSnackbar({
+          message: res.message || '피드 수정에 실패했습니다.',
+          variant: 'top',
+          onClose: closePopup,
+        });
+        return { success: false as const, error: res.message };
+      }
+    } catch (error) {
+      console.error('피드 수정 실패:', error);
+      openSnackbar({
+        message: '피드 수정 중 오류가 발생했습니다.',
+        variant: 'top',
+        onClose: closePopup,
+      });
+      return { success: false as const, error: '피드 수정 중 오류가 발생했습니다.' };
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { updateExistingFeed, loading };
+};

--- a/src/pages/feed/FeedDetailPage.tsx
+++ b/src/pages/feed/FeedDetailPage.tsx
@@ -87,7 +87,10 @@ const FeedDetailPage = () => {
 
   const handleMoreClick = () => {
     openMoreMenu({
-      onEdit: () => console.log('수정하기 클릭'),
+      onEdit: () => {
+        closePopup();
+        navigate(`/post/update/${feedId}`);
+      },
       onClose: () => {
         closePopup();
       },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,7 @@ import SignupNickname from './signup/SignupNickname';
 import SignupDone from './signup/SignupDone';
 import CreateGroup from './group/CreateGroup';
 import CreatePost from './post/CreatePost';
+import UpdatePost from './post/UpdatePost';
 import Group from './group/Group';
 import Feed from './feed/Feed';
 import GroupSearch from './groupSearch/GroupSearch';
@@ -51,6 +52,7 @@ const Router = () => {
         <Route path="post/create" element={<CreatePost />} />
         <Route path="group" element={<Group />} />
         <Route path="group/create" element={<CreateGroup />} />
+        <Route path="post/update/:feedId" element={<UpdatePost />} />
         <Route path="group/search" element={<GroupSearch />} />
         <Route path="group/detail" element={<GroupDetail />} />
         <Route path="group/detail/joined" element={<ParticipatedGroupDetail />} />

--- a/src/pages/post/UpdatePost.tsx
+++ b/src/pages/post/UpdatePost.tsx
@@ -111,11 +111,15 @@ const UpdatePost = () => {
       ...(remainImageUrls.length ? { remainImageUrls } : {}),
     };
 
-    // 수정 모드에서는 새 이미지 추가 불가
+    // API 요청 전 데이터 확인
+    console.log('수정 요청 데이터:', {
+      feedId: Number(feedId),
+      body: body,
+    });
+
     const result = await updateExistingFeed(Number(feedId), body);
 
     if (!result?.success) {
-      // 에러는 useUpdateFeed에서 이미 처리됨
       return;
     }
   };

--- a/src/pages/post/UpdatePost.tsx
+++ b/src/pages/post/UpdatePost.tsx
@@ -1,0 +1,204 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import TitleHeader from '../../components/common/TitleHeader';
+import BookSelectionSection from '../../components/creategroup/BookSelectionSection';
+import PostContentSection from '../../components/createpost/PostContentSection';
+import PhotoSection from '../../components/createpost/PhotoSection';
+import PrivacyToggleSection from '../../components/createpost/PrivacyToggleSection';
+import TagSelectionSection from '../../components/createpost/TagSelectionSection';
+import leftarrow from '../../assets/common/leftArrow.svg';
+import { Container } from './CreatePost.styled';
+import { Section } from '../group/CommonSection.styled';
+import { useUpdateFeed } from '@/hooks/useUpdateFeed';
+import { usePopupActions } from '@/hooks/usePopupActions';
+import { getFeedDetail } from '@/api/feeds/getFeedDetail';
+import type { UpdateFeedBody } from '@/api/feeds/updateFeed';
+
+interface Book {
+  id: number;
+  title: string;
+  author: string;
+  cover: string;
+  isbn: string;
+}
+
+const UpdatePost = () => {
+  const navigate = useNavigate();
+  const { feedId } = useParams<{ feedId: string }>();
+  const [selectedBook, setSelectedBook] = useState<Book | null>(null);
+  const [postContent, setPostContent] = useState('');
+  const [selectedPhotos] = useState<File[]>([]); // 수정 모드에서는 사용하지 않음
+  const [remainImageUrls, setRemainImageUrls] = useState<string[]>([]); // 유지할 기존 이미지들
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const { openSnackbar, closePopup } = usePopupActions();
+  const { updateExistingFeed, loading: updateLoading } = useUpdateFeed({
+    onSuccess: feedId => {
+      console.log('피드 수정 성공! 피드 ID:', feedId);
+      navigate(`/feed/${feedId}`);
+    },
+  });
+
+  // 피드 상세 정보 로드
+  useEffect(() => {
+    const loadFeedDetail = async () => {
+      if (!feedId) {
+        openSnackbar({
+          message: '잘못된 피드 ID입니다.',
+          variant: 'top',
+          onClose: closePopup,
+        });
+        navigate(-1);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        const response = await getFeedDetail(Number(feedId));
+        const data = response.data;
+
+        // 기존 데이터로 폼 초기화
+        setSelectedBook({
+          id: 0, // API에서 bookId가 없다면 임시값
+          title: data.bookTitle,
+          author: data.bookAuthor,
+          cover: '', // API에서 bookCover가 없다면 빈 문자열
+          isbn: data.isbn,
+        });
+
+        setPostContent(data.contentBody);
+        setIsPrivate(!data.isPublic); // isPublic 필드 사용
+        setSelectedTags(data.tagList || []);
+        setRemainImageUrls(data.contentUrls || []); // 처음에는 모든 기존 이미지 유지
+      } catch (error) {
+        console.error('피드 상세 정보 로드 실패:', error);
+        openSnackbar({
+          message: '피드 정보를 불러오는데 실패했습니다.',
+          variant: 'top',
+          onClose: closePopup,
+        });
+        navigate(-1);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadFeedDetail();
+  }, [feedId, navigate, openSnackbar, closePopup]);
+
+  const handleBackClick = () => {
+    navigate(-1);
+  };
+
+  const handleCompleteClick = async () => {
+    if (!isFormValid) {
+      openSnackbar({
+        message: '글 내용을 입력해주세요.',
+        variant: 'top',
+        onClose: closePopup,
+      });
+      return;
+    }
+
+    if (!feedId) return;
+
+    const body: UpdateFeedBody = {
+      contentBody: postContent.trim(),
+      isPublic: !isPrivate,
+      ...(selectedTags.length ? { tagList: selectedTags } : {}),
+      ...(remainImageUrls.length ? { remainImageUrls } : {}),
+    };
+
+    // 수정 모드에서는 새 이미지 추가 불가
+    const result = await updateExistingFeed(Number(feedId), body);
+
+    if (!result?.success) {
+      // 에러는 useUpdateFeed에서 이미 처리됨
+      return;
+    }
+  };
+
+  // 새로 추가할 이미지 핸들러 (수정 모드에서는 사용하지 않음)
+  const handlePhotoAdd = () => {
+    // 수정 모드에서는 새 이미지 추가 불가
+    return;
+  };
+
+  // 새로 추가한 이미지 제거 (수정 모드에서는 사용하지 않음)
+  const handlePhotoRemove = () => {
+    // 수정 모드에서는 새 이미지 추가 불가
+    return;
+  };
+
+  // 기존 이미지 제거 (remainImageUrls에서 제외)
+  const handleExistingImageRemove = (imageUrl: string) => {
+    setRemainImageUrls(prev => prev.filter(url => url !== imageUrl));
+  };
+
+  const handlePrivacyToggle = () => setIsPrivate(v => !v);
+
+  const handleTagToggle = (tag: string) => {
+    setSelectedTags(prev => (prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]));
+  };
+
+  const isFormValid = postContent.trim() !== '';
+
+  // 로딩 중
+  if (loading) {
+    return (
+      <div style={{ padding: '56px 0', textAlign: 'center', color: 'white' }}>
+        피드 정보를 불러오는 중...
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <TitleHeader
+        leftIcon={<img src={leftarrow} alt="뒤로가기" />}
+        title="글 수정"
+        rightButton={updateLoading ? '수정 중...' : '완료'}
+        onLeftClick={handleBackClick}
+        onRightClick={handleCompleteClick}
+        isNextActive={isFormValid && !updateLoading}
+      />
+      <Container>
+        {/* 책 정보는 수정할 수 없음 (읽기 전용으로 표시) */}
+        <BookSelectionSection
+          selectedBook={selectedBook}
+          onSearchClick={() => {}} // 비활성화
+          onChangeClick={() => {}} // 비활성화
+          readOnly={true} // 읽기 전용 모드
+        />
+
+        <Section showDivider />
+
+        <PostContentSection content={postContent} onContentChange={setPostContent} />
+
+        <Section showDivider />
+
+        {/* 기존 이미지 삭제만 가능, 추가는 불가 */}
+        <PhotoSection
+          photos={selectedPhotos}
+          onPhotoAdd={handlePhotoAdd}
+          onPhotoRemove={handlePhotoRemove}
+          existingImageUrls={remainImageUrls}
+          onExistingImageRemove={handleExistingImageRemove}
+          isEditMode={true} // 수정 모드로 설정하여 추가 버튼 숨김
+        />
+
+        <Section showDivider />
+
+        <PrivacyToggleSection isPrivate={isPrivate} onToggle={handlePrivacyToggle} />
+
+        <Section showDivider />
+
+        <TagSelectionSection selectedTags={selectedTags} onTagToggle={handleTagToggle} />
+      </Container>
+    </>
+  );
+};
+
+export default UpdatePost;

--- a/src/pages/post/UpdatePost.tsx
+++ b/src/pages/post/UpdatePost.tsx
@@ -27,8 +27,8 @@ const UpdatePost = () => {
   const { feedId } = useParams<{ feedId: string }>();
   const [selectedBook, setSelectedBook] = useState<Book | null>(null);
   const [postContent, setPostContent] = useState('');
-  const [selectedPhotos] = useState<File[]>([]); // 수정 모드에서는 사용하지 않음
-  const [remainImageUrls, setRemainImageUrls] = useState<string[]>([]); // 유지할 기존 이미지들
+  const [selectedPhotos] = useState<File[]>([]);
+  const [remainImageUrls, setRemainImageUrls] = useState<string[]>([]);
   const [isPrivate, setIsPrivate] = useState(false);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -86,7 +86,7 @@ const UpdatePost = () => {
     };
 
     loadFeedDetail();
-  }, [feedId]); // 의존성 배열에서 함수들 제거
+  }, [feedId]);
 
   const handleBackClick = () => {
     navigate(-1);
@@ -111,12 +111,6 @@ const UpdatePost = () => {
       ...(remainImageUrls.length ? { remainImageUrls } : {}),
     };
 
-    // API 요청 전 데이터 확인
-    console.log('수정 요청 데이터:', {
-      feedId: Number(feedId),
-      body: body,
-    });
-
     const result = await updateExistingFeed(Number(feedId), body);
 
     if (!result?.success) {
@@ -124,19 +118,14 @@ const UpdatePost = () => {
     }
   };
 
-  // 새로 추가할 이미지 핸들러 (수정 모드에서는 사용하지 않음)
   const handlePhotoAdd = () => {
-    // 수정 모드에서는 새 이미지 추가 불가
     return;
   };
 
-  // 새로 추가한 이미지 제거 (수정 모드에서는 사용하지 않음)
   const handlePhotoRemove = () => {
-    // 수정 모드에서는 새 이미지 추가 불가
     return;
   };
 
-  // 기존 이미지 제거 (remainImageUrls에서 제외)
   const handleExistingImageRemove = (imageUrl: string) => {
     setRemainImageUrls(prev => prev.filter(url => url !== imageUrl));
   };
@@ -169,12 +158,11 @@ const UpdatePost = () => {
         isNextActive={isFormValid && !updateLoading}
       />
       <Container>
-        {/* 책 정보는 수정할 수 없음 (읽기 전용으로 표시) */}
         <BookSelectionSection
           selectedBook={selectedBook}
-          onSearchClick={() => {}} // 비활성화
-          onChangeClick={() => {}} // 비활성화
-          readOnly={true} // 읽기 전용 모드
+          onSearchClick={() => {}}
+          onChangeClick={() => {}}
+          readOnly={true}
         />
 
         <Section showDivider />
@@ -183,14 +171,13 @@ const UpdatePost = () => {
 
         <Section showDivider />
 
-        {/* 기존 이미지 삭제만 가능, 추가는 불가 */}
         <PhotoSection
           photos={selectedPhotos}
           onPhotoAdd={handlePhotoAdd}
           onPhotoRemove={handlePhotoRemove}
           existingImageUrls={remainImageUrls}
           onExistingImageRemove={handleExistingImageRemove}
-          isEditMode={true} // 수정 모드로 설정하여 추가 버튼 숨김
+          isEditMode={true}
         />
 
         <Section showDivider />

--- a/src/pages/post/UpdatePost.tsx
+++ b/src/pages/post/UpdatePost.tsx
@@ -61,17 +61,17 @@ const UpdatePost = () => {
 
         // 기존 데이터로 폼 초기화
         setSelectedBook({
-          id: 0, // API에서 bookId가 없다면 임시값
+          id: 0,
           title: data.bookTitle,
           author: data.bookAuthor,
-          cover: '', // API에서 bookCover가 없다면 빈 문자열
+          cover: '',
           isbn: data.isbn,
         });
 
         setPostContent(data.contentBody);
-        setIsPrivate(!data.isPublic); // isPublic 필드 사용
+        setIsPrivate(!data.isPublic);
         setSelectedTags(data.tagList || []);
-        setRemainImageUrls(data.contentUrls || []); // 처음에는 모든 기존 이미지 유지
+        setRemainImageUrls(data.contentUrls || []);
       } catch (error) {
         console.error('피드 상세 정보 로드 실패:', error);
         openSnackbar({
@@ -86,7 +86,7 @@ const UpdatePost = () => {
     };
 
     loadFeedDetail();
-  }, [feedId, navigate, openSnackbar, closePopup]);
+  }, [feedId]); // 의존성 배열에서 함수들 제거
 
   const handleBackClick = () => {
     navigate(-1);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#94 

## 📝 작업 내용

피드 수정 기능을 구현했습니다. 사용자가 작성한 피드의 내용, 공개/비공개 설정, 태그, 기존 이미지를 수정할 수 있는 기능을 추가했습니다.

## 🕸️ 주요 구현 내용

**1. API 레이어 구현**
- `updateFeed.ts`: 피드 수정 API 함수 구현
- `useUpdateFeed.ts`: 피드 수정 비즈니스 로직을 담은 커스텀 훅 구현

**2. 수정 페이지 컴포넌트 구현**
- `UpdatePost.tsx`: 피드 수정 전용 페이지 컴포넌트 생성
- 기존 피드 데이터를 불러와 폼에 자동 입력
- 수정 완료 후 해당 피드 상세 페이지로 자동 이동

**3. 기존 컴포넌트 확장**
- `PhotoSection.tsx`: `isEditMode` props 추가하여 수정 모드에서 사진 추가 버튼 숨김 처리
- `BookSelectionSection.tsx`: readOnly props 추가하여 읽기 전용 모드 지원
- `getFeedDetail.ts`: isPublic 필드를 타입 정의에 추가

### 기능적 제약사항 (요구사항에 따른 설계)
- **책 정보 수정 불가:** 선택된 책 정보는 읽기 전용으로 표시되며 변경할 수 없습니다.
- **이미지 추가 불가, 삭제만 가능:** 수정 모드에서는 새로운 이미지를 추가할 수 없고, 기존 이미지의 삭제만 가능합니다. 이를 위해 PhotoSection 컴포넌트에 isEditMode props를 추가하여 사진 추가 버튼을 완전히 숨겼습니다.
- **수정 가능한 항목:** 글 내용, 공개/비공개 설정, 태그 선택, 기존 이미지 삭제

### 기술적 해결사항
- **API 요청 형식 최적화:** 초기에는 스웨거 명세서에 따라 `multipart/form-data` 형식으로 구현했으나, 실제 서버에서는 `application/json` 형식을 기대하고 있어 500 에러가 발생했습니다. 이를 해결하기 위해 JSON 형식을 우선으로 시도하고, 실패 시 FormData로 fallback하는 로직을 구현했습니다.
- **무한 렌더링 방지:** `useEffect`의 의존성 배열에서 함수 참조로 인한 무한 루프를 방지하기 위해 의존성을 feedId만으로 제한했습니다.