### PR TITLE
feat: 새 글 작성을 위한 화면 조회(카테고리, 태그 조회) API 연동

### DIFF
--- a/src/api/feeds/getWriteInfo.ts
+++ b/src/api/feeds/getWriteInfo.ts
@@ -1,0 +1,38 @@
+import { apiClient } from '../index';
+
+// 카테고리 및 태그 데이터 타입
+export interface CategoryData {
+  category: string;
+  tagList: string[];
+}
+
+// API 응답 데이터 타입
+export interface WriteInfoData {
+  categoryList: CategoryData[];
+}
+
+// API 응답 타입
+export interface GetWriteInfoResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: WriteInfoData;
+}
+
+// 새 글 작성을 위한 카테고리 및 태그 조회 API 함수
+export const getWriteInfo = async () => {
+  const response = await apiClient.get<GetWriteInfoResponse>('/feeds/write-info');
+  return response.data;
+};
+
+/*
+사용 예시:
+const writeInfo = await getWriteInfo();
+console.log(writeInfo.data.categoryList); // CategoryData[]
+
+// 카테고리별 태그 접근
+writeInfo.data.categoryList.forEach(category => {
+  console.log(`카테고리: ${category.category}`);
+  console.log(`태그: ${category.tagList.join(', ')}`);
+});
+*/


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#71 

## 📝 작업 내용

새 글 작성 시 필요한 카테고리 및 태그 정보를 서버에서 동적으로 가져오도록 API 연동 작업을 수행했습니다.

## 🕸️ 주요 변경 사항
**1. API 연동 파일 신규 생성**
`src/api/feeds/getWriteInfo.ts` 파일을 새로 생성하여 `/feeds/write-info `엔드포인트와 연동했습니다. 이 API는 새 글 작성 시 사용할 수 있는 모든 카테고리와 각 카테고리별 태그 목록을 반환합니다.

**2. TagSelectionSection 컴포넌트 리팩토링**
기존에 하드코딩되어 있던 카테고리 및 태그 데이터를 제거하고, 새로 생성한 API를 통해 동적으로 데이터를 로드하도록 변경했습니다. 이를 통해 서버에서 관리하는 최신 카테고리 및 태그 정보를 실시간으로 반영할 수 있게 되었습니다. 컴포넌트 마운트 시 자동으로 API를 호출하여 데이터를 가져오며, 로딩 상태와 에러 처리도 추가했습니다.

**3. 데이터 구조 개선**
API 응답 구조에 맞춰 `CategoryData` 인터페이스를 정의하고, 각 카테고리별로 태그 목록을 관리하는 구조로 개선했습니다. 기존의 하드코딩된 장르-태그 매핑 구조에서 서버 데이터 기반의 유연한 구조로 변경되어, 향후 카테고리나 태그가 추가/변경될 때 코드 수정 없이 자동으로 반영됩니다.

**4. 사용자 경험 개선**
API 호출 중에는 "로딩 중..." 메시지를 표시하여 사용자에게 상태를 명확히 전달하도록 했습니다. 또한 API 응답의 첫 번째 카테고리를 기본 선택하여 사용자가 별도 조작 없이도 바로 태그를 선택할 수 있도록 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 게시글 작성의 태그 선택이 서버에서 최신 카테고리·태그를 동적으로 불러오도록 개선되었습니다.
  - 데이터 로딩 중 상태 표시(“로딩 중...”)가 추가되었습니다.
  - 카테고리 버튼으로 손쉽게 전환하며, 선택된 카테고리에 맞춘 태그 목록이 표시됩니다.
  - 태그 선택 제한(최대 5개)이 유지됩니다.

- 리팩터링
  - 하드코딩된 장르/태그 정보를 제거하고 데이터 기반 흐름으로 전환했습니다.
  - 로딩·오류 상태 관리와 로깅을 정비해 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->