### PR TITLE
feat: Rooms 도메인 API 연동

### DIFF
--- a/src/api/rooms/getJoinedRooms.ts
+++ b/src/api/rooms/getJoinedRooms.ts
@@ -1,0 +1,34 @@
+import { apiClient } from '../index';
+
+// 가입한 방 목록 응답 데이터 타입
+export interface JoinedRoomItem {
+  roomId: number;
+  bookImageUrl: string;
+  roomTitle: string;
+  memberCount: number;
+  userPercentage: number;
+}
+
+export interface JoinedRoomsResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: {
+    roomList: JoinedRoomItem[];
+    nickname: string;
+    page: number;
+    size: number;
+    last: boolean;
+    first: boolean;
+  };
+}
+
+export const getJoinedRooms = async (page: number = 1): Promise<JoinedRoomsResponse> => {
+  try {
+    const response = await apiClient.get<JoinedRoomsResponse>(`/rooms/home/joined?page=${page}`);
+    return response.data;
+  } catch (error) {
+    console.error('가입한 방 목록 조회 API 오류:', error);
+    throw error;
+  }
+};

--- a/src/api/rooms/getMyRooms.ts
+++ b/src/api/rooms/getMyRooms.ts
@@ -1,0 +1,44 @@
+import { apiClient } from '../index';
+
+export type RoomType = 'playingAndRecruiting' | 'recruiting' | 'playing' | 'expired';
+
+// 방 데이터 타입
+export interface Room {
+  roomId: number;
+  bookImageUrl: string;
+  roomName: string;
+  recruitCount: number;
+  memberCount: number;
+  endDate: string;
+  type: string;
+}
+
+// 내 방 조회 응답 타입
+export interface MyRoomsResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: {
+    roomList: Room[];
+    nextCursor: string;
+    isLast: boolean;
+  };
+}
+
+export const getMyRooms = async (
+  type: RoomType = 'playingAndRecruiting',
+  cursor: string | null = null,
+): Promise<MyRoomsResponse> => {
+  try {
+    const params = new URLSearchParams();
+    params.append('type', type);
+    if (cursor) {
+      params.append('cursor', cursor);
+    }
+    const response = await apiClient.get<MyRoomsResponse>(`/rooms/my?${params.toString()}`);
+    return response.data;
+  } catch (error) {
+    console.error('내 방 조회 API 오류:', error);
+    throw error;
+  }
+};

--- a/src/api/rooms/getRoomDetail.ts
+++ b/src/api/rooms/getRoomDetail.ts
@@ -1,0 +1,49 @@
+import { apiClient } from '../index';
+
+// 방 상세 정보 응답 타입
+export interface RoomDetailResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: {
+    isHost: boolean;
+    isJoining: boolean;
+    roomId: number;
+    roomName: string;
+    roomImageUrl: string;
+    isPublic: boolean;
+    progressStartDate: string;
+    progressEndDate: string;
+    recruitEndDate: string;
+    category: string;
+    roomDescription: string;
+    memberCount: number;
+    recruitCount: number;
+    isbn: string;
+    bookImageUrl: string;
+    bookTitle: string;
+    authorName: string;
+    bookDescription: string;
+    publisher: string;
+    recommendRooms: RecommendRoom[];
+  };
+}
+
+export interface RecommendRoom {
+  roomId: number;
+  roomImageUrl: string;
+  roomName: string;
+  memberCount: number;
+  recruitCount: number;
+  recruitEndDate: string;
+}
+
+export const getRoomDetail = async (roomId: number): Promise<RoomDetailResponse> => {
+  try {
+    const response = await apiClient.get<RoomDetailResponse>(`/rooms/${roomId}/recruiting`);
+    return response.data;
+  } catch (error) {
+    console.error('방 상세 정보 조회 API 오류:', error);
+    throw error;
+  }
+};

--- a/src/api/rooms/getRoomsByCategory.ts
+++ b/src/api/rooms/getRoomsByCategory.ts
@@ -1,0 +1,33 @@
+import { apiClient } from '../index';
+
+// 방 목록 응답 데이터 타입
+export interface RoomItem {
+  roomId: number;
+  bookImageUrl: string;
+  roomName: string;
+  recruitCount: number;
+  memberCount: number;
+  deadlineDate: string;
+}
+
+export interface RoomsResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: {
+    deadlineRoomList: RoomItem[];
+    popularRoomList: RoomItem[];
+  };
+}
+
+export const getRoomsByCategory = async (category: string): Promise<RoomsResponse> => {
+  try {
+    const response = await apiClient.get<RoomsResponse>(
+      `/rooms?category=${encodeURIComponent(category)}`,
+    );
+    return response.data;
+  } catch (error) {
+    console.error('방 목록 조회 API 오류:', error);
+    throw error;
+  }
+};

--- a/src/components/group/CompletedGroupModal.tsx
+++ b/src/components/group/CompletedGroupModal.tsx
@@ -1,86 +1,58 @@
+import { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import type { Group } from './MyGroupBox';
 import { GroupCard } from './GroupCard';
 import TitleHeader from '../common/TitleHeader';
 import { Modal, Overlay } from './Modal.styles';
+import { getMyRooms, type Room } from '@/api/rooms/getMyRooms';
+import { colors, typography } from '@/styles/global/global';
 
 interface CompletedGroupModalProps {
   onClose: () => void;
 }
 
-const dummyCompletedGroups: Group[] = [
-  {
-    id: '1',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 1,
-    genre: '문학',
-  },
-  {
-    id: '2',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 2,
-    genre: '문학',
-  },
-  {
-    id: '3',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 3,
-    genre: '문학',
-  },
-  {
-    id: '4',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 4,
-    genre: '문학',
-  },
-  {
-    id: '5',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 4,
-    genre: '과학·IT',
-  },
-  {
-    id: '6',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 4,
-    genre: '과학·IT',
-  },
-];
-
-const userName = '00';
-
 const CompletedGroupModal = ({ onClose }: CompletedGroupModalProps) => {
+  const [rooms, setRooms] = useState<Room[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const convertRoomToGroup = (room: Room): Group => {
+    return {
+      id: room.roomId.toString(),
+      title: room.roomName,
+      userName: '',
+      participants: room.memberCount,
+      maximumParticipants: room.recruitCount,
+      coverUrl: room.bookImageUrl,
+      deadLine: 0,
+      isOnGoing: false,
+    };
+  };
+
+  useEffect(() => {
+    const fetchCompletedRooms = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const response = await getMyRooms('expired', null);
+        if (response.isSuccess) {
+          setRooms(response.data.roomList);
+        } else {
+          setError(response.message);
+        }
+      } catch (error) {
+        console.error('완료된 방 목록 조회 실패:', error);
+        setError('완료된 방 목록을 불러오는데 실패했습니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchCompletedRooms();
+  }, []);
+
+  const convertedGroups = rooms.map(convertRoomToGroup);
   return (
     <Overlay>
       <Modal>
@@ -89,11 +61,20 @@ const CompletedGroupModal = ({ onClose }: CompletedGroupModalProps) => {
           leftIcon={<img src={leftArrow} alt="뒤로 가기" />}
           onLeftClick={onClose}
         />
-        <Text>{userName}님이 참여했던 모임방들을 확인해보세요.</Text>
-        <Content>
-          {dummyCompletedGroups.map(group => (
-            <GroupCard key={group.id} group={group} type={'modal'}></GroupCard>
-          ))}
+        <Text>00님이 참여했던 모임방들을 확인해보세요.</Text>
+        <Content isEmpty={!isLoading && !error && convertedGroups.length === 0}>
+          {isLoading ? (
+            <LoadingMessage>로딩 중...</LoadingMessage>
+          ) : error ? (
+            <ErrorMessage>{error}</ErrorMessage>
+          ) : convertedGroups.length > 0 ? (
+            convertedGroups.map(group => <GroupCard key={group.id} group={group} type={'modal'} />)
+          ) : (
+            <EmptyState data-empty="true">
+              <EmptyTitle>완료된 모임방이 없어요</EmptyTitle>
+              <EmptySubText>아직 완료된 모임방이 없습니다.</EmptySubText>
+            </EmptyState>
+          )}
         </Content>
       </Modal>
     </Overlay>
@@ -103,21 +84,63 @@ const CompletedGroupModal = ({ onClose }: CompletedGroupModalProps) => {
 export default CompletedGroupModal;
 
 const Text = styled.p`
-  font-size: var(--font-size-medium01);
-  font-weight: var(--font-weight-regular);
-  color: var(--color-white);
+  font-size: ${typography.fontSize.sm};
+  font-weight: ${typography.fontWeight.regular};
+  color: ${colors.white};
   margin: 96px 20px 20px 20px;
 `;
 
-const Content = styled.div`
+const Content = styled.div<{ isEmpty?: boolean }>`
   display: grid;
   gap: 20px;
-  overflow-y: auto;
+  overflow-y: ${({ isEmpty }) => (isEmpty ? 'visible' : 'auto')};
   padding: 0 20px;
-
+  flex: 1;
   grid-template-columns: 1fr;
 
   @media (min-width: 584px) {
     grid-template-columns: 1fr 1fr;
   }
+`;
+
+const LoadingMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 20px;
+  color: ${colors.white};
+  font-size: ${typography.fontSize.base};
+`;
+
+const ErrorMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 20px;
+  color: #ff6b6b;
+  font-size: ${typography.fontSize.base};
+`;
+
+const EmptyState = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 20px;
+  color: ${colors.grey[100]};
+  text-align: center;
+  height: 100%;
+`;
+
+const EmptyTitle = styled.p`
+  font-size: ${typography.fontSize.lg};
+  font-weight: ${typography.fontWeight.semibold};
+  margin-bottom: 8px;
+  color: ${colors.white};
+`;
+
+const EmptySubText = styled.p`
+  font-size: ${typography.fontSize.sm};
+  font-weight: ${typography.fontWeight.regular};
+  color: ${colors.grey[100]};
 `;

--- a/src/components/group/GroupCard.tsx
+++ b/src/components/group/GroupCard.tsx
@@ -9,12 +9,13 @@ interface Props {
   isOngoing?: boolean;
   type?: 'main' | 'search' | 'modal';
   isRecommend?: boolean;
+  onClick?: () => void;
 }
 
 export const GroupCard = forwardRef<HTMLDivElement, Props>(
-  ({ group, isOngoing, type = 'main', isRecommend = false }, ref) => {
+  ({ group, isOngoing, type = 'main', isRecommend = false, onClick }, ref) => {
     return (
-      <Card ref={ref} cardType={type}>
+      <Card ref={ref} cardType={type} onClick={onClick}>
         <Cover src={group.coverUrl} alt="cover" cardType={type} isRecommend={isRecommend} />
         <Info>
           <Title isRecommend={isRecommend}>{group.title}</Title>

--- a/src/components/group/GroupCard.tsx
+++ b/src/components/group/GroupCard.tsx
@@ -53,7 +53,9 @@ const Card = styled.div<{ cardType: 'main' | 'search' | 'modal' }>`
   box-sizing: border-box;
   padding: ${({ cardType }) => (cardType === 'search' ? '24px 12px 12px 12px' : '12px')};
   gap: 12px;
-  width: 100%;
+  min-width: 208px;
+  min-height: 80px;
+  padding: 12px;
 `;
 
 const Cover = styled.img<{ cardType: 'main' | 'search' | 'modal'; isRecommend?: boolean }>`

--- a/src/components/group/MyGroupBox.tsx
+++ b/src/components/group/MyGroupBox.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import rightChevron from '../../assets/common/right-Chevron.svg';
 import { useState, useEffect } from 'react';
 import { getJoinedRooms, type JoinedRoomItem } from '@/api/rooms/getJoinedRooms';
+import { colors, typography } from '@/styles/global/global';
 
 export interface Group {
   id: number | string;
@@ -105,7 +106,7 @@ export function MyGroupBox({ onMyGroupsClick }: MyGroupProps) {
 }
 
 const Container = styled.div`
-  background-color: var(--color-main-black);
+  background-color: ${colors.black.main};
   position: relative;
   width: 100%;
   overflow-x: hidden;
@@ -119,9 +120,9 @@ const Header = styled.div`
 
 const Title = styled.h2`
   flex: 1;
-  font-size: var(--font-size-large02);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-white);
+  font-size: ${typography.fontSize.xl};
+  font-weight: ${typography.fontWeight.bold};
+  color: ${colors.white};
   margin: 0;
 `;
 
@@ -158,7 +159,7 @@ const Dot = styled.div<{ active: boolean }>`
   width: 4px;
   height: 4px;
   border-radius: 50%;
-  background: ${({ active }) => (active ? 'var(--color-white)' : `var(--color-grey-300)`)};
+  background: ${({ active }) => (active ? colors.white : colors.grey[300])};
   transition: background-color 0.3s;
 `;
 
@@ -170,8 +171,8 @@ const LoadingContainer = styled.div`
 `;
 
 const LoadingText = styled.p`
-  color: var(--color-grey-300);
-  font-size: var(--font-size-medium02);
+  color: ${colors.grey[300]};
+  font-size: ${typography.fontSize.base};
   margin: 0;
 `;
 
@@ -183,8 +184,8 @@ const ErrorContainer = styled.div`
 `;
 
 const ErrorText = styled.p`
-  color: var(--color-red);
-  font-size: var(--font-size-medium02);
+  color: ${colors.red};
+  font-size: ${typography.fontSize.base};
   margin: 0;
 `;
 
@@ -196,7 +197,7 @@ const EmptyContainer = styled.div`
 `;
 
 const EmptyText = styled.p`
-  color: var(--color-grey-300);
-  font-size: var(--font-size-medium02);
+  color: ${colors.grey[300]};
+  font-size: ${typography.fontSize.base};
   margin: 0;
 `;

--- a/src/components/group/MyGroupModal.tsx
+++ b/src/components/group/MyGroupModal.tsx
@@ -1,96 +1,65 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import styled from '@emotion/styled';
 import TitleHeader from '../common/TitleHeader';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import type { Group } from './MyGroupBox';
 import { GroupCard } from './GroupCard';
 import { Modal, Overlay } from './Modal.styles';
+import { getMyRooms, type Room, type RoomType } from '@/api/rooms/getMyRooms';
 
 interface MyGroupModalProps {
   onClose: () => void;
 }
 
-const dummyMyGroups: Group[] = [
-  {
-    id: '1',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 1,
-    genre: '문학',
-    isOnGoing: true,
-  },
-  {
-    id: '2',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 2,
-    genre: '문학',
-    isOnGoing: true,
-  },
-  {
-    id: '3',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 3,
-    genre: '문학',
-    isOnGoing: true,
-  },
-  {
-    id: '4',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 4,
-    genre: '문학',
-    isOnGoing: true,
-  },
-  {
-    id: '5',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 4,
-    genre: '과학·IT',
-    isOnGoing: false,
-  },
-  {
-    id: '6',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 4,
-    genre: '과학·IT',
-    isOnGoing: false,
-  },
-];
-
 export const MyGroupModal = ({ onClose }: MyGroupModalProps) => {
   const [selected, setSelected] = useState<'진행중' | '모집중' | ''>('');
+  const [rooms, setRooms] = useState<Room[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const filtered = selected
-    ? dummyMyGroups.filter(g => (selected === '진행중' ? g.isOnGoing : !g.isOnGoing))
-    : dummyMyGroups;
+  const getRoomType = useCallback((): RoomType => {
+    if (selected === '진행중') return 'playing';
+    if (selected === '모집중') return 'recruiting';
+    return 'playingAndRecruiting';
+  }, [selected]);
+
+  const fetchRooms = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const roomType = getRoomType();
+      const response = await getMyRooms(roomType, null);
+      console.log(response);
+      if (response.isSuccess) {
+        setRooms(response.data.roomList);
+      } else {
+        setError(response.message);
+      }
+    } catch (error) {
+      console.error('방 목록 조회 실패:', error);
+      setError('방 목록을 불러오는데 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [getRoomType]);
+
+  const convertRoomToGroup = (room: Room): Group => {
+    return {
+      id: room.roomId.toString(),
+      title: room.roomName,
+      participants: room.memberCount,
+      maximumParticipants: room.recruitCount,
+      coverUrl: room.bookImageUrl,
+      deadLine: 0,
+      isOnGoing: room.type === 'playing' || room.type === 'playingAndRecruiting',
+    };
+  };
+
+  useEffect(() => {
+    fetchRooms();
+  }, [fetchRooms]);
+
+  const convertedGroups = rooms.map(convertRoomToGroup);
   return (
     <Overlay>
       <Modal>
@@ -113,14 +82,23 @@ export const MyGroupModal = ({ onClose }: MyGroupModalProps) => {
         </TabContainer>
 
         <Content>
-          {filtered.map(group => (
-            <GroupCard
-              key={group.id}
-              group={group}
-              isOngoing={group.isOnGoing ? true : false}
-              type={'modal'}
-            />
-          ))}
+          {isLoading ? (
+            <LoadingMessage>로딩 중...</LoadingMessage>
+          ) : error ? (
+            <ErrorMessage>{error}</ErrorMessage>
+          ) : convertedGroups.length > 0 ? (
+            convertedGroups.map(group => (
+              <GroupCard key={group.id} group={group} isOngoing={group.isOnGoing} type={'modal'} />
+            ))
+          ) : (
+            <EmptyMessage>
+              {selected === '진행중'
+                ? '진행중인 모임방이 없습니다.'
+                : selected === '모집중'
+                  ? '모집중인 모임방이 없습니다.'
+                  : '참여한 모임방이 없습니다.'}
+            </EmptyMessage>
+          )}
         </Content>
       </Modal>
     </Overlay>
@@ -157,4 +135,31 @@ const Content = styled.div`
   @media (min-width: 584px) {
     grid-template-columns: 1fr 1fr;
   }
+`;
+
+const LoadingMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 20px;
+  color: #fff;
+  font-size: var(--font-size-regular);
+`;
+
+const ErrorMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 20px;
+  color: #ff6b6b;
+  font-size: var(--font-size-regular);
+`;
+
+const EmptyMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 20px;
+  color: #999;
+  font-size: var(--font-size-regular);
 `;

--- a/src/components/group/MyGroupModal.tsx
+++ b/src/components/group/MyGroupModal.tsx
@@ -46,7 +46,6 @@ export const MyGroupModal = ({ onClose }: MyGroupModalProps) => {
               : 'playingAndRecruiting';
 
         const response = await getMyRooms(roomType, null);
-        console.log(response);
 
         if (response.isSuccess) {
           setRooms(response.data.roomList);

--- a/src/components/group/RecruitingGroupBox.tsx
+++ b/src/components/group/RecruitingGroupBox.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 import type { Group } from './MyGroupBox';
 import { GroupCard } from './GroupCard';
+import { colors, typography } from '@/styles/global/global';
 
 interface Props {
   groups: Group[];
@@ -26,9 +27,14 @@ export function RecruitingGroupBox({ groups, title }: Props) {
         ))}
       </TabContainer>
       <Grid>
-        {filtered.map(group => (
-          <GroupCard key={group.id} group={group} type={'main'} />
-        ))}
+        {filtered.length > 0 ? (
+          filtered.map(group => <GroupCard key={group.id} group={group} type={'main'} />)
+        ) : (
+          <EmptyContent>
+            <EmptyMainText>모임방이 아직 없어요.</EmptyMainText>
+            <EmptySubText>해당 장르의 모임방이 생기면 보여줄게요!</EmptySubText>
+          </EmptyContent>
+        )}
       </Grid>
     </Container>
   );
@@ -94,4 +100,30 @@ const Grid = styled.div`
   @media (min-width: 584px) {
     grid-template-columns: 1fr 1fr;
   }
+`;
+
+const EmptyContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 60px 20px;
+  grid-column: 1 / -1;
+`;
+
+const EmptyMainText = styled.p`
+  color: ${colors.white};
+  font-size: ${typography.fontSize.lg};
+  font-weight: ${typography.fontWeight.semibold};
+  text-align: center;
+  margin: 0;
+`;
+
+const EmptySubText = styled.p`
+  color: ${colors.grey[100]};
+  font-size: ${typography.fontSize.sm};
+  font-weight: ${typography.fontWeight.regular};
+  text-align: center;
+  margin: 0;
 `;

--- a/src/components/group/RecruitingGroupBox.tsx
+++ b/src/components/group/RecruitingGroupBox.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import type { Group } from './MyGroupBox';
 import { GroupCard } from './GroupCard';
 import { colors, typography } from '@/styles/global/global';
+import { useNavigate } from 'react-router-dom';
+import { getRoomDetail } from '@/api/rooms/getRoomDetail';
 
 interface Props {
   groups: Group[];
@@ -13,8 +15,24 @@ const GENRE = ['문학', '과학·IT', '사회과학', '인문학', '예술'];
 
 export function RecruitingGroupBox({ groups, title }: Props) {
   const [selected, setSelected] = useState<string>('문학');
+  const navigate = useNavigate();
 
   const filtered = useMemo(() => groups.filter(g => g.genre === selected), [groups, selected]);
+
+  const handleGroupCardClick = async (groupId: number | string) => {
+    try {
+      const roomId = typeof groupId === 'string' ? parseInt(groupId) : groupId;
+
+      const response = await getRoomDetail(roomId);
+
+      if (response.isSuccess) {
+        navigate(`/group/detail/${roomId}`);
+      }
+    } catch (error) {
+      console.error('방 상세 정보 조회 오류:', error);
+      navigate(`/group/${groupId}`);
+    }
+  };
 
   return (
     <Container>
@@ -28,7 +46,14 @@ export function RecruitingGroupBox({ groups, title }: Props) {
       </TabContainer>
       <Grid>
         {filtered.length > 0 ? (
-          filtered.map(group => <GroupCard key={group.id} group={group} type={'main'} />)
+          filtered.map(group => (
+            <GroupCard
+              key={group.id}
+              group={group}
+              type={'main'}
+              onClick={() => handleGroupCardClick(group.id)}
+            />
+          ))
         ) : (
           <EmptyContent>
             <EmptyMainText>모임방이 아직 없어요.</EmptyMainText>

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -137,9 +137,8 @@ const CreateGroup = () => {
 
       if (isSuccessful) {
         // 성공 시 모집 중인 방 상세 페이지로 이동
-        navigate('/group/detail', {
+        navigate(`/group/detail/${response.data.roomId}`, {
           replace: true,
-          state: { roomId: response.data.roomId },
         });
       } else {
         alert(`방 생성에 실패했습니다: ${response.message} (코드: ${response.code})`);

--- a/src/pages/group/Group.tsx
+++ b/src/pages/group/Group.tsx
@@ -6,11 +6,12 @@ import { MyGroupBox } from '../../components/group/MyGroupBox';
 import Blank from '@/components/common/Blank';
 import styled from '@emotion/styled';
 import { RecruitingGroupCarousel, type Section } from '@/components/group/RecruitingGroupCarousel';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { MyGroupModal } from '@/components/group/MyGroupModal';
 import CompletedGroupModal from '@/components/group/CompletedGroupModal';
 import { useNavigate } from 'react-router-dom';
 import makegroupfab from '../../assets/common/makegroupfab.svg';
+import { getRoomsByCategory, type RoomItem } from '@/api/rooms/getRoomsByCategory';
 
 const dummyMyGroups: GroupType[] = [
   {
@@ -42,85 +43,70 @@ const dummyMyGroups: GroupType[] = [
   },
 ];
 
-const dummyRecruitingGroups: GroupType[] = [
-  {
-    id: '1',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 1,
-    genre: '문학',
-  },
-  {
-    id: '2',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 2,
-    genre: '문학',
-  },
-  {
-    id: '3',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 3,
-    genre: '문학',
-  },
-  {
-    id: '4',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 4,
-    genre: '문학',
-  },
-  {
-    id: '5',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 4,
-    genre: '과학·IT',
-  },
-  {
-    id: '6',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    maximumParticipants: 30,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-    deadLine: 4,
-    genre: '과학·IT',
-  },
-];
-
-const sections: Section[] = [
-  { title: '마감 임박한 독서 모임방', groups: dummyRecruitingGroups },
-  { title: '인기 있는 독서 모임방', groups: dummyRecruitingGroups },
-  { title: '인플루언서·작가 독서 모임방', groups: dummyRecruitingGroups },
-];
+const convertRoomItemToGroup = (
+  room: RoomItem,
+  category: string,
+  listType: 'deadline' | 'popular',
+): GroupType => ({
+  id: `${room.roomId}-${category}-${listType}`,
+  title: room.roomName,
+  participants: room.memberCount,
+  maximumParticipants: room.recruitCount,
+  coverUrl: room.bookImageUrl,
+  deadLine: Math.ceil(
+    (new Date(room.deadlineDate).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24),
+  ),
+  genre: category,
+});
 
 const Group = () => {
   const navigate = useNavigate();
   const [isMyGroupModalOpen, setIsMyGroupModalOpen] = useState(false);
   const [isCompletedGroupModalOpen, setIsCompletedGroupModalOpen] = useState(false);
+  const [sections, setSections] = useState<Section[]>([
+    { title: '마감 임박한 독서 모임방', groups: [] },
+    { title: '인기 있는 독서 모임방', groups: [] },
+    { title: '인플루언서·작가 독서 모임방', groups: [] },
+  ]);
+
+  const fetchAllRoomsData = async () => {
+    try {
+      const categories = ['문학', '인문학', '사회과학', '과학·IT', '예술'];
+      const deadlineRoomsData: GroupType[] = [];
+      const popularRoomsData: GroupType[] = [];
+
+      for (const category of categories) {
+        const response = await getRoomsByCategory(category);
+        if (response.isSuccess) {
+          const deadlineGroups = response.data.deadlineRoomList.map(room =>
+            convertRoomItemToGroup(room, category, 'deadline'),
+          );
+          const popularGroups = response.data.popularRoomList.map(room =>
+            convertRoomItemToGroup(room, category, 'popular'),
+          );
+          deadlineRoomsData.push(...deadlineGroups);
+          popularRoomsData.push(...popularGroups);
+        }
+      }
+
+      setSections([
+        { title: '마감 임박한 독서 모임방', groups: deadlineRoomsData },
+        { title: '인기 있는 독서 모임방', groups: popularRoomsData },
+        { title: '인플루언서·작가 독서 모임방', groups: [] },
+      ]);
+    } catch (error) {
+      console.error('방 목록 조회 오류:', error);
+      setSections([
+        { title: '마감 임박한 독서 모임방', groups: [] },
+        { title: '인기 있는 독서 모임방', groups: [] },
+        { title: '인플루언서·작가 독서 모임방', groups: [] },
+      ]);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllRoomsData();
+  }, []);
 
   const openMyGroupModal = () => setIsMyGroupModalOpen(true);
   const closeMyGroupModal = () => setIsMyGroupModalOpen(false);
@@ -131,6 +117,7 @@ const Group = () => {
   const handleSearchBarClick = () => {
     navigate('/group/search');
   };
+
   return (
     <Wrapper>
       {isMyGroupModalOpen && <MyGroupModal onClose={closeMyGroupModal} />}

--- a/src/pages/group/Group.tsx
+++ b/src/pages/group/Group.tsx
@@ -13,36 +13,6 @@ import { useNavigate } from 'react-router-dom';
 import makegroupfab from '../../assets/common/makegroupfab.svg';
 import { getRoomsByCategory, type RoomItem } from '@/api/rooms/getRoomsByCategory';
 
-const dummyMyGroups: GroupType[] = [
-  {
-    id: '1',
-    title: '호르몬 체인지 완독하는 방',
-    participants: 22,
-    userName: 'hoho',
-    progress: 40,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-  },
-  {
-    id: '2',
-    title: '시집만 읽는 사람들 3월',
-    userName: 'hoho2',
-    participants: 15,
-    progress: 0,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-  },
-  {
-    id: '3',
-    title: '일본 소설 좋아하는 사람들',
-    userName: 'hoho3',
-    participants: 30,
-    progress: 100,
-    coverUrl:
-      'https://marketplace.canva.com/EAF9zlwqylI/1/0/1003w/canva-%EB%B2%A0%EC%9D%B4%EC%A7%80-%EC%A3%BC%ED%99%A9-%EA%B7%80%EC%97%BD%EA%B3%A0-%EB%AF%B8%EB%8B%88%EB%A9%80%ED%95%9C-%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8-e%EB%B6%81-%EC%9C%84%EB%A1%9C-%EC%A2%8B%EC%9D%80%EA%B8%80-%EC%B1%85%ED%91%9C%EC%A7%80-zrZ6hI8_IWo.jpg',
-  },
-];
-
 const convertRoomItemToGroup = (
   room: RoomItem,
   category: string,
@@ -124,7 +94,7 @@ const Group = () => {
       {isCompletedGroupModalOpen && <CompletedGroupModal onClose={closeCompletedGroupModal} />}
       <MainHeader type="group" leftButtonClick={openCompletedGroupModal} />
       <SearchBar placeholder="모임방 참여할 사람!" onClick={handleSearchBarClick} />
-      <MyGroupBox groups={dummyMyGroups} onMyGroupsClick={openMyGroupModal}></MyGroupBox>
+      <MyGroupBox onMyGroupsClick={openMyGroupModal}></MyGroupBox>
       <Blank height={'10px'} margin={'32px 0'}></Blank>
       <RecruitingGroupCarousel sections={sections} />
       <NavBar src={makegroupfab} path="/group/create" />

--- a/src/pages/group/Group.tsx
+++ b/src/pages/group/Group.tsx
@@ -129,7 +129,7 @@ const Group = () => {
   const closeCompletedGroupModal = () => setIsCompletedGroupModalOpen(false);
 
   const handleSearchBarClick = () => {
-    navigate('/groupsearch');
+    navigate('/group/search');
   };
   return (
     <Wrapper>

--- a/src/pages/groupDetail/GroupDetail.styled.ts
+++ b/src/pages/groupDetail/GroupDetail.styled.ts
@@ -176,13 +176,14 @@ export const BookDetails = styled.div`
   font-weight: ${typography.fontWeight.medium};
   gap: 20px;
   color: ${colors.white};
-  margin: auto 0;
+  margin-top: 8px;
 `;
 
 export const BookIntro = styled.div`
   > p {
     margin-top: 4px;
     color: ${colors.grey[200]};
+    font-size: ${typography.fontSize['2xs']};
   }
 `;
 

--- a/src/pages/groupDetail/GroupDetail.tsx
+++ b/src/pages/groupDetail/GroupDetail.tsx
@@ -76,9 +76,10 @@ const GroupDetail = () => {
     const diffTime = endDate.getTime() - today.getTime();
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
+    console.log(endDate);
     if (diffDays < 0) return '모집 종료';
-    if (diffDays === 0) return 'D-DAY';
-    return `D-${diffDays}`;
+    if (diffDays === 0) return '오늘 마감';
+    return `${diffDays}일 남음`;
   };
 
   useEffect(() => {

--- a/src/pages/groupDetail/GroupDetail.tsx
+++ b/src/pages/groupDetail/GroupDetail.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import {
   Wrapper,
   TopBackground,
@@ -27,29 +28,27 @@ import {
 } from './GroupDetail.styled';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import moreIcon from '../../assets/common/more.svg';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { IconButton } from '@/components/common/IconButton';
-import { mockGroupDetail } from '../../mocks/groupDetail.mock';
 import lockIcon from '../../assets/group/lock.svg';
 import calendarIcon from '../../assets/group/calendar.svg';
 import peopleIcon from '../../assets/common/darkPeople.svg';
 import rightChevron from '../../assets/common/right-Chevron.svg';
 import { GroupCard } from '@/components/group/GroupCard';
+import {
+  getRoomDetail,
+  type RoomDetailResponse,
+  type RecommendRoom,
+} from '@/api/rooms/getRoomDetail';
+import type { Group } from '@/components/group/MyGroupBox';
 
 const GroupDetail = () => {
-  const {
-    title,
-    isPrivate,
-    introduction,
-    activityPeriod,
-    members,
-    ddayText,
-    genre,
-    book,
-    recommendations,
-  } = mockGroupDetail;
-
+  const { roomId } = useParams<{ roomId: string }>();
   const navigate = useNavigate();
+
+  const [roomData, setRoomData] = useState<RoomDetailResponse['data'] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleBackButton = () => {
     navigate(-1);
@@ -57,21 +56,98 @@ const GroupDetail = () => {
 
   const handleMoreButton = () => {};
 
+  const convertRecommendRoomToGroup = (room: RecommendRoom): Group => {
+    return {
+      id: room.roomId.toString(),
+      title: room.roomName,
+      userName: '',
+      participants: room.memberCount,
+      maximumParticipants: room.recruitCount,
+      coverUrl: room.roomImageUrl,
+      deadLine: 0,
+      genre: '',
+      isOnGoing: true,
+    };
+  };
+
+  const calculateDday = (recruitEndDate: string): string => {
+    const today = new Date();
+    const endDate = new Date(recruitEndDate);
+    const diffTime = endDate.getTime() - today.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+    if (diffDays < 0) return '모집 종료';
+    if (diffDays === 0) return 'D-DAY';
+    return `D-${diffDays}`;
+  };
+
+  useEffect(() => {
+    const fetchRoomDetail = async () => {
+      if (!roomId) return;
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await getRoomDetail(Number(roomId));
+        console.log(response);
+
+        if (response.isSuccess) {
+          setRoomData(response.data);
+        } else {
+          setError(response.message);
+        }
+      } catch (error) {
+        console.error('방 상세 정보 조회 실패:', error);
+        setError('방 정보를 불러오는데 실패했습니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRoomDetail();
+  }, [roomId]);
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (error || !roomData) {
+    return <div>에러: {error}</div>;
+  }
+
+  const {
+    roomName,
+    isPublic,
+    roomDescription,
+    progressStartDate,
+    progressEndDate,
+    memberCount,
+    recruitCount,
+    recruitEndDate,
+    category,
+    bookTitle,
+    authorName,
+    bookDescription,
+    bookImageUrl,
+    recommendRooms,
+  } = roomData;
+
   return (
     <Wrapper>
-      <TopBackground genre={genre}>
+      <TopBackground genre={category}>
         <Header>
           <IconButton src={leftArrow} onClick={handleBackButton} />
           <IconButton src={moreIcon} onClick={handleMoreButton} />
         </Header>
         <BannerSection>
           <GroupTitle>
-            {title} {isPrivate && <img src={lockIcon} alt="자물쇠 아이콘"></img>}
+            {roomName} {!isPublic && <img src={lockIcon} alt="자물쇠 아이콘"></img>}
           </GroupTitle>
           <SubTitle>
             <div>소개글</div>
             <br />
-            <Intro>{introduction}</Intro>
+            <Intro>{roomDescription}</Intro>
           </SubTitle>
           <MetaInfo>
             <Meta>
@@ -79,7 +155,7 @@ const GroupDetail = () => {
                 <IconButton src={calendarIcon} alt="달력 아이콘" /> 모임 활동기간
               </span>
               <MetaDate>
-                {activityPeriod.start} ~ {activityPeriod.end}
+                {progressStartDate} ~ {progressEndDate}
               </MetaDate>
             </Meta>
             <Meta>
@@ -87,33 +163,33 @@ const GroupDetail = () => {
                 <IconButton src={peopleIcon} alt="사람 아이콘" /> 참여 중인 독서메이트
               </span>
               <span>
-                <MetaMember>{members.current}</MetaMember>
-                <MetaTotalMember>/ {members.max}명</MetaTotalMember>
+                <MetaMember>{memberCount}</MetaMember>
+                <MetaTotalMember>/ {recruitCount}명</MetaTotalMember>
               </span>
             </Meta>
           </MetaInfo>
           <TagRow>
             <Tag>
-              모집 <strong>{ddayText}</strong>
+              모집 <strong>{calculateDday(recruitEndDate)}</strong>
             </Tag>
             <Tag>
-              장르 <TagGenre>{genre}</TagGenre>
+              장르 <TagGenre>{category}</TagGenre>
             </Tag>
           </TagRow>
         </BannerSection>
       </TopBackground>
       <BookSection>
         <BookHeader>
-          <h3>{book.title}</h3>
+          <h3>{bookTitle}</h3>
           <IconButton src={rightChevron} alt="책 이동 버튼"></IconButton>
         </BookHeader>
         <BookInfo>
-          <BookCover src={book.coverUrl} alt={book.title} />
+          <BookCover src={bookImageUrl} alt={bookTitle} />
           <BookDetails>
-            <div>{book.author}</div>
+            <div>{authorName}</div>
             <BookIntro>
               도서 소개 <br />
-              <p>{book.description}</p>
+              <p>{bookDescription}</p>
             </BookIntro>
           </BookDetails>
         </BookInfo>
@@ -121,10 +197,10 @@ const GroupDetail = () => {
       <RecommendSection>
         <RecommendText>이런 모임방은 어때요?</RecommendText>
         <GroupCardBox>
-          {recommendations.map(group => (
+          {recommendRooms.map(room => (
             <GroupCard
-              key={group.id}
-              group={group}
+              key={room.roomId}
+              group={convertRecommendRoomToGroup(room)}
               isOngoing={true}
               isRecommend={true}
               type={'modal'}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -52,7 +52,7 @@ const Router = () => {
         <Route path="group/create" element={<CreateGroup />} />
         <Route path="post/update/:feedId" element={<UpdatePost />} />
         <Route path="group/search" element={<GroupSearch />} />
-        <Route path="group/detail" element={<GroupDetail />} />
+        <Route path="group/detail/:roomId" element={<GroupDetail />} />
         <Route path="group/detail/joined" element={<ParticipatedGroupDetail />} />
         <Route path="group/members" element={<GroupMembers />} />
         <Route path="memory" element={<Memory />} />


### PR DESCRIPTION
## #️⃣연관된 이슈

[API] Rooms API 연동 #106

## 📝작업 내용

- 내 모임방 리스트 조회

- 모집중인 방 상세보기

- 참여하기/취소하기

- 장르별 마감 임박한/인기 있는 독서 모임방

- 모집 마감하기

- 참여중인 내 모임방 조회

> 서버 개발이 아직 안된 아래 API를 제외하고 Rooms 도메인에 대한 API 연동 완료했습니다!

- 방 삭제 (서버 미개발)

- 방 검색 (서버 미개발)

## 💬리뷰 요구사항(선택)

snackbar는 API 연동 후 일괄 적용하도록 하겠습니다!

우선 전체적인 API 연동이 끝난 후 QA 진행하며 플로우들을 이어주는 작업을 진행이 필요할 것 같습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 그룹/상세/모달 화면이 실제 API 데이터로 동작하며 마감/인기/참여/완료 모임을 실시간으로 표시합니다.
  - 그룹 카드 클릭 시 상세 화면으로 이동합니다.
  - 상세 화면에 추천 모임과 모집 D-day 표시가 추가되었습니다.
- 변경
  - 그룹 상세 경로가 /group/detail/:roomId 로 변경되었습니다.
  - 그룹 생성 완료 시 /group/detail/:roomId 로 이동합니다.
  - 그룹 검색 경로가 /group/search 로 변경되었습니다.
- UI/UX
  - 로딩/에러/빈 상태를 추가하여 피드백을 강화했습니다.
  - 카드 크기와 타이포그래피 등 스타일을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->