### PR TITLE
feat: 기록 삭제 API 연동 및 더보기 메뉴 기능 추가

### DIFF
--- a/src/api/record/deleteRecord.ts
+++ b/src/api/record/deleteRecord.ts
@@ -1,0 +1,43 @@
+import { apiClient } from '../index';
+import type { ApiResponse } from '@/types/record';
+
+// 기록 삭제 응답 데이터 타입
+export interface DeleteRecordData {
+  roomId: number; // 삭제된 기록이 속한 방 ID
+}
+
+// API 응답 타입
+export type DeleteRecordResponse = ApiResponse<DeleteRecordData>;
+
+// 기록 삭제 API 함수
+export const deleteRecord = async (
+  roomId: number,
+  recordId: number,
+): Promise<DeleteRecordResponse> => {
+  try {
+    const response = await apiClient.delete<DeleteRecordResponse>(
+      `/rooms/${roomId}/record/${recordId}`,
+    );
+    return response.data;
+  } catch (error) {
+    console.error('기록 삭제 API 오류:', error);
+    throw error;
+  }
+};
+
+/*
+사용 예시:
+try {
+  const result = await deleteRecord(1, 123);
+  if (result.isSuccess) {
+    console.log("기록 삭제 성공:", result.data.roomId);
+    // 성공 처리 로직 (예: 목록에서 제거, 성공 메시지 표시)
+  } else {
+    console.error("기록 삭제 실패:", result.message);
+    // 실패 처리 로직
+  }
+} catch (error) {
+  console.error("API 호출 오류:", error);
+  // 에러 처리 로직
+}
+*/

--- a/src/api/record/deleteVote.ts
+++ b/src/api/record/deleteVote.ts
@@ -1,0 +1,38 @@
+import { apiClient } from '../index';
+import type { ApiResponse } from '@/types/record';
+
+// 투표 삭제 응답 데이터 타입
+export interface DeleteVoteData {
+  roomId: number; // 삭제된 투표가 속한 방 ID
+}
+
+// API 응답 타입
+export type DeleteVoteResponse = ApiResponse<DeleteVoteData>;
+
+// 투표 삭제 API 함수
+export const deleteVote = async (roomId: number, voteId: number): Promise<DeleteVoteResponse> => {
+  try {
+    const response = await apiClient.delete<DeleteVoteResponse>(`/rooms/${roomId}/vote/${voteId}`);
+    return response.data;
+  } catch (error) {
+    console.error('투표 삭제 API 오류:', error);
+    throw error;
+  }
+};
+
+/*
+사용 예시:
+try {
+  const result = await deleteVote(1, 456);
+  if (result.isSuccess) {
+    console.log("투표 삭제 성공:", result.data.roomId);
+    // 성공 처리 로직 (예: 목록에서 제거, 성공 메시지 표시)
+  } else {
+    console.error("투표 삭제 실패:", result.message);
+    // 실패 처리 로직
+  }
+} catch (error) {
+  console.error("API 호출 오류:", error);
+  // 에러 처리 로직
+}
+*/

--- a/src/components/memory/RecordItem/RecordItem.tsx
+++ b/src/components/memory/RecordItem/RecordItem.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useRef, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import type { Record } from '../../../pages/memory/Memory';
 import TextRecord from './TextRecord';
 import PollRecord from './PollRecord';
@@ -17,6 +18,9 @@ import {
   ActionSection,
   ActionButton,
 } from './RecordItem.styled';
+import { usePopupActions } from '@/hooks/usePopupActions';
+import { deleteRecord } from '@/api/record/deleteRecord';
+import { deleteVote } from '@/api/record/deleteVote';
 
 interface RecordItemProps {
   record: Record;
@@ -24,6 +28,10 @@ interface RecordItemProps {
 }
 
 const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
+  const navigate = useNavigate();
+  const { roomId } = useParams<{ roomId: string }>();
+  const { openMoreMenu, openConfirm, openSnackbar } = usePopupActions();
+
   const {
     user,
     content,
@@ -34,11 +42,21 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
     pollOptions,
     pageRange,
     recordType,
+    isWriter,
   } = record;
 
   // 좋아요 상태 관리
   const [isLiked, setIsLiked] = useState(false);
   const [currentLikeCount, setCurrentLikeCount] = useState(likeCount);
+
+  // 길게 누르기 상태 관리
+  const [isPressed, setIsPressed] = useState(false);
+  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+  const pressStartPos = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const hasTriggeredLongPress = useRef(false);
+
+  // API에서 받은 isWriter 속성으로 내 기록인지 판단
+  const isMyRecord = isWriter ?? false;
 
   const handleLikeClick = () => {
     if (isLiked) {
@@ -62,8 +80,152 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
     return '0p'; // 기본값
   };
 
+  const handleEdit = useCallback(() => {
+    const currentRoomId = roomId || '1';
+
+    if (type === 'poll') {
+      navigate(`/memory/poll/edit/${currentRoomId}/${record.id}`);
+    } else {
+      navigate(`/memory/record/edit/${currentRoomId}/${record.id}`);
+    }
+  }, [roomId, type, record.id, navigate]);
+
+  const handleDeleteConfirm = useCallback(() => {
+    const recordTypeName = type === 'poll' ? '투표' : '기록';
+
+    openConfirm({
+      title: `${recordTypeName}을 삭제하시겠어요?`,
+      disc: `삭제된 ${recordTypeName}은 복구할 수 없습니다.`,
+      onConfirm: () => handleDelete(),
+    });
+  }, [type, openConfirm]);
+
+  const handleDelete = useCallback(async () => {
+    const currentRoomId = roomId || '1';
+    const recordId = parseInt(record.id);
+
+    try {
+      let response;
+
+      if (type === 'poll') {
+        response = await deleteVote(parseInt(currentRoomId), recordId);
+      } else {
+        response = await deleteRecord(parseInt(currentRoomId), recordId);
+      }
+
+      if (response.isSuccess) {
+        const recordTypeName = type === 'poll' ? '투표' : '기록';
+        openSnackbar({
+          message: `${recordTypeName}가 삭제되었습니다.`,
+          variant: 'top',
+          onClose: () => {},
+        });
+
+        // TODO: 목록에서 해당 기록 제거 (부모 컴포넌트 업데이트 필요)
+        // 현재는 페이지 새로고침으로 임시 처리
+        window.location.reload();
+      } else {
+        openSnackbar({
+          message: '삭제에 실패했습니다. 다시 시도해주세요.',
+          variant: 'top',
+          onClose: () => {},
+        });
+      }
+    } catch (error) {
+      console.error('삭제 중 오류 발생:', error);
+      openSnackbar({
+        message: '삭제 중 오류가 발생했습니다.',
+        variant: 'top',
+        onClose: () => {},
+      });
+    }
+  }, [roomId, record.id, type, openSnackbar]);
+
+  const handleReport = useCallback(() => {
+    openSnackbar({
+      message: '신고가 접수되었습니다.',
+      variant: 'top',
+      onClose: () => {},
+    });
+  }, [openSnackbar]);
+
+  const handleLongPress = useCallback(() => {
+    if (isMyRecord) {
+      // 내 기록: 수정하기, 삭제하기 (기존 MoreMenuProps 타입에 맞게 수정)
+      openMoreMenu({
+        onEdit: handleEdit,
+        onDelete: handleDeleteConfirm,
+        onClose: () => {},
+      });
+    } else {
+      // 다른 사람 기록: 신고하기만 표시하는 경우
+      // 현재 MoreMenuProps 타입에는 신고 옵션이 없으므로 스낵바로 처리
+      handleReport();
+    }
+  }, [isMyRecord, openMoreMenu, handleEdit, handleDeleteConfirm, handleReport]);
+
+  const handleLongPressStart = useCallback(
+    (e: React.MouseEvent | React.TouchEvent) => {
+      e.preventDefault();
+
+      const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+      const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+
+      pressStartPos.current = { x: clientX, y: clientY };
+      hasTriggeredLongPress.current = false;
+      setIsPressed(true);
+
+      longPressTimer.current = setTimeout(() => {
+        if (!hasTriggeredLongPress.current) {
+          hasTriggeredLongPress.current = true;
+          handleLongPress();
+        }
+      }, 500); // 500ms 길게 누르기
+    },
+    [handleLongPress],
+  );
+
+  const handleLongPressEnd = useCallback(() => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+    setIsPressed(false);
+  }, []);
+
+  const handleLongPressMove = useCallback(
+    (e: React.MouseEvent | React.TouchEvent) => {
+      if (!longPressTimer.current) return;
+
+      const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+      const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+
+      const deltaX = Math.abs(clientX - pressStartPos.current.x);
+      const deltaY = Math.abs(clientY - pressStartPos.current.y);
+
+      // 10px 이상 움직이면 길게 누르기 취소
+      if (deltaX > 10 || deltaY > 10) {
+        handleLongPressEnd();
+      }
+    },
+    [handleLongPressEnd],
+  );
+
   return (
-    <Container shouldBlur={shouldBlur}>
+    <Container
+      shouldBlur={shouldBlur}
+      onMouseDown={handleLongPressStart}
+      onMouseUp={handleLongPressEnd}
+      onMouseLeave={handleLongPressEnd}
+      onMouseMove={handleLongPressMove}
+      onTouchStart={handleLongPressStart}
+      onTouchEnd={handleLongPressEnd}
+      onTouchMove={handleLongPressMove}
+      style={{
+        transform: isPressed ? 'scale(0.98)' : 'scale(1)',
+        transition: 'transform 0.1s ease',
+      }}
+    >
       <UserSection>
         <UserAvatar />
         <UserInfo>

--- a/src/components/memory/RecordItem/RecordItem.tsx
+++ b/src/components/memory/RecordItem/RecordItem.tsx
@@ -30,7 +30,7 @@ interface RecordItemProps {
 const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
   const navigate = useNavigate();
   const { roomId } = useParams<{ roomId: string }>();
-  const { openMoreMenu, openConfirm, openSnackbar } = usePopupActions();
+  const { openMoreMenu, openConfirm, openSnackbar, closePopup } = usePopupActions();
 
   const {
     user,
@@ -155,13 +155,13 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
       openMoreMenu({
         onEdit: handleEdit,
         onDelete: handleDeleteConfirm,
-        onClose: () => {},
+        onClose: closePopup,
       });
     } else {
       // 다른 사람 기록: 신고하기
       handleReport();
     }
-  }, [isMyRecord, openMoreMenu, handleEdit, handleDeleteConfirm, handleReport]);
+  }, [isMyRecord, openMoreMenu, handleEdit, handleDeleteConfirm, handleReport, closePopup]);
 
   const handleLongPressStart = useCallback(
     (e: React.MouseEvent | React.TouchEvent) => {

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -25,6 +25,7 @@ export interface Record {
   recordType?: 'page' | 'overall';
   pollOptions?: PollOption[];
   pageRange?: string;
+  isWriter?: boolean;
 }
 
 export interface PollOption {
@@ -48,6 +49,7 @@ const convertPostToRecord = (post: Post): Record => {
     type: post.postType === 'VOTE' ? 'poll' : 'text',
     recordType: post.isOverview ? 'overall' : 'page',
     pageRange: post.isOverview ? undefined : post.page.toString(),
+    isWriter: post.isWriter,
     pollOptions: post.voteItems.map((item, index) => ({
       id: item.voteItemId.toString(),
       text: item.itemName,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#106 

## 📝 작업 내용

기록장(Memory) 화면의 개별 기록 아이템에 길게 누르기를 통한 더보기 메뉴 기능과 기록/투표 삭제 API 연동을 구현했습니다.

## 🕸️ 주요 구현 사항
**1. 기록 및 투표 삭제 API 함수 구현**
- `deleteRecord.ts`: 기록 삭제 API (DELETE /rooms/{roomId}/record/{recordId})
- `deleteVote.ts`: 투표 삭제 API (DELETE /rooms/{roomId}/vote/{voteId})

**2. RecordItem 컴포넌트에 길게 누르기 기능 추가**
- **500ms 길게 누르기 감지:** 마우스와 터치 이벤트 모두 지원
- **움직임 감지:** 10px 이상 드래그 시 길게 누르기 자동 취소
- **시각적 피드백:** 누르는 동안 0.98 스케일 애니메이션 효과

**3. 권한 기반 더보기 메뉴 분기 처리**
- **내 기록 (isWriter: true):** 수정하기, 삭제하기 바텀시트 표시
- **다른 사람 기록 (isWriter: false):** 신고하기 스낵바 즉시 표시

**4. 안전한 삭제 프로세스 구현**
- **확인 다이얼로그:** "기록/투표을 삭제하시겠어요?" 재확인 단계
- **API 연동:** 기록 타입에 따라 deleteRecord 또는 deleteVote 함수 호출
- **임시 새로고침:** 현재는 삭제 후 window.location.reload()로 목록 갱신 (추후 상태 관리로 개선 예정)

**5. UX 최적화**
- **빈 영역 클릭:** 더보기 메뉴 열린 상태에서 오버레이 클릭 시 메뉴 자동 닫기
- **크로스 플랫폼 지원:** 데스크톱 마우스, 터치패드, 모바일 터치 모든 환경에서 정상 동작
- **성능 최적화:** `useCallback`을 활용한 불필요한 리렌더링 방지

## 💬 리뷰 요구사항
- **접근성:** 길게 누르기 기능이 접근성 측면에서 문제가 없는지, 키보드 사용자를 위한 대안이 필요한지 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 기록 아이템 길게 누르기 제스처 지원(마우스/터치).
  - 내 기록: 더보기 메뉴에서 수정 진입 및 삭제 가능.
  - 다른 사람 기록: 신고 기능 제공.
  - 삭제 전 확인 다이얼로그, 성공/실패 스낵바 표시.
  - 투표/일반 기록 모두 삭제 지원, 삭제 후 목록 자동 새로고침.
  - 길게 누르는 동안 눌림 애니메이션 적용, 드래그 시 길게 누르기 취소로 오동작 방지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->