### PR TITLE
feat: 진행중인 방 상세보기 및 독서메이트 조회 API 연동 구현

### DIFF
--- a/src/api/rooms/getRoomMembers.ts
+++ b/src/api/rooms/getRoomMembers.ts
@@ -1,6 +1,5 @@
 import { apiClient } from '../index';
 
-// 독서메이트 정보 타입
 export interface RoomMember {
   userId: number;
   nickname: string;
@@ -28,15 +27,28 @@ export interface Member {
   profileImageUrl?: string;
 }
 
-// API 데이터를 Member 형태로 변환하는 함수
 export const convertRoomMembersToMembers = (roomMembers: RoomMember[]): Member[] => {
-  return roomMembers.map(member => ({
-    id: member.userId.toString(),
-    nickname: member.nickname,
-    role: member.alias, // alias를 role로 사용
-    followersCount: member.subscriberCount,
-    profileImageUrl: member.imageUrl,
-  }));
+  const convertedMembers = roomMembers.map(member => {
+    const memberData = member as any;
+
+    // 다양한 가능한 필드명들을 체크
+    const alias = memberData.alias || memberData.aliasName || memberData.role || '독서메이트';
+    const followerCount =
+      memberData.subscriberCount || memberData.followerCount || memberData.followersCount || 0;
+    const imageUrl = memberData.imageUrl || memberData.profileImageUrl || memberData.image;
+
+    const convertedMember = {
+      id: member.userId.toString(),
+      nickname: member.nickname,
+      role: alias,
+      followersCount: followerCount,
+      profileImageUrl: imageUrl,
+    };
+
+    return convertedMember;
+  });
+
+  return convertedMembers;
 };
 
 export const getRoomMembers = async (roomId: number): Promise<RoomMembersResponse> => {

--- a/src/api/rooms/getRoomMembers.ts
+++ b/src/api/rooms/getRoomMembers.ts
@@ -5,7 +5,7 @@ export interface RoomMember {
   nickname: string;
   imageUrl: string;
   alias: string;
-  subscriberCount: number;
+  followerCount: number;
 }
 
 // 독서메이트 조회 응답 타입
@@ -29,20 +29,12 @@ export interface Member {
 
 export const convertRoomMembersToMembers = (roomMembers: RoomMember[]): Member[] => {
   const convertedMembers = roomMembers.map(member => {
-    const memberData = member as any;
-
-    // 다양한 가능한 필드명들을 체크
-    const alias = memberData.alias || memberData.aliasName || memberData.role || '독서메이트';
-    const followerCount =
-      memberData.subscriberCount || memberData.followerCount || memberData.followersCount || 0;
-    const imageUrl = memberData.imageUrl || memberData.profileImageUrl || memberData.image;
-
-    const convertedMember = {
+    const convertedMember: Member = {
       id: member.userId.toString(),
-      nickname: member.nickname,
-      role: alias,
-      followersCount: followerCount,
-      profileImageUrl: imageUrl,
+      nickname: member.nickname || '익명',
+      role: member.alias || '독서메이트',
+      followersCount: member.followerCount || 0,
+      profileImageUrl: member.imageUrl || undefined,
     };
 
     return convertedMember;

--- a/src/api/rooms/getRoomMembers.ts
+++ b/src/api/rooms/getRoomMembers.ts
@@ -1,0 +1,50 @@
+import { apiClient } from '../index';
+
+// 독서메이트 정보 타입
+export interface RoomMember {
+  userId: number;
+  nickname: string;
+  imageUrl: string;
+  alias: string;
+  subscriberCount: number;
+}
+
+// 독서메이트 조회 응답 타입
+export interface RoomMembersResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: {
+    userList: RoomMember[];
+  };
+}
+
+// 기존 Member 타입과 연결하기 위한 변환 함수
+export interface Member {
+  id: string;
+  nickname: string;
+  role: string;
+  followersCount?: number;
+  profileImageUrl?: string;
+}
+
+// API 데이터를 Member 형태로 변환하는 함수
+export const convertRoomMembersToMembers = (roomMembers: RoomMember[]): Member[] => {
+  return roomMembers.map(member => ({
+    id: member.userId.toString(),
+    nickname: member.nickname,
+    role: member.alias, // alias를 role로 사용
+    followersCount: member.subscriberCount,
+    profileImageUrl: member.imageUrl,
+  }));
+};
+
+export const getRoomMembers = async (roomId: number): Promise<RoomMembersResponse> => {
+  try {
+    const response = await apiClient.get<RoomMembersResponse>(`/rooms/${roomId}/users`);
+    return response.data;
+  } catch (error) {
+    console.error('독서메이트 조회 API 오류:', error);
+    throw error;
+  }
+};

--- a/src/api/rooms/getRoomMembers.ts
+++ b/src/api/rooms/getRoomMembers.ts
@@ -4,7 +4,7 @@ export interface RoomMember {
   userId: number;
   nickname: string;
   imageUrl: string;
-  alias: string;
+  aliasName: string;
   followerCount: number;
 }
 
@@ -32,7 +32,7 @@ export const convertRoomMembersToMembers = (roomMembers: RoomMember[]): Member[]
     const convertedMember: Member = {
       id: member.userId.toString(),
       nickname: member.nickname || '익명',
-      role: member.alias || '독서메이트',
+      role: member.aliasName || '독서메이트',
       followersCount: member.followerCount || 0,
       profileImageUrl: member.imageUrl || undefined,
     };

--- a/src/api/rooms/getRoomPlaying.ts
+++ b/src/api/rooms/getRoomPlaying.ts
@@ -1,0 +1,72 @@
+import { apiClient } from '../index';
+
+// 투표 아이템 타입
+export interface VoteItem {
+  itemName: string;
+}
+
+// 현재 투표 타입
+export interface CurrentVote {
+  content: string;
+  page: number;
+  isOverview: boolean;
+  voteItems: VoteItem[];
+}
+
+// 진행중인 방 상세 정보 응답 타입
+export interface RoomPlayingResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: {
+    isHost: boolean;
+    roomId: number;
+    roomName: string;
+    roomImageUrl: string;
+    isPublic: boolean;
+    progressStartDate: string;
+    progressEndDate: string;
+    category: string;
+    categoryColor: string;
+    roomDescription: string;
+    memberCount: number;
+    recruitCount: number;
+    isbn: string;
+    bookTitle: string;
+    authorName: string;
+    currentPage: number;
+    userPercentage: number;
+    currentVotes: CurrentVote[];
+  };
+}
+
+// HotTopicSection에서 사용할 Poll 타입 (API 데이터를 변환)
+export interface Poll {
+  id: string;
+  question: string;
+  options: { id: string; text: string }[];
+  pageNumber: number;
+}
+
+// API 데이터를 Poll 형태로 변환하는 함수
+export const convertVotesToPolls = (currentVotes: CurrentVote[]): Poll[] => {
+  return currentVotes.map((vote, index) => ({
+    id: index.toString(),
+    question: vote.content,
+    options: vote.voteItems.map((item, itemIndex) => ({
+      id: itemIndex.toString(),
+      text: item.itemName,
+    })),
+    pageNumber: vote.page,
+  }));
+};
+
+export const getRoomPlaying = async (roomId: number): Promise<RoomPlayingResponse> => {
+  try {
+    const response = await apiClient.get<RoomPlayingResponse>(`/rooms/${roomId}/playing`);
+    return response.data;
+  } catch (error) {
+    console.error('진행중인 방 상세 정보 조회 API 오류:', error);
+    throw error;
+  }
+};

--- a/src/components/members/MemberList.styled.ts
+++ b/src/components/members/MemberList.styled.ts
@@ -48,8 +48,8 @@ export const ProfileSection = styled.div`
 `;
 
 export const ProfileImage = styled.div`
-  width: 48px;
-  height: 48px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   background-color: ${colors.grey['400']};
   flex-shrink: 0;

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import type { KeyboardEvent } from 'react';
 import rightChevron from '../../assets/member/right-chevron.svg';
-import type { Member } from '../../mocks/members.mock';
+import type { Member } from '@/api/rooms/getRoomMembers';
 import {
   Container,
   MemberItem,
@@ -47,7 +47,11 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
           }}
         >
           <ProfileSection>
-            <ProfileImage />
+            {member.profileImageUrl ? (
+              <ProfileImageWithSrc src={member.profileImageUrl} alt={`${member.nickname} 프로필`} />
+            ) : (
+              <ProfileImage />
+            )}
             <MemberInfo>
               <MemberName>{member.nickname}</MemberName>
               <MemberRole>{member.role}</MemberRole>
@@ -62,5 +66,10 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
     </Container>
   );
 };
+
+// 프로필 이미지가 있을 때 사용하는 스타일드 컴포넌트
+const ProfileImageWithSrc = ({ src, alt }: { src: string; alt: string }) => (
+  <ProfileImage as="img" src={src} alt={alt} style={{ objectFit: 'cover' }} />
+);
 
 export default MemberList;

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import type { KeyboardEvent } from 'react';
+import styled from '@emotion/styled';
 import rightChevron from '../../assets/member/right-chevron.svg';
 import type { Member } from '@/api/rooms/getRoomMembers';
 import {
@@ -68,8 +69,13 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
 };
 
 // 프로필 이미지가 있을 때 사용하는 스타일드 컴포넌트
-const ProfileImageWithSrc = ({ src, alt }: { src: string; alt: string }) => (
-  <ProfileImage as="img" src={src} alt={alt} style={{ objectFit: 'cover' }} />
-);
+const ProfileImageWithSrc = styled.img`
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background-color: var(--color-grey-400);
+  flex-shrink: 0;
+  object-fit: cover;
+`;
 
 export default MemberList;

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -70,8 +70,8 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
 
 // 프로필 이미지가 있을 때 사용하는 스타일드 컴포넌트
 const ProfileImageWithSrc = styled.img`
-  width: 48px;
-  height: 48px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   background-color: var(--color-grey-400);
   flex-shrink: 0;

--- a/src/pages/groupMembers/GroupMembers.styled.ts
+++ b/src/pages/groupMembers/GroupMembers.styled.ts
@@ -11,3 +11,32 @@ export const Wrapper = styled.div`
   margin: 0 auto;
   background-color: ${colors.black.main};
 `;
+
+export const LoadingContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: var(--color-grey-200);
+  font-size: var(--string-size-base, 16px);
+`;
+
+export const ErrorContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: var(--color-red);
+  font-size: var(--string-size-base, 16px);
+  text-align: center;
+  padding: 20px;
+`;
+
+export const EmptyContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: var(--color-grey-200);
+  font-size: var(--string-size-base, 16px);
+`;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,7 +53,7 @@ const Router = () => {
         <Route path="post/update/:feedId" element={<UpdatePost />} />
         <Route path="group/search" element={<GroupSearch />} />
         <Route path="group/detail/:roomId" element={<GroupDetail />} />
-        <Route path="group/detail/joined" element={<ParticipatedGroupDetail />} />
+        <Route path="group/detail/joined/:roomId" element={<ParticipatedGroupDetail />} />
         <Route path="group/members" element={<GroupMembers />} />
         <Route path="memory" element={<Memory />} />
         <Route path="rooms/:roomId/memory" element={<Memory />} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -54,7 +54,7 @@ const Router = () => {
         <Route path="group/search" element={<GroupSearch />} />
         <Route path="group/detail/:roomId" element={<GroupDetail />} />
         <Route path="group/detail/joined/:roomId" element={<ParticipatedGroupDetail />} />
-        <Route path="group/members" element={<GroupMembers />} />
+        <Route path="group/:roomId/members" element={<GroupMembers />} />
         <Route path="memory" element={<Memory />} />
         <Route path="rooms/:roomId/memory" element={<Memory />} />
         <Route path="memory/record/write/:roomId" element={<RecordWrite />} />


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#106 

## 📝 작업 내용

진행중인 방 상세보기 페이지와 독서메이트 조회 기능을 API와 연동하여 구현했습니다.

## 🕸️ 주요 구현 사항

**1. 진행중인 방 상세보기 API 연동**
- **API 파일 생성:** `/rooms/{roomId}/playing` 엔드포인트를 호출하는 `getRoomPlaying.ts` API 함수를 구현했습니다.
- **타입 정의:** 스웨거 명세에 맞는 `RoomPlayingResponse`, `CurrentVote`, `VoteItem` 등의 타입을 정의했습니다.
- **데이터 변환 함수:** API 응답의 `currentVotes` 데이터를 기존 `HotTopicSection` 컴포넌트에서 사용하는 Poll 형태로 변환하는 `convertVotesToPolls` 함수를 구현했습니다.
- **ParticipatedGroupDetail 컴포넌트 개선:** 기존 목킹 데이터를 제거하고 실제 API 데이터를 사용하도록 수정했습니다. useParams를 통해 roomId를 받아 API를 호출하며, 로딩/에러 상태도 적절히 처리합니다.

**2. 독서메이트 조회 API 연동**
- **API 파일 생성:** `/rooms/{roomId}/users` 엔드포인트를 호출하는 `getRoomMembers.ts` API 함수를 구현했습니다.
- **타입 정의:** `RoomMember`, `RoomMembersResponse` 타입을 스웨거 명세에 맞게 정의했습니다.
- **데이터 변환:** API 응답의 `userList` 데이터를 기존 `MemberList` 컴포넌트에서 사용하는 `Member` 형태로 변환하는 함수를 구현했습니다.
- **GroupMembers 컴포넌트 개선:** 기존 목킹 데이터를 제거하고 실제 API 연동을 구현했습니다. roomId 파라미터 처리를 위해 localStorage 백업 로직도 추가했습니다.

**3. 데이터 매핑 및 변환**

- **진행중인 방 데이터:** `roomName`, `roomDescription`, `progressStartDate/progressEndDate`, `memberCount`, `category`, `bookTitle/authorName`, `currentPage/userPercentage`, `currentVotes` 등을 UI 컴포넌트에 맞게 매핑했습니다.
- **독서메이트 데이터:** `userId→id`, `nickname→nickname`, `alias→role`, `subscriberCount→followersCount`, `imageUrl→profileImageUrl` 등의 필드 매핑을 구현했습니다.
- **날짜 포맷팅:** API 응답의 `YYYY-MM-DD` 형식을 UI에서 사용하는 `YYYY.MM.DD` 형식으로 변환했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 그룹 상세(참여중) 화면이 실데이터로 동작하며 투표(핫토픽)를 UI용 폼으로 변환해 표시합니다. 로딩·에러 상태 UI가 추가되었습니다.
  * 그룹 멤버 목록이 실데이터로 표시되고, 원격 프로필 이미지를 표시하며 비어있음/로딩/에러 상태 UI를 제공합니다. 멤버 클릭 시 다른 사용자 피드로 이동합니다.
* **Refactor**
  * 라우트가 roomId 파라미터 기반으로 변경되었습니다.
* **Style**
  * 프로필 이미지 크기 조정 및 대체 텍스트 추가로 접근성·레이아웃 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->