### PR TITLE
feat: 책 페이지 정보 조회 API 연동 구현 및 일부 로직 수정

### DIFF
--- a/src/api/rooms/getBookPage.ts
+++ b/src/api/rooms/getBookPage.ts
@@ -1,0 +1,48 @@
+import { apiClient } from '../index';
+
+// 책 페이지 정보 응답 데이터 타입
+export interface BookPageData {
+  totalBookPage: number; // 책 전체 페이지 수
+  recentBookPage: number; // 최근 기록한 페이지 번호
+  isOverviewPossible: boolean; // 총평 작성 가능 여부
+  roomId: number; // 방 ID
+}
+
+// API 응답 타입
+export interface BookPageResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: BookPageData;
+}
+
+// 책 전체 페이지수 및 총평 작성 가능 여부 조회 API 함수
+export const getBookPage = async (roomId: number): Promise<BookPageResponse> => {
+  try {
+    const response = await apiClient.get<BookPageResponse>(`/rooms/${roomId}/book-page`);
+    return response.data;
+  } catch (error) {
+    console.error('책 페이지 정보 조회 API 오류:', error);
+    throw error;
+  }
+};
+
+/*
+사용 예시:
+try {
+  const result = await getBookPage(1);
+  if (result.isSuccess) {
+    console.log("책 전체 페이지 수:", result.data.totalBookPage);
+    console.log("최근 기록한 페이지:", result.data.recentBookPage);
+    console.log("총평 작성 가능:", result.data.isOverviewPossible);
+    console.log("방 ID:", result.data.roomId);
+    // 성공 처리 로직
+  } else {
+    console.error("책 페이지 정보 조회 실패:", result.message);
+    // 실패 처리 로직
+  }
+} catch (error) {
+  console.error("API 호출 오류:", error);
+  // 에러 처리 로직 (400: 파라미터 잘못, 403: 접근 권한 없음, 404: 방 없음)
+}
+*/

--- a/src/components/memory/MemoryContent/MemoryContent.tsx
+++ b/src/components/memory/MemoryContent/MemoryContent.tsx
@@ -17,6 +17,7 @@ interface MemoryContentProps {
   selectedPageRange: { start: number; end: number } | null;
   hasRecords: boolean;
   showUploadProgress: boolean;
+  currentUserPage: number;
   onTabChange: (tab: RecordType) => void;
   onFilterChange: (filter: FilterType) => void;
   onSortChange: (sort: SortType) => void;

--- a/src/components/recordwrite/PageRangeSection.tsx
+++ b/src/components/recordwrite/PageRangeSection.tsx
@@ -28,6 +28,7 @@ interface PageRangeSectionProps {
   isOverallEnabled: boolean;
   onOverallToggle: () => void;
   readingProgress: number;
+  isOverviewPossible: boolean;
 }
 
 const PageRangeSection = ({

--- a/src/pages/pollwrite/PollWrite.tsx
+++ b/src/pages/pollwrite/PollWrite.tsx
@@ -116,19 +116,38 @@ const PollWrite = () => {
     setIsSubmitting(true);
 
     try {
-      // 페이지 범위 결정: 총평이 아닌 경우 페이지 번호 필요
-      const finalPage = isOverallEnabled
-        ? 0 // 총평인 경우 페이지는 0
-        : pageRange.trim() !== ''
-          ? parseInt(pageRange.trim())
-          : lastRecordedPage; // 입력값이 없으면 마지막 기록 페이지 사용
-
       // 투표 옵션 필터링 (빈 옵션 제거)
       const validOptions = pollOptions.filter(option => option.trim() !== '');
 
       if (validOptions.length < 2) {
         openSnackbar({
           message: '투표 옵션은 최소 2개 이상이어야 합니다.',
+          variant: 'top',
+          onClose: () => {},
+        });
+        setIsSubmitting(false);
+        return;
+      }
+
+      // 페이지 범위 결정
+      let finalPage: number;
+
+      if (isOverallEnabled) {
+        // 총평인 경우: 책의 마지막 페이지 또는 전체 페이지 수 사용
+        finalPage = totalPages;
+      } else {
+        // 일반 투표인 경우
+        if (pageRange.trim() !== '') {
+          finalPage = parseInt(pageRange.trim());
+        } else {
+          finalPage = lastRecordedPage;
+        }
+      }
+
+      // 페이지 유효성 검사
+      if (finalPage <= 0 || finalPage > totalPages) {
+        openSnackbar({
+          message: `유효하지 않은 페이지입니다. (1-${totalPages} 사이의 값을 입력해주세요)`,
           variant: 'top',
           onClose: () => {},
         });

--- a/src/pages/pollwrite/PollWrite.tsx
+++ b/src/pages/pollwrite/PollWrite.tsx
@@ -5,7 +5,6 @@ import PageRangeSection from '../../components/recordwrite/PageRangeSection';
 import PollCreationSection from '../../components/pollwrite/PollCreationSection';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import { Container } from './PollWrite.styled';
-import type { Record } from '../memory/Memory';
 import { createVote } from '../../api/record/createVote';
 import type { CreateVoteRequest } from '../../types/record';
 import { getBookPage } from '../../api/rooms/getBookPage';
@@ -105,7 +104,7 @@ const PollWrite = () => {
         onClose: () => {},
       });
     }
-  }, [isOverallEnabled, isOverviewPossible, openSnackbar]);
+  }, [isOverallEnabled, isOverviewPossible]);
 
   const handleBackClick = () => {
     navigate(-1);
@@ -154,34 +153,8 @@ const PollWrite = () => {
       if (response.isSuccess) {
         console.log('투표 생성 성공:', response.data);
 
-        // 투표 옵션 생성 (Memory 페이지 표시용)
-        const pollOptionsData = validOptions.map((option, index) => ({
-          id: `${index + 1}.`,
-          text: option.trim(),
-          percentage: index === 0 ? 90 : 10, // 첫 번째 옵션을 90%로 설정 (데모용)
-          isHighest: index === 0, // 첫 번째 옵션이 최고값
-        }));
-
-        // 임시로 Memory 페이지용 투표 객체 생성 (기존 인터페이스 호환성을 위해)
-        const newPollRecord: Record & { isUploading?: boolean } = {
-          id: response.data.voteId.toString(),
-          user: 'user.01', // TODO: 실제 사용자 정보로 변경
-          userPoints: 132, // TODO: 실제 사용자 포인트로 변경
-          content: pollContent,
-          likeCount: 0,
-          commentCount: 0,
-          timeAgo: '방금 전',
-          createdAt: new Date(),
-          type: 'poll',
-          recordType: isOverallEnabled ? 'overall' : 'page',
-          pageRange: isOverallEnabled ? undefined : finalPage.toString(),
-          pollOptions: pollOptionsData,
-          isUploading: false, // API 호출이 완료되었으므로 false
-        };
-
         // 성공 시 기록장으로 이동
         navigate(`/rooms/${roomId}/memory`, {
-          state: { newRecord: newPollRecord },
           replace: true,
         });
       } else {

--- a/src/pages/pollwrite/PollWrite.tsx
+++ b/src/pages/pollwrite/PollWrite.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import TitleHeader from '../../components/common/TitleHeader';
 import PageRangeSection from '../../components/recordwrite/PageRangeSection';
@@ -8,10 +8,13 @@ import { Container } from './PollWrite.styled';
 import type { Record } from '../memory/Memory';
 import { createVote } from '../../api/record/createVote';
 import type { CreateVoteRequest } from '../../types/record';
+import { getBookPage } from '../../api/rooms/getBookPage';
+import { usePopupActions } from '../../hooks/usePopupActions';
 
 const PollWrite = () => {
   const navigate = useNavigate();
   const { roomId } = useParams<{ roomId: string }>();
+  const { openSnackbar } = usePopupActions();
 
   const [pageRange, setPageRange] = useState('');
   const [pollContent, setPollContent] = useState('');
@@ -19,19 +22,97 @@ const PollWrite = () => {
   const [isOverallEnabled, setIsOverallEnabled] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // TODO: 실제로는 백엔드에서 받아온 책 정보에서 전체 페이지 수를 가져와야 함
-  const totalPages = 600; // 임시 값
-  // TODO: 실제로는 백엔드에서 받아온 가장 마지막 기록 페이지를 가져와야 함
-  const lastRecordedPage = 456; // 임시 값 (기록이 없으면 0)
-  // TODO: 실제로는 백엔드에서 받아온 읽기 진행도를 가져와야 함
-  const readingProgress = 70; // 임시 값 (80% 미만이므로 총평 비활성화)
+  // API에서 받아올 데이터
+  const [totalPages, setTotalPages] = useState(0);
+  const [lastRecordedPage, setLastRecordedPage] = useState(0);
+  const [isOverviewPossible, setIsOverviewPossible] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 컴포넌트 마운트 시 책 페이지 정보 조회
+  useEffect(() => {
+    const fetchBookPageInfo = async () => {
+      if (!roomId) {
+        openSnackbar({
+          message: '방 정보를 찾을 수 없습니다.',
+          variant: 'top',
+          onClose: () => {},
+        });
+        navigate(-1);
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        const response = await getBookPage(parseInt(roomId));
+
+        if (response.isSuccess) {
+          setTotalPages(response.data.totalBookPage);
+          setLastRecordedPage(response.data.recentBookPage);
+          setIsOverviewPossible(response.data.isOverviewPossible);
+        } else {
+          openSnackbar({
+            message: response.message || '책 정보를 불러오는데 실패했습니다.',
+            variant: 'top',
+            onClose: () => {},
+          });
+        }
+      } catch (error) {
+        console.error('책 페이지 정보 조회 오류:', error);
+
+        let errorMessage = '책 정보를 불러오는 중 오류가 발생했습니다.';
+
+        if (error && typeof error === 'object' && 'response' in error) {
+          const axiosError = error as {
+            response?: {
+              data?: {
+                message?: string;
+                code?: number;
+              };
+            };
+          };
+
+          if (axiosError.response?.data?.message) {
+            errorMessage = axiosError.response.data.message;
+          } else if (axiosError.response?.data?.code === 400) {
+            errorMessage = '파라미터 값 중 유효하지 않은 값이 있습니다.';
+          } else if (axiosError.response?.data?.code === 403) {
+            errorMessage = '방 접근 권한이 없습니다.';
+          } else if (axiosError.response?.data?.code === 404) {
+            errorMessage = '존재하지 않는 방입니다.';
+          }
+        }
+
+        openSnackbar({
+          message: errorMessage,
+          variant: 'top',
+          onClose: () => {},
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchBookPageInfo();
+  }, [roomId, navigate, openSnackbar]);
+
+  // 총평 모드가 변경될 때 isOverviewPossible 체크
+  useEffect(() => {
+    if (isOverallEnabled && !isOverviewPossible) {
+      setIsOverallEnabled(false);
+      openSnackbar({
+        message: '총평 작성 조건을 만족하지 않습니다.',
+        variant: 'top',
+        onClose: () => {},
+      });
+    }
+  }, [isOverallEnabled, isOverviewPossible, openSnackbar]);
 
   const handleBackClick = () => {
     navigate(-1);
   };
 
   const handleCompleteClick = async () => {
-    if (isSubmitting || !roomId) return; // 중복 실행 방지 및 roomId 체크
+    if (isSubmitting || !roomId) return;
 
     setIsSubmitting(true);
 
@@ -47,7 +128,11 @@ const PollWrite = () => {
       const validOptions = pollOptions.filter(option => option.trim() !== '');
 
       if (validOptions.length < 2) {
-        alert('투표 옵션은 최소 2개 이상이어야 합니다.');
+        openSnackbar({
+          message: '투표 옵션은 최소 2개 이상이어야 합니다.',
+          variant: 'top',
+          onClose: () => {},
+        });
         setIsSubmitting(false);
         return;
       }
@@ -102,7 +187,11 @@ const PollWrite = () => {
       } else {
         // API 에러 응답 처리
         console.error('투표 생성 실패:', response.message);
-        alert(`투표 생성에 실패했습니다: ${response.message}`);
+        openSnackbar({
+          message: response.message || '투표 생성에 실패했습니다.',
+          variant: 'top',
+          onClose: () => {},
+        });
         setIsSubmitting(false);
       }
     } catch (error) {
@@ -114,36 +203,68 @@ const PollWrite = () => {
       if (error && typeof error === 'object' && 'response' in error) {
         const axiosError = error as {
           response?: {
-            status: number;
-            data?: { message?: string };
+            data?: {
+              message?: string;
+              code?: number;
+            };
           };
         };
 
         if (axiosError.response?.data?.message) {
           errorMessage = axiosError.response.data.message;
-        } else if (axiosError.response?.status) {
-          errorMessage = `서버 오류 (${axiosError.response.status})`;
+        } else if (axiosError.response?.data?.code === 400) {
+          errorMessage = '입력값을 확인해 주세요.';
+        } else if (axiosError.response?.data?.code === 403) {
+          errorMessage = '방 접근 권한이 없습니다.';
+        } else if (axiosError.response?.data?.code === 404) {
+          errorMessage = '존재하지 않는 방입니다.';
         }
       }
 
-      alert(errorMessage);
+      openSnackbar({
+        message: errorMessage,
+        variant: 'top',
+        onClose: () => {},
+      });
       setIsSubmitting(false);
     }
   };
 
-  // 투표 내용과 최소 2개의 옵션이 필요
-  const isFormValid =
-    pollContent.trim() !== '' && pollOptions.filter(option => option.trim() !== '').length >= 2;
+  // 로딩 중일 때 표시
+  if (isLoading) {
+    return (
+      <>
+        <TitleHeader
+          leftIcon={<img src={leftArrow} alt="뒤로가기" />}
+          title="투표 작성"
+          onLeftClick={handleBackClick}
+        />
+        <Container>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              height: '200px',
+              color: '#fff',
+            }}
+          >
+            로딩 중...
+          </div>
+        </Container>
+      </>
+    );
+  }
 
   return (
     <>
       <TitleHeader
         leftIcon={<img src={leftArrow} alt="뒤로가기" />}
-        title="투표 생성"
-        rightButton="완료"
+        title="투표 작성"
+        rightButton={<div className="complete">완료</div>}
         onLeftClick={handleBackClick}
         onRightClick={handleCompleteClick}
-        isNextActive={isFormValid && !isSubmitting}
+        isNextActive={pollContent.trim().length > 0 && !isSubmitting}
       />
       <Container>
         <PageRangeSection
@@ -152,10 +273,10 @@ const PollWrite = () => {
           totalPages={totalPages}
           lastRecordedPage={lastRecordedPage}
           isOverallEnabled={isOverallEnabled}
-          onOverallToggle={() => setIsOverallEnabled(!isOverallEnabled)}
-          readingProgress={readingProgress}
+          onOverallToggle={() => setIsOverallEnabled(prev => !prev)}
+          readingProgress={isOverviewPossible ? 80 : 70} // 총평 가능하면 80% 이상으로 표시
+          isOverviewPossible={isOverviewPossible}
         />
-
         <PollCreationSection
           content={pollContent}
           onContentChange={setPollContent}

--- a/src/pages/pollwrite/PollWrite.tsx
+++ b/src/pages/pollwrite/PollWrite.tsx
@@ -93,7 +93,7 @@ const PollWrite = () => {
     };
 
     fetchBookPageInfo();
-  }, [roomId, navigate, openSnackbar]);
+  }, [roomId]);
 
   // 총평 모드가 변경될 때 isOverviewPossible 체크
   useEffect(() => {

--- a/src/pages/recordwrite/RecordWrite.tsx
+++ b/src/pages/recordwrite/RecordWrite.tsx
@@ -92,7 +92,7 @@ const RecordWrite = () => {
     };
 
     fetchBookPageInfo();
-  }, [roomId, navigate, openSnackbar]);
+  }, [roomId]);
 
   // 총평 모드가 변경될 때 isOverviewPossible 체크
   useEffect(() => {

--- a/src/pages/recordwrite/RecordWrite.tsx
+++ b/src/pages/recordwrite/RecordWrite.tsx
@@ -115,12 +115,31 @@ const RecordWrite = () => {
     setIsSubmitting(true);
 
     try {
-      // 페이지 범위 결정: 총평이 아닌 경우 페이지 번호 필요
-      const finalPage = isOverallEnabled
-        ? 0 // 총평인 경우 페이지는 0
-        : pageRange.trim() !== ''
-          ? parseInt(pageRange.trim())
-          : lastRecordedPage; // 입력값이 없으면 마지막 기록 페이지 사용
+      // 페이지 범위 결정
+      let finalPage: number;
+
+      if (isOverallEnabled) {
+        // 총평인 경우: 책의 마지막 페이지 또는 전체 페이지 수 사용
+        finalPage = totalPages;
+      } else {
+        // 일반 기록인 경우
+        if (pageRange.trim() !== '') {
+          finalPage = parseInt(pageRange.trim());
+        } else {
+          finalPage = lastRecordedPage;
+        }
+      }
+
+      // 페이지 유효성 검사
+      if (finalPage <= 0 || finalPage > totalPages) {
+        openSnackbar({
+          message: `유효하지 않은 페이지입니다. (1-${totalPages} 사이의 값을 입력해주세요)`,
+          variant: 'top',
+          onClose: () => {},
+        });
+        setIsSubmitting(false);
+        return;
+      }
 
       // API 요청 데이터 생성
       const recordData: CreateRecordRequest = {

--- a/src/pages/recordwrite/RecordWrite.tsx
+++ b/src/pages/recordwrite/RecordWrite.tsx
@@ -5,7 +5,6 @@ import PageRangeSection from '../../components/recordwrite/PageRangeSection';
 import RecordContentSection from '../../components/recordwrite/RecordContentSection';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import { Container } from './RecordWrite.styled';
-import type { Record } from '../memory/Memory';
 import { createRecord } from '../../api/record/createRecord';
 import type { CreateRecordRequest } from '../../types/record';
 import { getBookPage } from '../../api/rooms/getBookPage';
@@ -104,7 +103,7 @@ const RecordWrite = () => {
         onClose: () => {},
       });
     }
-  }, [isOverallEnabled, isOverviewPossible, openSnackbar]);
+  }, [isOverallEnabled, isOverviewPossible]);
 
   const handleBackClick = () => {
     navigate(-1);
@@ -139,25 +138,8 @@ const RecordWrite = () => {
       if (response.isSuccess) {
         console.log('기록 생성 성공:', response.data);
 
-        // 임시로 Memory 페이지용 기록 객체 생성 (기존 인터페이스 호환성을 위해)
-        const newRecord: Record & { isUploading?: boolean } = {
-          id: response.data.recordId.toString(),
-          user: 'user.01', // TODO: 실제 사용자 정보로 변경
-          userPoints: 132, // TODO: 실제 사용자 포인트로 변경
-          content: content,
-          likeCount: 0,
-          commentCount: 0,
-          timeAgo: '방금 전',
-          createdAt: new Date(),
-          type: 'text' as const,
-          recordType: isOverallEnabled ? 'overall' : 'page',
-          pageRange: isOverallEnabled ? undefined : finalPage.toString(),
-          isUploading: false, // API 호출이 완료되었으므로 false
-        };
-
         // 성공 시 기록장으로 이동
         navigate(`/rooms/${roomId}/memory`, {
-          state: { newRecord },
           replace: true,
         });
       } else {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#106 

## 📝 작업 내용

기록장에서 책 페이지 정보 조회 API를 연동하고 총평 기록이 제대로 표시되지 않는 문제를 해결했습니다.

## 🕸️ 주요 수정 사항

**1. 기록 작성 API 수정 (RecordWrite.tsx, PollWrite.tsx)**
- 총평 작성 시 페이지 값이 0으로 전송되어 서버에서 유효성 검증 오류(40002)가 발생하는 문제 해결
- 총평인 경우 페이지를 전체 페이지 수(totalPages)로 설정하도록 수정
- `getBookPage` API를 추가로 호출하여 책 페이지 정보와 총평 작성 가능 여부를 확인
- 페이지 유효성 검사 로직 강화 (1~전체페이지 범위 체크)

**2. 기록장 조회 API 수정 (Memory.tsx)**

- API 스웨거 명세에 따라 `isOverview` 파라미터가 필요함을 확인
- 기존 단일 API 호출로는 일반 기록만 가져와서 총평 기록이 누락되는 문제 발견
- 일반 기록(`isOverview: false`)과 총평 기록(`isOverview: true`)을 병렬로 호출하여 모든 기록을 가져오도록 수정
- `Promise.all`을 사용하여 성능 최적화
- API 응답에서 받은 `isOverviewEnabled` 값을 `readingProgress` 계산에 활용하여 총평보기 버튼 활성화 제어

**3. 필터링 로직 강화**

- 총평보기 버튼 클릭 시 `recordType === 'overall'`인 기록만 필터링하여 표시
- 페이지별보기 필터와 총평보기 필터의 명확한 분리
- 프론트엔드 레벨에서의 필터링으로 API 호출 최소화