### PR TITLE
feat: 방 게시물(기록,투표) 좋아요 상태변경 API 연동 구현

### DIFF
--- a/src/api/roomPosts/postRoomPostLike.ts
+++ b/src/api/roomPosts/postRoomPostLike.ts
@@ -1,0 +1,64 @@
+import { apiClient } from '../index';
+import type { RoomPostLikeRequest, RoomPostLikeResponse } from '@/types/roomPostLike';
+
+// 방 게시물(기록,투표) 좋아요 상태변경 API 함수
+export const postRoomPostLike = async (
+  postId: number,
+  requestData: RoomPostLikeRequest,
+): Promise<RoomPostLikeResponse> => {
+  try {
+    const response = await apiClient.post<RoomPostLikeResponse>(
+      `/room-posts/${postId}/likes`,
+      requestData,
+    );
+    return response.data;
+  } catch (error) {
+    console.error('방 게시물 좋아요 API 오류:', error);
+    throw error;
+  }
+};
+
+/*
+사용 예시:
+
+// 기록 게시물 좋아요
+const likeRecordPost = async (postId: number, isLiked: boolean) => {
+  try {
+    const result = await postRoomPostLike(postId, {
+      type: !isLiked, // 현재 상태 반대로 전송
+      roomPostType: 'RECORD'
+    });
+    
+    if (result.isSuccess) {
+      console.log('좋아요 상태 변경 성공:', result.data.isLiked);
+      console.log('게시물 ID:', result.data.postId);
+      // UI 업데이트 로직
+    } else {
+      console.error('좋아요 상태 변경 실패:', result.message);
+      // 에러 처리 로직
+    }
+  } catch (error) {
+    console.error('API 호출 오류:', error);
+    // 네트워크 에러 처리 로직
+  }
+};
+
+// 투표 게시물 좋아요
+const likeVotePost = async (postId: number, isLiked: boolean) => {
+  try {
+    const result = await postRoomPostLike(postId, {
+      type: !isLiked, // 현재 상태 반대로 전송
+      roomPostType: 'VOTE'
+    });
+    
+    if (result.isSuccess) {
+      console.log('좋아요 상태 변경 성공:', result.data.isLiked);
+      // UI 업데이트 로직
+    } else {
+      console.error('좋아요 상태 변경 실패:', result.message);
+    }
+  } catch (error) {
+    console.error('API 호출 오류:', error);
+  }
+};
+*/

--- a/src/components/memory/MemoryContent/MemoryContent.tsx
+++ b/src/components/memory/MemoryContent/MemoryContent.tsx
@@ -1,4 +1,5 @@
-import type { RecordType, FilterType, Record } from '../../../pages/memory/Memory';
+import type { RecordType, FilterType } from '../../../pages/memory/Memory';
+import type { Record } from '../../../types/memory';
 import type { SortType } from '../SortDropdown';
 import RecordTabs from '../RecordTabs';
 import RecordFilters from '../RecordFilters/RecordFilters';

--- a/src/components/memory/MemoryContent/RecordList.tsx
+++ b/src/components/memory/MemoryContent/RecordList.tsx
@@ -1,4 +1,4 @@
-import type { Record } from '../../../pages/memory/Memory';
+import type { Record } from '../../../types/memory';
 import RecordItem from '../RecordItem/RecordItem';
 import { RecordListContainer } from './RecordList.styled';
 

--- a/src/components/memory/RecordFilters/FilterButtons.tsx
+++ b/src/components/memory/RecordFilters/FilterButtons.tsx
@@ -40,9 +40,9 @@ const FilterButtons = ({
     switch (sort) {
       case 'latest':
         return '최신순';
-      case 'popular':
+      case 'like':
         return '인기순';
-      case 'comments':
+      case 'comment':
         return '댓글 많은순';
       default:
         return '최신순';

--- a/src/components/memory/RecordItem/PollRecord.tsx
+++ b/src/components/memory/RecordItem/PollRecord.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import type { PollOption } from '../../../pages/memory/Memory';
+import type { PollOption } from '../../../types/memory';
 import {
   PollSection,
   PollQuestion,

--- a/src/components/memory/SortDropdown.tsx
+++ b/src/components/memory/SortDropdown.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { DropdownContainer, DropdownItem } from './SortDropdown.styled';
 
-export type SortType = 'latest' | 'popular' | 'comments';
+export type SortType = 'latest' | 'like' | 'comment';
 
 interface SortDropdownProps {
   isOpen: boolean;
@@ -33,8 +33,8 @@ const SortDropdown = ({ isOpen, selectedSort, onSortSelect }: SortDropdownProps)
 
   const sortOptions = [
     { value: 'latest' as SortType, label: '최신순' },
-    { value: 'popular' as SortType, label: '인기순' },
-    { value: 'comments' as SortType, label: '댓글 많은순' },
+    { value: 'like' as SortType, label: '인기순' },
+    { value: 'comment' as SortType, label: '댓글 많은순' },
   ];
 
   return (

--- a/src/pages/groupDetail/ParticipatedGroupDetail.tsx
+++ b/src/pages/groupDetail/ParticipatedGroupDetail.tsx
@@ -124,25 +124,25 @@ const ParticipatedGroupDetail = () => {
   };
 
   const handleRecordSectionClick = () => {
-    navigate(`/memory/${roomId}`);
+    navigate(`/rooms/${roomId}/memory`);
+  };
+
+  const handleHotTopicSectionClick = () => {
+    navigate(`/rooms/${roomId}/memory`);
+  };
+
+  const handlePollClick = (pageNumber: number) => {
+    navigate(`/rooms/${roomId}/memory?page=${pageNumber}&filter=poll`);
   };
 
   const handleCommentSectionClick = () => {
     navigate(`/today-words/${roomId}`);
   };
 
-  const handleHotTopicSectionClick = () => {
-    navigate(`/memory/${roomId}`);
-  };
-
   const handleBookSectionClick = () => {
     if (roomData?.data.isbn) {
       navigate(`/book/${roomData.data.isbn}`);
     }
-  };
-
-  const handlePollClick = (pageNumber: number) => {
-    navigate(`/memory/${roomId}?page=${pageNumber}&filter=poll`);
   };
 
   const handleMembersClick = () => {

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -7,33 +7,10 @@ import MemoryAddButton from '../../components/memory/MemoryAddButton/MemoryAddBu
 import Snackbar from '../../components/common/Modal/Snackbar';
 import { Container, FixedHeader, ScrollableContent, FloatingElements } from './Memory.styled';
 import { getMemoryPosts } from '../../api/memory/getMemoryPosts';
-import type { Post } from '../../types/memory';
+import type { Post, Record } from '../../types/memory';
 
 export type RecordType = 'group' | 'my';
 export type FilterType = 'page' | 'overall';
-
-export interface Record {
-  id: string;
-  user: string;
-  userPoints: number;
-  content: string;
-  likeCount: number;
-  commentCount: number;
-  timeAgo: string;
-  createdAt: Date;
-  type: 'text' | 'poll';
-  recordType?: 'page' | 'overall';
-  pollOptions?: PollOption[];
-  pageRange?: string;
-  isWriter?: boolean;
-}
-
-export interface PollOption {
-  id: string;
-  text: string;
-  percentage: number;
-  isHighest?: boolean;
-}
 
 // API 포스트를 기존 Record 타입으로 변환하는 함수
 const convertPostToRecord = (post: Post): Record => {
@@ -50,6 +27,7 @@ const convertPostToRecord = (post: Post): Record => {
     recordType: post.isOverview ? 'overall' : 'page',
     pageRange: post.isOverview ? undefined : post.page.toString(),
     isWriter: post.isWriter,
+    isLiked: post.isLiked,
     pollOptions: post.voteItems.map((item, index) => ({
       id: item.voteItemId.toString(),
       text: item.itemName,
@@ -90,7 +68,10 @@ const Memory = () => {
 
   // API 데이터 로드 함수
   const loadMemoryPosts = useCallback(async () => {
-    if (!roomId) return;
+    if (!roomId) {
+      setError('방 ID가 없습니다.');
+      return;
+    }
 
     setError(null);
 

--- a/src/stores/usePopupStore.ts
+++ b/src/stores/usePopupStore.ts
@@ -15,6 +15,7 @@ export interface MoreMenuProps {
   onEdit?: () => void;
   onDelete?: () => void;
   onClose?: () => void;
+  onReport?: () => void;
 }
 
 export interface SnackbarProps {

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -54,3 +54,29 @@ export interface GetMemoryPostsResponse {
   message: string;
   data: MemoryPostsData;
 }
+
+// Memory 페이지에서 사용하는 Record 타입 (좋아요 상태 포함)
+export interface Record {
+  id: string;
+  user: string;
+  userPoints: number;
+  content: string;
+  likeCount: number;
+  commentCount: number;
+  timeAgo: string;
+  createdAt: Date;
+  type: 'text' | 'poll';
+  recordType: 'page' | 'overall';
+  pageRange?: string;
+  isWriter: boolean;
+  isLiked: boolean; // 좋아요 상태 추가
+  pollOptions?: PollOption[];
+}
+
+// 투표 옵션 타입
+export interface PollOption {
+  id: string;
+  text: string;
+  percentage: number;
+  isHighest: boolean;
+}

--- a/src/types/roomPostLike.ts
+++ b/src/types/roomPostLike.ts
@@ -1,0 +1,19 @@
+// 방 게시물 좋아요 요청 데이터 타입
+export interface RoomPostLikeRequest {
+  type: boolean; // true: 좋아요, false: 좋아요 취소
+  roomPostType: 'RECORD' | 'VOTE'; // 방 게시물 타입
+}
+
+// 방 게시물 좋아요 응답 데이터 타입
+export interface RoomPostLikeData {
+  postId: number; // 게시물 ID
+  isLiked: boolean; // 좋아요 상태
+}
+
+// API 응답 타입
+export interface RoomPostLikeResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: RoomPostLikeData;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#106 

## 📝 작업 내용

기록장(Memory) 페이지의 좋아요 기능 구현과 관련된 여러 문제를 해결했습니다.

## 🕸️ 주요 작업 내용

**1. 좋아요 API 연동 및 상태 관리 구현**
- `postRoomPostLike` API를 사용하여 좋아요/좋아요 취소 기능을 구현했습니다. 기록 타입(RECORD/VOTE)에 따라 적절한 `roomPostType` 파라미터를 전송하도록 처리했습니다.
- 서버 응답에 따른 좋아요 상태(`isLiked`)와 좋아요 수(`likeCount`) 실시간 업데이트를 구현했습니다.
- API 호출 실패 시 에러 코드별로 구분된 사용자 친화적인 오류 메시지를 표시하도록 했습니다(방 접근 권한 없음, 이미 좋아요한 게시물 등).

**2. 터치 이벤트 충돌 문제 해결**
- 기존에 좋아요 버튼과 길게 누르기 기능 간의 터치 이벤트 충돌로 인해 passive event listener 오류가 발생하던 문제를 해결했습니다.
- 액션 섹션(좋아요, 댓글 버튼 영역)에서는 길게 누르기 기능을 완전히 제외하고, `stopPropagation`을 통해 이벤트 전파를 차단하여 터치 이벤트가 분리되도록 구현했습니다.
- 마우스 클릭과 터치 이벤트 모두에서 좋아요 기능이 정상 동작하도록 했습니다.

**3. Memory 페이지 타입 시스템 정리**
- `Record`와 `PollOption` 타입을 `types/memory.ts`로 통합하여 import 오류를 해결했습니다.
- `SortType` 정의를 API 스펙에 맞게 수정했습니다(`popular → like`, `comments → comment`).
- TypeScript 타입 오류들을 모두 해결하여 빌드가 정상적으로 되도록 했습니다.

**4. 좋아요 상태 데이터 구조 개선**
- Record 타입에 isLiked 속성을 추가하여 좋아요 상태를 추적할 수 있도록 했습니다.
- API에서 받은 Post 데이터를 Record로 변환할 때 `isLiked` 속성이 올바르게 매핑되도록 `convertPostToRecord` 함수를 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 메모리 게시글 좋아요/취소 지원(투표·텍스트 모두), 상태·카운트 즉시 반영 및 실패 시 스낵바 안내
  - 비소유자 롱프레스 신고, 소유자 클릭 편집/삭제
  - 메모리 경로 /rooms/{roomId}/memory로 일원화, 투표 페이지 이동(filter=poll) 지원
- Improvements
  - 정렬 키워드 정비(표시 라벨은 기존 유지)
  - 진행도·페이지 범위 필터 연동 및 업로드 진행 표시
  - 특정 조건(80% 진행도 미달) 시 안내 메시지 강화
- Refactor
  - 메모리/좋아요 관련 타입 분리 및 공용화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->