### PR TITLE
fix: 피드 게시글 수정 navigation 추가

### DIFF
--- a/src/pages/feed/FeedDetailPage.tsx
+++ b/src/pages/feed/FeedDetailPage.tsx
@@ -91,7 +91,7 @@ const FeedDetailPage = () => {
       openMoreMenu({
         onEdit: () => {
           closePopup();
-          // navigate(`/post/update/${feedId}`);
+          navigate(`/post/update/${feedId}`);
         },
         onClose: () => {
           closePopup();


### PR DESCRIPTION
이하동일

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 피드 상세 화면에서 더보기 메뉴의 ‘수정’을 선택하면 이제 정상적으로 게시글 수정 화면으로 이동합니다. 이전에는 동작하지 않던 이동 문제가 해결되어, 팝업이 닫힌 뒤 자연스럽게 전환됩니다. 사용자는 추가 조작 없이 곧바로 수정 작업을 시작할 수 있습니다. 전반적인 편집 흐름의 신뢰성과 사용성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->