### PR TITLE
fix: 책 검색 무한스크롤 로직 수정 및 최근검색어 API 수정

### DIFF
--- a/src/api/recentsearch/deleteRecentSearch.ts
+++ b/src/api/recentsearch/deleteRecentSearch.ts
@@ -10,11 +10,10 @@ export interface DeleteRecentSearchResponse {
 
 export const deleteRecentSearch = async (
   recentSearchId: number,
-  userId: number,
 ): Promise<DeleteRecentSearchResponse> => {
   try {
     const response = await apiClient.delete<DeleteRecentSearchResponse>(
-      `/recent-searches/${recentSearchId}?userId=${userId}`,
+      `/recent-searches/${recentSearchId}`,
     );
     return response.data;
   } catch (error) {

--- a/src/components/search/BookSearchResult.tsx
+++ b/src/components/search/BookSearchResult.tsx
@@ -45,7 +45,7 @@ export function BookSearchResult({
         ) : (
           searchedBookList.map((book, index) => (
             <BookItem
-              key={book.id}
+              key={`book-${book.isbn}-${index}`}
               onClick={() => navigate(`/search/book/${book.isbn}`)}
               ref={
                 index === searchedBookList.length - 1 && lastBookElementCallback

--- a/src/components/search/BookSearchResult.tsx
+++ b/src/components/search/BookSearchResult.tsx
@@ -9,6 +9,7 @@ interface BookSearchResultProps {
   hasMore?: boolean;
   isLoading?: boolean;
   lastBookElementCallback?: (node: HTMLDivElement | null) => void;
+  totalElements?: number;
 }
 
 export function BookSearchResult({
@@ -17,6 +18,7 @@ export function BookSearchResult({
   hasMore = false,
   isLoading = false,
   lastBookElementCallback,
+  totalElements,
 }: BookSearchResultProps) {
   const navigate = useNavigate();
 
@@ -32,7 +34,7 @@ export function BookSearchResult({
   return (
     <Wrapper>
       <List>
-        {type === 'searching' ? <></> : <ResultHeader>전체 {searchedBookList.length}</ResultHeader>}
+        {type === 'searching' ? <></> : <ResultHeader>전체 {totalElements}</ResultHeader>}
 
         {isEmptySearchedBookList() ? (
           <EmptyWrapper>

--- a/src/pages/feed/UserSearch.tsx
+++ b/src/pages/feed/UserSearch.tsx
@@ -61,9 +61,7 @@ const UserSearch = () => {
 
   const handleDelete = async (recentSearchId: number) => {
     try {
-      const userId = 1; // 임시 userId
-
-      const response = await deleteRecentSearch(recentSearchId, userId);
+      const response = await deleteRecentSearch(recentSearchId);
 
       if (response.isSuccess) {
         setRecentSearches(prev => prev.filter(item => item.recentSearchId !== recentSearchId));

--- a/src/pages/groupSearch/GroupSearch.tsx
+++ b/src/pages/groupSearch/GroupSearch.tsx
@@ -289,8 +289,7 @@ const GroupSearch = () => {
             handleDelete={(term: string) => {
               const x = recentSearches.find(i => i.searchTerm === term);
               if (!x) return;
-              const userId = 1;
-              deleteRecentSearch(x.recentSearchId, userId).then(res => {
+              deleteRecentSearch(x.recentSearchId).then(res => {
                 if (res.isSuccess) {
                   setRecentSearches(prev =>
                     prev.filter(it => it.recentSearchId !== x.recentSearchId),


### PR DESCRIPTION
## #️⃣연관된 이슈
없음

## 📝작업 내용
- 책 검색 무한스크롤 로직을 수정했습니다. 검색 완료 단계의 화면에서 전체 책 수가 제대로 반영되도록 하였습니다.
- 최근검색어 삭제 API 요청 쿼리파라미터에서 userId가 더이상 필요하지않아서 삭제했습니다.

### 스크린샷
<img width="800" height="984" alt="image" src="https://github.com/user-attachments/assets/6f401280-58bc-444f-9a61-7d21d47a4402" />

## 💬리뷰 요구사항
무한스크롤이 약간 버벅이는 현상이 느껴지는데 이 부분을 해결해야할 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 검색 결과에 전체 결과 수(total count)가 표시됩니다.

- Refactor
  - 무한 스크롤 로딩이 개선되어 다음 페이지가 자동으로 매끄럽게 로드되고 더보기 가능 여부 판단이 정확해졌습니다.
  - 초기 진입 시 최근 검색이 자동으로 불러와집니다.
  - 최근 검색 삭제 흐름이 단순화되어 더 안정적으로 동작합니다.
  - 새 검색 시작 시 상태가 초기화되어 일관된 결과를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->