### PR TITLE
fix: 책 검색 모달 탭 유지 및 무한스크롤 기능 추가

### DIFF
--- a/src/api/books/getSearchBooks.ts
+++ b/src/api/books/getSearchBooks.ts
@@ -58,9 +58,9 @@ export const getSearchBooks = async (
   }
 };
 
-export const convertToSearchedBooks = (apiBooks: BookSearchItem[]): SearchedBook[] => {
+export const convertToSearchedBooks = (apiBooks: BookSearchItem[], startIndex: number = 0): SearchedBook[] => {
   return apiBooks.map((book, index) => ({
-    id: index + 1,
+    id: startIndex + index + 1,
     title: book.title,
     author: book.authorName,
     publisher: book.publisher,

--- a/src/components/common/BookSearchBottomSheet/BookList.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookList.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useRef, useCallback } from 'react';
 import {
   BookList as StyledBookList,
   BookItem,
   BookCover,
   BookInfo,
   BookTitle,
+  LoadingContainer,
+  LoadingText,
 } from './BookSearchBottomSheet.styled';
 
 export interface Book {
@@ -17,17 +20,58 @@ export interface Book {
 interface BookListProps {
   books: Book[];
   onBookSelect: (book: Book) => void;
+  onLoadMore?: () => Promise<void>;
+  hasNextPage?: boolean;
+  isLoadingMore?: boolean;
+  isSearchMode?: boolean;
 }
 
-const BookList = ({ books, onBookSelect }: BookListProps) => {
+const BookList = ({ 
+  books, 
+  onBookSelect, 
+  onLoadMore, 
+  hasNextPage = false, 
+  isLoadingMore = false,
+  isSearchMode = false 
+}: BookListProps) => {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const loadingRef = useRef<HTMLDivElement | null>(null);
+
   const handleImageError = (e: React.SyntheticEvent<HTMLImageElement>) => {
     e.currentTarget.style.display = 'none';
   };
 
+  // 무한스크롤을 위한 Intersection Observer 설정
+  const lastBookElementRef = useCallback((node: HTMLDivElement | null) => {
+    if (isLoadingMore) return;
+    
+    if (observerRef.current) observerRef.current.disconnect();
+    
+    observerRef.current = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting && hasNextPage && onLoadMore && isSearchMode) {
+        onLoadMore();
+      }
+    });
+    
+    if (node) observerRef.current.observe(node);
+  }, [isLoadingMore, hasNextPage, onLoadMore, isSearchMode]);
+
+  useEffect(() => {
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+    };
+  }, []);
+
   return (
     <StyledBookList>
-      {books.map(book => (
-        <BookItem key={book.id} onClick={() => onBookSelect(book)}>
+      {books.map((book, index) => (
+        <BookItem 
+          key={`${book.id}-${book.isbn}`} 
+          onClick={() => onBookSelect(book)}
+          ref={index === books.length - 1 ? lastBookElementRef : null}
+        >
           <BookCover>
             <img src={book.cover} alt={book.title} onError={handleImageError} />
           </BookCover>
@@ -36,6 +80,13 @@ const BookList = ({ books, onBookSelect }: BookListProps) => {
           </BookInfo>
         </BookItem>
       ))}
+      
+      {/* 검색 모드에서 더 많은 데이터가 있고 로딩 중일 때 로딩 표시 */}
+      {isSearchMode && isLoadingMore && (
+        <LoadingContainer ref={loadingRef}>
+          <LoadingText>더 많은 책을 불러오는 중...</LoadingText>
+        </LoadingContainer>
+      )}
     </StyledBookList>
   );
 };

--- a/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
@@ -26,10 +26,13 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBott
     error,
     showEmptyState,
     showTabs,
+    hasNextPage,
+    isLoadingMore,
     setSearchQuery,
     handleTabChange,
     loadInitialData,
     performSearch,
+    loadMoreSearchResults,
   } = useBookSearch();
 
   // 컴포넌트가 열릴 때 초기 데이터 로드
@@ -101,7 +104,16 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBott
               onClose={onClose}
             />
 
-            {showBookList && <BookList books={filteredBooks} onBookSelect={handleBookSelect} />}
+            {showBookList && (
+              <BookList 
+                books={filteredBooks} 
+                onBookSelect={handleBookSelect}
+                onLoadMore={loadMoreSearchResults}
+                hasNextPage={hasNextPage}
+                isLoadingMore={isLoadingMore}
+                isSearchMode={searchQuery.trim() !== ''}
+              />
+            )}
           </BookListContainer>
         </Content>
       </BottomSheetContainer>

--- a/src/components/common/BookSearchBottomSheet/useBookSearch.ts
+++ b/src/components/common/BookSearchBottomSheet/useBookSearch.ts
@@ -14,6 +14,9 @@ export const useBookSearch = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchTimeoutId, setSearchTimeoutId] = useState<NodeJS.Timeout | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   // API에서 받은 데이터를 Book 타입으로 변환하는 함수
   const convertSavedBookToBook = (savedBook: SavedBook): Book => ({
@@ -76,32 +79,65 @@ export const useBookSearch = () => {
   };
 
   // 실제 검색 API 호출 함수
-  const performSearch = async (query: string) => {
+  const performSearch = async (query: string, page: number = 1, isNewSearch: boolean = true) => {
     if (!query.trim()) {
       setSearchResults([]);
+      setCurrentPage(1);
+      setHasNextPage(false);
       return;
     }
 
     try {
-      setIsLoading(true);
+      if (isNewSearch) {
+        setIsLoading(true);
+        setCurrentPage(1);
+      } else {
+        setIsLoadingMore(true);
+      }
       setError(null);
       
-      const response = await getSearchBooks(query.trim(), 1, true);
+      const response = await getSearchBooks(query.trim(), page, true);
       
       if (response.isSuccess) {
-        const convertedResults = convertToSearchedBooks(response.data.searchResult);
-        setSearchResults(convertedResults);
+        const startIndex = isNewSearch ? 0 : searchResults.length;
+        const convertedResults = convertToSearchedBooks(response.data.searchResult, startIndex);
+        
+        if (isNewSearch) {
+          setSearchResults(convertedResults);
+        } else {
+          setSearchResults(prev => [...prev, ...convertedResults]);
+        }
+        
+        setCurrentPage(page);
+        setHasNextPage(!response.data.last);
       } else {
         setError(response.message || '검색에 실패했습니다.');
-        setSearchResults([]);
+        if (isNewSearch) {
+          setSearchResults([]);
+        }
       }
     } catch (err) {
       console.error('검색 오류:', err);
       setError('검색 중 오류가 발생했습니다.');
-      setSearchResults([]);
+      if (isNewSearch) {
+        setSearchResults([]);
+      }
     } finally {
-      setIsLoading(false);
+      if (isNewSearch) {
+        setIsLoading(false);
+      } else {
+        setIsLoadingMore(false);
+      }
     }
+  };
+
+  // 더 많은 검색 결과 로드
+  const loadMoreSearchResults = async () => {
+    if (!searchQuery.trim() || isLoadingMore || !hasNextPage) {
+      return;
+    }
+    
+    await performSearch(searchQuery.trim(), currentPage + 1, false);
   };
 
   // 검색어 변경 핸들러 (디바운싱 적용)
@@ -120,6 +156,8 @@ export const useBookSearch = () => {
     } else {
       setSearchResults([]);
       setError(null);
+      setCurrentPage(1);
+      setHasNextPage(false);
     }
   };
 
@@ -165,7 +203,7 @@ export const useBookSearch = () => {
   const currentTabBooks = activeTab === 'saved' ? savedBooks : groupBooks;
   const hasBooks = isSearchMode ? searchResults.length > 0 : currentTabBooks.length > 0;
   const showEmptyState = !isLoading && !error && !hasBooks;
-  const showTabs = !isSearchMode && !showEmptyState;
+  const showTabs = !isSearchMode; // 검색 모드가 아닐 때는 항상 탭 표시
 
   // 컴포넌트 언마운트 시 타이머 정리
   useEffect(() => {
@@ -186,11 +224,14 @@ export const useBookSearch = () => {
     hasBooks,
     showEmptyState,
     showTabs,
+    hasNextPage,
+    isLoadingMore,
 
     // Actions
     setSearchQuery: handleSearchQueryChange,
     handleTabChange,
     loadInitialData,
     performSearch,
+    loadMoreSearchResults,
   };
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

생략

## 📝 작업 내용

이번 PR에서는 책 검색 바텀시트의 사용성을 크게 개선하는 두 가지 주요 문제를 해결했습니다.

**1. 탭 사라짐 문제 해결**
기존에는 '내 모임 책' 탭으로 전환했을 때 등록된 책이 없어서 예외처리 화면(빈 상태)이 표시되면 탭 자체가 사라지는 문제가 있었습니다. 이는 사용자가 다른 탭으로 다시 전환할 수 없게 만드는 치명적인 UX 문제였습니다. useBookSearch.ts의 `showTabs` 로직을 수정하여 검색 모드가 아닐 때는 빈 상태와 관계없이 항상 탭이 표시되도록 개선했습니다.

**2. 검색 결과 무한스크롤 기능 구현**
검색 결과가 많을 때 첫 번째 페이지만 표시되고 추가 결과를 볼 수 없었던 문제를 해결했습니다. API는 이미 페이지네이션을 지원하고 있었지만 클라이언트에서 이를 활용하지 못하고 있었습니다. Intersection Observer API를 활용하여 사용자가 목록 하단에 도달하면 자동으로 다음 페이지를 로드하는 무한스크롤을 구현했습니다. 또한 페이지 간 책 ID 중복을 방지하기 위해 각 페이지의 시작 인덱스를 고려한 고유 ID 생성 로직도 추가했습니다.

## 🕸️ 주요 변경사항
- useBookSearch.ts: 페이지네이션 상태 관리(`currentPage`, `hasNextPage`, `isLoadingMore`) 추가
- `performSearch` 함수: 신규 검색과 추가 로딩을 구분하여 결과를 누적하는 로직 구현
- BookList.tsx: `Intersection Observer`를 이용한 무한스크롤 감지 및 로딩 상태 표시
- getSearchBooks.ts: 페이지별 고유 ID 생성을 위한 `startIndex` 파라미터 추가