### PR TITLE
fix: QA 3차

### DIFF
--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -24,6 +24,10 @@ const LoadingSpinner = ({
 const Container = styled.div<{ fullHeight: boolean }>`
   display: flex;
   flex-direction: column;
+  width: 100%;
+  max-width: 767px;
+  min-width: 320px;
+  margin: 0 auto;
   justify-content: center;
   align-items: center;
   ${({ fullHeight }) =>

--- a/src/components/common/Post/PostBody.tsx
+++ b/src/components/common/Post/PostBody.tsx
@@ -9,6 +9,7 @@ const Container = styled.div`
   flex-direction: column;
   width: 100%;
   gap: 16px;
+  cursor: pointer;
 `;
 
 const PostContent = styled.div<{ hasImage: boolean }>`
@@ -82,9 +83,11 @@ const PostBody = ({
   }, [contentBody]);
 
   return (
-    <Container>
-      <BookInfoCard bookTitle={bookTitle} bookAuthor={bookAuthor} isbn={isbn} />
-      <PostContent hasImage={hasImage} onClick={() => handlePostClick(feedId)}>
+    <Container onClick={() => handlePostClick(feedId)}>
+      <div onClick={(e) => e.stopPropagation()}>
+        <BookInfoCard bookTitle={bookTitle} bookAuthor={bookAuthor} isbn={isbn} />
+      </div>
+      <PostContent hasImage={hasImage}>
         <div className="content" ref={contentRef}>
           {contentBody}
         </div>

--- a/src/components/common/Post/PostFooter.tsx
+++ b/src/components/common/Post/PostFooter.tsx
@@ -52,6 +52,7 @@ interface PostFooterProps {
   isLiked?: boolean;
   isPublic?: boolean;
   isDetail?: boolean;
+  onSaveToggle?: (feedId: number, newSaveState: boolean) => void;
 }
 
 const PostFooter = ({
@@ -63,6 +64,7 @@ const PostFooter = ({
   isLiked = false,
   isPublic = true,
   isDetail = false,
+  onSaveToggle,
 }: PostFooterProps) => {
   const [liked, setLiked] = useState(isLiked);
   const [likeCount, setLikeCount] = useState<number>(initialLikeCount);
@@ -90,9 +92,15 @@ const PostFooter = ({
       const response = await postSaveFeed(feedId, !saved);
 
       if (response.isSuccess) {
+        const newSaveState = response.data?.isSaved ?? !saved;
         // 성공 시 상태 업데이트
-        setSaved(response.data?.isSaved ?? !saved);
-        console.log('저장 상태 변경 성공:', response.data?.isSaved);
+        setSaved(newSaveState);
+        console.log('저장 상태 변경 성공:', newSaveState);
+        
+        // 부모 컴포넌트에 알림
+        if (onSaveToggle) {
+          onSaveToggle(feedId, newSaveState);
+        }
       } else {
         console.error('저장 상태 변경 실패:', response.message);
       }

--- a/src/components/feed/FeedPost.tsx
+++ b/src/components/feed/FeedPost.tsx
@@ -26,13 +26,13 @@ const BorderBottom = styled.div`
   background: #1c1c1c;
 `;
 
-const FeedPost = ({ showHeader, isLast, isMyFeed, ...postData }: FeedPostProps) => {
+const FeedPost = ({ showHeader, isLast, isMyFeed, onSaveToggle, ...postData }: FeedPostProps) => {
   return (
     <>
       <Container>
         {showHeader && <PostHeader {...postData} />}
         <PostBody {...postData} />
-        <PostFooter isMyFeed={!!isMyFeed} {...postData} />
+        <PostFooter isMyFeed={!!isMyFeed} onSaveToggle={onSaveToggle} {...postData} />
       </Container>
       {!isLast && <BorderBottom />}
     </>

--- a/src/components/feed/UserProfileItem.tsx
+++ b/src/components/feed/UserProfileItem.tsx
@@ -17,13 +17,18 @@ const UserProfileItem = ({
   userId,
   isLast,
   type,
+  isMyself,
 }: UserProfileItemProps) => {
   const navigate = useNavigate();
   const [followed, setFollowed] = useState(isFollowing);
   const { openPopup } = usePopupStore();
 
   const handleProfileClick = () => {
-    navigate(`/otherfeed/${userId}`);
+    if (isMyself) {
+      navigate(`/myfeed/${userId}`);
+    } else {
+      navigate(`/otherfeed/${userId}`);
+    }
   };
 
   const toggleFollow = async (e: React.MouseEvent) => {
@@ -62,7 +67,7 @@ const UserProfileItem = ({
             </div>
           </div>
         </div>
-        {type === 'followlist' && (
+        {type === 'followlist' && !isMyself && (
           <div className="followbutton" onClick={toggleFollow}>
             {followed ? '띱 취소' : '띱 하기'}
           </div>

--- a/src/components/group/Modal.styles.ts
+++ b/src/components/group/Modal.styles.ts
@@ -4,11 +4,14 @@ import styled from '@emotion/styled';
 export const Overlay = styled.div<{ $whiteBg?: boolean }>`
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   position: fixed;
   top: 0;
-  left: 0;
-  width: 100vw;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 767px;
+  min-width: 320px;
   height: 100vh;
   background: ${({ $whiteBg }) => ($whiteBg ? 'white' : colors.black.main)};
   z-index: 110;

--- a/src/pages/feed/FollowerListPage.tsx
+++ b/src/pages/feed/FollowerListPage.tsx
@@ -135,6 +135,7 @@ const FollowerListPage = () => {
             type={type as UserProfileType}
             isFollowing={user.isFollowing}
             isLast={index === userList.length - 1}
+            isMyself={user.isMyself}
           />
         ))}
       </UserProfileList>

--- a/src/pages/feed/FollowerListPage.tsx
+++ b/src/pages/feed/FollowerListPage.tsx
@@ -157,7 +157,9 @@ const Wrapper = styled.div`
 const TotalBar = styled.div`
   position: fixed;
   top: 0;
-  width: 727px;
+  width: 94.8%;
+  max-width: 727px;
+  min-width: 320px;
   padding: 76px 0px 4px 0px;
   border-bottom: 1px solid var(--color-darkgrey-dark);
   background-color: var(--color-black-main);

--- a/src/pages/searchBook/SearchBook.tsx
+++ b/src/pages/searchBook/SearchBook.tsx
@@ -238,7 +238,7 @@ const SearchBook = () => {
 
   if (isLoading || error || !bookDetail) {
     if (isLoading) {
-      return <LoadingSpinner fullHeight={true} />;
+      return <LoadingSpinner fullHeight={true} size="large" message="책 정보 불러오는 중..." />;
     }
     return (
       <Wrapper>

--- a/src/types/follow.ts
+++ b/src/types/follow.ts
@@ -6,4 +6,5 @@ export interface FollowData {
   aliasColor?: string;
   followerCount?: number;
   isFollowing?: boolean;
+  isMyself?: boolean;
 }

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -31,6 +31,7 @@ export interface FeedPostProps extends PostData {
   isMyFeed?: boolean;
   isTotalFeed?: boolean;
   isLast?: boolean;
+  onSaveToggle?: (feedId: number, newSaveState: boolean) => void;
 }
 
 export type PostBodyProps = Pick<

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -10,4 +10,5 @@ export interface UserProfileItemProps {
   userId: number;
   isLast?: boolean;
   type?: UserProfileType;
+  isMyself?: boolean;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
없음

## 📝작업 내용
- 로딩스피너 design수정
- 내 모임방 모달 design수정
- 다른 사용자 띱 목록 조회 API isMyself 변수 추가

## 💬리뷰 요구사항
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 팔로워 목록에서 자기 자신 인식: 내 프로필 클릭 시 내 피드로 이동하고, 자기자신이면 팔로우 버튼을 숨깁니다.
  - 게시글 저장 토글 연동: 저장/해제 시 상위로 변경을 통지해 저장 목록에 즉시 반영됩니다.
  - 저장 페이지 초기 로딩 개선: 저장된 피드와 도서를 병렬로 불러오고 전체 로딩 스피너를 표시합니다.
  - 포스트 클릭 동작 개선: 게시글 영역 클릭 시 피드를 새 탭으로 열고 도서 영역 클릭은 예외 처리됩니다.

- **Style**
  - 로딩 스피너 컨테이너에 가로 폭 제한(최대/최소)과 중앙 정렬 적용.
  - 그룹 모달 오버레이를 화면 중앙에 정렬하고 반응형 폭 제한 추가.

- **UX**
  - 검색/도서 로딩 시 더 큰 로딩 스피너와 사용자 메시지 표시.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->