### PR TITLE
fix: QA 사항 반영

### DIFF
--- a/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.styled.ts
+++ b/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.styled.ts
@@ -249,7 +249,7 @@ export const EmptyContainer = styled.div`
 `;
 
 export const EmptyText = styled.p`
-  color: #e0e0e0;};
+  color: #e0e0e0;
   font-size: ${typography.fontSize.sm};
   font-weight: ${typography.fontWeight.regular};
   margin: 0;

--- a/src/components/common/TitleHeader.tsx
+++ b/src/components/common/TitleHeader.tsx
@@ -7,7 +7,7 @@ const HeaderWrapper = styled.div`
   left: 0;
   right: 0;
   z-index: 100;
-  max-width: 766px;
+  max-width: 767px;
   margin: 0 auto;
   padding: 16px 20px;
   background-color: ${colors.black.main};

--- a/src/components/group/Modal.styles.ts
+++ b/src/components/group/Modal.styles.ts
@@ -12,7 +12,8 @@ export const Overlay = styled.div<{ $whiteBg?: boolean }>`
   width: 100%;
   max-width: 767px;
   min-width: 320px;
-  height: 100vh;
+  padding-top: 56px;
+  min-height: 100vh;
   background: ${({ $whiteBg }) => ($whiteBg ? 'white' : colors.black.main)};
   z-index: 110;
 `;

--- a/src/components/group/RecruitingGroupBox.tsx
+++ b/src/components/group/RecruitingGroupBox.tsx
@@ -68,6 +68,7 @@ export function RecruitingGroupBox({ groups, title }: Props) {
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+  height: 100%;
   min-width: 260px;
   max-width: 704px;
   width: 100%;
@@ -133,6 +134,7 @@ const EmptyContent = styled.div`
   justify-content: center;
   align-items: center;
   gap: 8px;
+  height: 133px;
   padding: 60px 20px;
   grid-column: 1 / -1;
 `;

--- a/src/components/group/RecruitingGroupCarousel.tsx
+++ b/src/components/group/RecruitingGroupCarousel.tsx
@@ -112,5 +112,5 @@ const Item = styled.div`
   max-width: 640px;
   scroll-snap-align: center;
   transition: transform 0.2s;
-  height: 800px;
+  /* height: 800px; */
 `;

--- a/src/components/search/MostSearchedBooks.tsx
+++ b/src/components/search/MostSearchedBooks.tsx
@@ -78,7 +78,7 @@ export default function MostSearchedBooks() {
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 36px 20px 0 20px;
+  padding: 32px 20px 0 20px;
   background-color: var(--color-black-main);
   margin-bottom: 72px;
 `;

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -52,7 +52,7 @@ const SearchBarWrapper = styled.div`
   background-color: var(--color-darkgrey-main);
   border-radius: 12px;
   width: calc(100% - 40px);
-  margin: 76px 20px 16px 20px;
+  margin: 16px 20px;
   padding: 8px 12px;
   box-sizing: border-box;
 

--- a/src/pages/Guide.tsx
+++ b/src/pages/Guide.tsx
@@ -236,7 +236,7 @@ const Header = styled.div<{ active: boolean }>`
   flex-direction: row;
   justify-content: flex-end;
   align-items: center;
-  max-width: 766px;
+  max-width: 767px;
   margin: 0 auto;
   padding: 16px 20px;
   background-color: ${colors.black.main};

--- a/src/pages/feed/UserSearch.tsx
+++ b/src/pages/feed/UserSearch.tsx
@@ -44,8 +44,10 @@ const UserSearch = () => {
   };
 
   useEffect(() => {
-    fetchRecentSearches();
-  }, []);
+    if (!isSearched) {
+      fetchRecentSearches();
+    }
+  }, [isSearched]);
 
   const handleChange = (value: string) => {
     setSearchTerm(value);
@@ -64,7 +66,8 @@ const UserSearch = () => {
       const response = await deleteRecentSearch(recentSearchId);
 
       if (response.isSuccess) {
-        setRecentSearches(prev => prev.filter(item => item.recentSearchId !== recentSearchId));
+        // 삭제 성공 후 최근 검색어 리스트를 다시 호출
+        await fetchRecentSearches();
       } else {
         console.error('최근 검색어 삭제 실패:', response.message);
       }
@@ -164,7 +167,7 @@ const Wrapper = styled.div`
 
 const SearchBarContainer = styled.div`
   position: fixed;
-  top: 0;
+  top: 56px;
   left: 0;
   right: 0;
   max-width: 767px;

--- a/src/pages/group/Group.tsx
+++ b/src/pages/group/Group.tsx
@@ -104,10 +104,11 @@ const Wrapper = styled.div`
   position: relative;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   min-width: 320px;
   max-width: 767px;
-  height: 100%;
+  min-height: 100vh;
   margin: 0 auto;
+  padding-top: 56px;
   background-color: #121212;
 `;

--- a/src/pages/groupSearch/GroupSearch.tsx
+++ b/src/pages/groupSearch/GroupSearch.tsx
@@ -54,6 +54,13 @@ const GroupSearch = () => {
     })();
   }, []);
 
+  // searchStatus가 'idle'로 변경될 때 최근 검색어 새로고침
+  useEffect(() => {
+    if (searchStatus === 'idle') {
+      fetchRecentSearches();
+    }
+  }, [searchStatus]);
+
   const fetchRecentSearches = async () => {
     try {
       const response = await getRecentSearch('ROOM');

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -335,6 +335,7 @@ const Header = styled.div`
   top: 0;
   left: 0;
   right: 0;
+  height: 56px;
   max-width: 767px;
   margin: 0 auto;
   color: ${colors.white};
@@ -347,7 +348,7 @@ const Header = styled.div`
 
 const SearchBarContainer = styled.div`
   position: fixed;
-  top: 0;
+  top: 56px;
   left: 0;
   right: 0;
   max-width: 767px;


### PR DESCRIPTION
## #️⃣연관된 이슈
없음

## 📝작업 내용
- 모임방 메인페이지에서 컨텐츠가 없음에도 스크롤되는 현상 수정 <br/>
<img width="984" height="989" alt="image" src="https://github.com/user-attachments/assets/247a45f1-5e31-44f4-9276-d47c299c5e04" /> <br/>
<img width="891" height="986" alt="image" src="https://github.com/user-attachments/assets/503bc855-1e47-4cfd-8e76-5e505ba79d59" /> <br/>
- 검색바 design 수정 : 검색바가 여러곳에서 재사용됨에 따라 페이지별 css style 수정이 불가피했습니다. <br/>
- 사용자 검색 > 최근 검색어 : 사용성을 높이기 위해 isSearched: true -> false 로 변경되었을 때 최근검색어 리스트 호출을 다시 하게끔 코드 수정하였습니다.
https://github.com/user-attachments/assets/3acc4336-e1f7-47ca-8c6e-d29e7bfcb7b7
- 모임 검색 > 최근 검색어 : 마찬가지로 최근검색어 또한 searchStatus === 'idle' 로 변경될 때 최근검색어 리스트를 새로고침하게끔 했습니다.

## 💬리뷰 요구사항
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 헤더 최대 너비 767px로 통일, 헤더 높이 56px 적용 및 검색바를 헤더 아래로 이동.
  - 모달 오버레이를 min-height 기반으로 변경하고 상단 여백 56px 추가.
  - 그룹 페이지 정렬을 상단 정렬로 변경, min-height 100vh와 상단 패딩 56px 적용.
  - 캐러셀 아이템 고정 높이 제거, 레이아웃 유연성 향상.
  - 검색 섹션 패딩/마진 조정으로 상단 여백 축소.
  - 리크루팅 박스 및 빈 상태 영역 높이 보정.

- 버그 수정
  - 빈 텍스트 색상 스타일의 문법 오류 수정.
  - 최근 검색: 삭제 후 서버 재조회 및 상태가 idle일 때 자동 갱신으로 목록 동기화 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->