### PR TITLE
fix: 내 피드 > 프로필 > 띱 목록 조회 안되는 이슈 수정

### DIFF
--- a/src/components/feed/MyFeed.tsx
+++ b/src/components/feed/MyFeed.tsx
@@ -41,6 +41,7 @@ const MyFeed = ({ showHeader, posts = [], isLast = false }: FeedListProps) => {
   return (
     <Container>
       <Profile
+        userId={profileData.userId}
         showFollowButton={false}
         profileImageUrl={profileData.profileImageUrl}
         nickname={profileData.nickname}

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,5 +1,6 @@
 // 내 프로필 정보 타입
 export interface MyProfileData {
+  userId: number;
   profileImageUrl: string;
   nickname: string;
   aliasName: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
내 피드 > 띱 목록 더보기 클릭을 해도 작동하지 않던 문제를 해결함.

### 스크린샷
<img width="2048" height="1272" alt="image" src="https://github.com/user-attachments/assets/247ce6b2-dfdd-442e-a949-ebffabc3cba6" />

## 💬리뷰 요구사항
없음