### PR TITLE
fix: 책 검색 레이아웃 이미지 깨짐

### DIFF
--- a/src/components/search/BookSearchResult.tsx
+++ b/src/components/search/BookSearchResult.tsx
@@ -104,6 +104,7 @@ const ResultHeader = styled.div`
 const Cover = styled.img`
   width: 80px;
   height: 107px;
+  flex-shrink: 0;
   object-fit: cover;
 `;
 
@@ -111,12 +112,20 @@ const BookInfo = styled.div`
   display: flex;
   flex-direction: column;
   margin-left: 12px;
+  min-width: 0;
 `;
 
 const Title = styled.h3`
   font-size: ${typography.fontSize.base};
   font-weight: ${typography.fontWeight.semibold};
   color: ${colors.white};
+  line-height: 20px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
 `;
 
 const Subtitle = styled.span`
@@ -124,6 +133,7 @@ const Subtitle = styled.span`
   font-weight: ${typography.fontWeight.medium};
   color: ${colors.grey[200]};
   margin-top: 8px;
+  line-height: 20px;
 `;
 
 const EmptyWrapper = styled.div`

--- a/src/pages/searchBook/SearchBook.styled.ts
+++ b/src/pages/searchBook/SearchBook.styled.ts
@@ -175,6 +175,10 @@ export const FeedSection = styled.section`
   margin-top: 20px;
 `;
 
+export const FeedPostContainer = styled.div`
+  min-height: 50vh;
+`;
+
 export const FeedTitle = styled.h2`
   color: ${colors.white};
   font-size: ${typography.fontSize.lg};

--- a/src/pages/searchBook/SearchBook.tsx
+++ b/src/pages/searchBook/SearchBook.tsx
@@ -20,6 +20,7 @@ import {
   EmptyState,
   EmptyTitle,
   EmptySubText,
+  FeedPostContainer,
 } from './SearchBook.styled';
 import { useNavigate, useParams } from 'react-router-dom';
 import leftArrow from '../../assets/common/leftArrow.svg';
@@ -298,11 +299,10 @@ const SearchBook = () => {
             setSelectedFilter={filter => setSelectedFilter(filter as (typeof FILTER)[number])}
           />
         </FilterContainer>
-
         {isLoadingFeeds && feeds.length === 0 ? (
           <LoadingBox>불러오는 중...</LoadingBox>
         ) : feeds.length > 0 ? (
-          <>
+          <FeedPostContainer>
             {feeds.map((post, idx) => (
               <div
                 key={post.feedId}
@@ -328,7 +328,7 @@ const SearchBook = () => {
                 />
               </div>
             ))}
-          </>
+          </FeedPostContainer>
         ) : (
           <EmptyState>
             <EmptyTitle>이 책으로 작성된 피드가 없어요.</EmptyTitle>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

[FIX] 9월 1주차 QA 사항 - 호준 #225

## 📝작업 내용

- 책 검색 레이아웃 이미지 깨짐 수정 + 디자인 요구사항 추가 반영
  
  <img width="748" height="542" alt="image" src="https://github.com/user-attachments/assets/e5519e2a-996d-4d05-af2a-94886cf8649b" />

- 책 상세 페이지 하단 여백 발생

  - post가 비어있을때와 동일하게 min-height 부여


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 도서 검색 결과 카드 UI 개선: 표지 이미지가 플렉스 레이아웃에서 축소되지 않도록 처리하고, 텍스트 레이아웃 안정화를 위해 min-width 적용. 제목은 2줄까지만 말줄임 처리(-webkit-line-clamp)로 가독성 향상, 서브타이틀 라인하이트 정리.
  - 검색 결과 리스트를 감싸는 컨테이너를 추가해 화면 최소 높이(min-height: 50vh) 보장. 로딩/빈 상태에서도 레이아웃이 흔들리지 않고 일관된 화면 구성 제공.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->