### PR TITLE
feat: rooms API 추가 연동 (방 나가기 / 기록 수정 / 투표 수정)

### DIFF
--- a/src/api/record/updateRecord.ts
+++ b/src/api/record/updateRecord.ts
@@ -1,0 +1,44 @@
+import { apiClient } from '../index';
+import type { UpdateRecordRequest, UpdateRecordData, ApiResponse } from '@/types/record';
+
+// API 응답 타입
+export type UpdateRecordResponse = ApiResponse<UpdateRecordData>;
+
+// 기록 수정 API 함수
+export const updateRecord = async (
+  roomId: number,
+  recordId: number,
+  recordData: UpdateRecordRequest,
+): Promise<UpdateRecordResponse> => {
+  try {
+    const response = await apiClient.patch<UpdateRecordResponse>(
+      `/rooms/${roomId}/records/${recordId}`,
+      recordData,
+    );
+    return response.data;
+  } catch (error) {
+    console.error('기록 수정 API 오류:', error);
+    throw error;
+  }
+};
+
+/*
+사용 예시:
+const recordData: UpdateRecordRequest = {
+  content: "수정된 기록 내용입니다~~"
+};
+
+try {
+  const result = await updateRecord(1, 123, recordData);
+  if (result.isSuccess) {
+    console.log("수정된 방 ID:", result.data.roomId);
+    // 성공 처리 로직
+  } else {
+    console.error("기록 수정 실패:", result.message);
+    // 실패 처리 로직
+  }
+} catch (error) {
+  console.error("API 호출 오류:", error);
+  // 에러 처리 로직
+}
+*/

--- a/src/api/record/updateVote.ts
+++ b/src/api/record/updateVote.ts
@@ -1,0 +1,44 @@
+import { apiClient } from '../index';
+import type { UpdateVoteRequest, UpdateVoteData, ApiResponse } from '@/types/record';
+
+// API 응답 타입
+export type UpdateVoteResponse = ApiResponse<UpdateVoteData>;
+
+// 투표 수정 API 함수
+export const updateVote = async (
+  roomId: number,
+  voteId: number,
+  voteData: UpdateVoteRequest,
+): Promise<UpdateVoteResponse> => {
+  try {
+    const response = await apiClient.patch<UpdateVoteResponse>(
+      `/rooms/${roomId}/votes/${voteId}`,
+      voteData,
+    );
+    return response.data;
+  } catch (error) {
+    console.error('투표 수정 API 오류:', error);
+    throw error;
+  }
+};
+
+/*
+사용 예시:
+const voteData: UpdateVoteRequest = {
+  content: "수정된 투표 내용입니다~"
+};
+
+try {
+  const result = await updateVote(1, 123, voteData);
+  if (result.isSuccess) {
+    console.log("수정된 방 ID:", result.data.roomId);
+    // 성공 처리 로직
+  } else {
+    console.error("투표 수정 실패:", result.message);
+    // 실패 처리 로직
+  }
+} catch (error) {
+  console.error("API 호출 오류:", error);
+  // 에러 처리 로직
+}
+*/

--- a/src/api/rooms/leaveRoom.ts
+++ b/src/api/rooms/leaveRoom.ts
@@ -1,0 +1,21 @@
+import { apiClient } from '../index';
+
+// 방 나가기 응답 타입
+export interface LeaveRoomResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data: string;
+}
+
+// 방 나가기 API 함수
+export const leaveRoom = async (roomId: number): Promise<LeaveRoomResponse> => {
+  try {
+    const response = await apiClient.delete<LeaveRoomResponse>(`/rooms/${roomId}/leave`);
+
+    return response.data;
+  } catch (error) {
+    console.error('방 나가기 API 오류:', error);
+    throw error;
+  }
+};

--- a/src/components/memory/RecordItem/RecordItem.tsx
+++ b/src/components/memory/RecordItem/RecordItem.tsx
@@ -125,9 +125,20 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
   };
 
   const handleEdit = useCallback(() => {
-    // API 개발 전까지 수정 기능 비활성화
-    console.log('수정 기능은 개발 중입니다.');
-  }, []);
+    if (!roomId) return;
+    
+    // 바텀시트 닫기
+    closePopup();
+    
+    // 기록 수정 페이지로 이동 (기록 정보를 쿼리 파라미터로 전달)
+    const params = new URLSearchParams({
+      content: content,
+      pageRange: pageRange || '',
+      recordType: recordType || 'normal'
+    });
+    
+    navigate(`/memory/record/edit/${roomId}/${record.id}?${params.toString()}`);
+  }, [roomId, record.id, content, pageRange, recordType, navigate, closePopup]);
 
   const handleDelete = useCallback(async () => {
     const currentRoomId = roomId || '1';

--- a/src/components/memory/RecordItem/RecordItem.tsx
+++ b/src/components/memory/RecordItem/RecordItem.tsx
@@ -130,15 +130,27 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
     // 바텀시트 닫기
     closePopup();
     
-    // 기록 수정 페이지로 이동 (기록 정보를 쿼리 파라미터로 전달)
-    const params = new URLSearchParams({
-      content: content,
-      pageRange: pageRange || '',
-      recordType: recordType || 'normal'
-    });
-    
-    navigate(`/memory/record/edit/${roomId}/${record.id}?${params.toString()}`);
-  }, [roomId, record.id, content, pageRange, recordType, navigate, closePopup]);
+    if (type === 'poll') {
+      // 투표 수정 페이지로 이동 (투표 정보를 쿼리 파라미터로 전달)
+      const params = new URLSearchParams({
+        content: content,
+        pageRange: pageRange || '',
+        recordType: recordType || 'normal',
+        options: JSON.stringify(pollOptions?.map(option => option.text) || [])
+      });
+      
+      navigate(`/memory/poll/edit/${roomId}/${record.id}?${params.toString()}`);
+    } else {
+      // 기록 수정 페이지로 이동 (기록 정보를 쿼리 파라미터로 전달)
+      const params = new URLSearchParams({
+        content: content,
+        pageRange: pageRange || '',
+        recordType: recordType || 'normal'
+      });
+      
+      navigate(`/memory/record/edit/${roomId}/${record.id}?${params.toString()}`);
+    }
+  }, [roomId, record.id, content, pageRange, recordType, type, pollOptions, navigate, closePopup]);
 
   const handleDelete = useCallback(async () => {
     const currentRoomId = roomId || '1';

--- a/src/components/pollwrite/PollCreationSection.tsx
+++ b/src/components/pollwrite/PollCreationSection.tsx
@@ -17,6 +17,8 @@ interface PollCreationSectionProps {
   onContentChange: (value: string) => void;
   options: string[];
   onOptionsChange: (options: string[]) => void;
+  isEditMode?: boolean; // 수정 모드 여부
+  autoFocus?: boolean; // 자동 포커스 및 커서 위치 설정 여부
 }
 
 const PollCreationSection = ({
@@ -24,11 +26,14 @@ const PollCreationSection = ({
   onContentChange,
   options,
   onOptionsChange,
+  isEditMode = false,
+  autoFocus = false,
 }: PollCreationSectionProps) => {
   const maxContentLength = 20;
   const maxOptions = 5;
   const [focusStates, setFocusStates] = useState<boolean[]>(options.map(() => false));
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const contentInputRef = useRef<HTMLInputElement>(null);
 
   const handleContentChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -87,10 +92,22 @@ const PollCreationSection = ({
     }
   }, [options.length, focusStates.length]);
 
+  // autoFocus 처리
+  useEffect(() => {
+    if (autoFocus && contentInputRef.current) {
+      const input = contentInputRef.current;
+      input.focus();
+      // 커서를 텍스트 끝으로 이동
+      const length = input.value.length;
+      input.setSelectionRange(length, length);
+    }
+  }, [autoFocus]);
+
   return (
     <Section>
       <PollContentContainer>
         <PollInput
+          ref={contentInputRef}
           placeholder="투표 내용을 20자 이내로 입력하세요."
           value={content}
           onChange={handleContentChange}
@@ -111,23 +128,30 @@ const PollCreationSection = ({
               onFocus={() => handleOptionFocus(index)}
               onBlur={() => handleOptionBlur(index)}
               maxLength={20}
+              disabled={isEditMode}
+              readOnly={isEditMode}
             />
-            {/* 텍스트가 있을 때는 X 아이콘으로 텍스트 삭제 */}
-            {option.trim() !== '' && (
-              <DeleteButton onClick={() => handleClearOption(index)}>
-                <img src={closeIcon} alt="텍스트 삭제" />
-              </DeleteButton>
-            )}
-            {/* 텍스트가 없고 3번째 항목(index >= 2)부터만 쓰레기통 아이콘으로 항목 삭제 */}
-            {option.trim() === '' && index >= 2 && (
-              <DeleteButton onClick={() => handleRemoveOption(index)}>
-                <img src={trashIcon} alt="항목 삭제" />
-              </DeleteButton>
+            {/* 수정 모드가 아니어야만 삭제 버튼 표시 */}
+            {!isEditMode && (
+              <>
+                {/* 텍스트가 있을 때는 X 아이콘으로 텍스트 삭제 */}
+                {option.trim() !== '' && (
+                  <DeleteButton onClick={() => handleClearOption(index)}>
+                    <img src={closeIcon} alt="텍스트 삭제" />
+                  </DeleteButton>
+                )}
+                {/* 텍스트가 없고 3번째 항목(index >= 2)부터만 쓰레기통 아이콘으로 항목 삭제 */}
+                {option.trim() === '' && index >= 2 && (
+                  <DeleteButton onClick={() => handleRemoveOption(index)}>
+                    <img src={trashIcon} alt="항목 삭제" />
+                  </DeleteButton>
+                )}
+              </>
             )}
           </OptionInputContainer>
         ))}
 
-        {options.length < maxOptions && (
+        {!isEditMode && options.length < maxOptions && (
           <AddOptionButton onClick={handleAddOption}>항목 추가</AddOptionButton>
         )}
       </PollOptionsContainer>

--- a/src/components/recordwrite/PageRangeSection.tsx
+++ b/src/components/recordwrite/PageRangeSection.tsx
@@ -35,6 +35,8 @@ interface PageRangeSectionProps {
   onOverallToggle: () => void;
   readingProgress: number;
   isOverviewPossible: boolean;
+  isDisabled?: boolean;
+  hideToggle?: boolean; // 총평 토글 버튼 숨김 여부
 }
 
 const PageRangeSection = ({
@@ -45,6 +47,8 @@ const PageRangeSection = ({
   isOverallEnabled,
   onOverallToggle,
   readingProgress,
+  isDisabled = false,
+  hideToggle = false,
 }: PageRangeSectionProps) => {
   const [hasError, setHasError] = useState(false);
   const [showRedTooltip, setShowRedTooltip] = useState(false);
@@ -112,12 +116,13 @@ const PageRangeSection = ({
                 onChange={handleInputChange}
                 inputMode="numeric"
                 inputLength={pageRange.length || lastRecordedPage.toString().length}
+                disabled={isDisabled}
               />
               <PageSuffix>/{totalPages}p</PageSuffix>
             </InputWrapper>
           )}
         </PageInputContainer>
-        {!isOverallEnabled && pageRange && (
+        {!isOverallEnabled && pageRange && !isDisabled && (
           <CloseButton onClick={handleClear}>
             <img src={closeIcon} alt="지우기" />
           </CloseButton>
@@ -148,21 +153,23 @@ const PageRangeSection = ({
             <TooltipArrow variant="green" />
           </Tooltip>
         )}
-        <ToggleContainer>
-          <LeftSection>
-            <InfoIcon onClick={handleInfoClick}>
-              <img src={infoIcon} alt="정보" />
-            </InfoIcon>
-            <ToggleLabel disabled={!canUseOverall}>총평</ToggleLabel>
-          </LeftSection>
-          <ToggleSwitch
-            active={isOverallEnabled}
-            onClick={handleToggleClick}
-            disabled={!canUseOverall}
-          >
-            <ToggleSlider active={isOverallEnabled} disabled={!canUseOverall} />
-          </ToggleSwitch>
-        </ToggleContainer>
+        {!hideToggle && (
+          <ToggleContainer>
+            <LeftSection>
+              <InfoIcon onClick={handleInfoClick}>
+                <img src={infoIcon} alt="정보" />
+              </InfoIcon>
+              <ToggleLabel disabled={!canUseOverall}>총평</ToggleLabel>
+            </LeftSection>
+            <ToggleSwitch
+              active={isOverallEnabled}
+              onClick={handleToggleClick}
+              disabled={!canUseOverall || isDisabled}
+            >
+              <ToggleSlider active={isOverallEnabled} disabled={!canUseOverall} />
+            </ToggleSwitch>
+          </ToggleContainer>
+        )}
       </TooltipContainer>
     </Section>
   );

--- a/src/components/recordwrite/RecordContentSection.tsx
+++ b/src/components/recordwrite/RecordContentSection.tsx
@@ -10,9 +10,14 @@ import {
 interface RecordContentSectionProps {
   content: string;
   onContentChange: (value: string) => void;
+  autoFocus?: boolean; // 자동 포커스 및 커서 위치 설정 여부
 }
 
-const RecordContentSection = ({ content, onContentChange }: RecordContentSectionProps) => {
+const RecordContentSection = ({
+  content,
+  onContentChange,
+  autoFocus = false,
+}: RecordContentSectionProps) => {
   const maxLength = 500;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -31,10 +36,19 @@ const RecordContentSection = ({ content, onContentChange }: RecordContentSection
     adjustHeight();
   }, [content]);
 
-  // 컴포넌트 마운트 시 초기 높이 설정
+  // 컴포넌트 마운트 시 초기 높이 설정 및 autoFocus 처리
   useEffect(() => {
     adjustHeight();
-  }, []);
+    
+    // autoFocus가 true이고 textarea가 있으면 포커스 및 커서를 끝으로 이동
+    if (autoFocus && textareaRef.current) {
+      const textarea = textareaRef.current;
+      textarea.focus();
+      // 커서를 텍스트 끝으로 이동
+      const length = textarea.value.length;
+      textarea.setSelectionRange(length, length);
+    }
+  }, [autoFocus]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onContentChange(e.target.value);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -64,6 +64,7 @@ const Router = () => {
         <Route path="memory/record/write/:roomId" element={<RecordWrite />} />
         <Route path="memory/record/edit/:roomId/:recordId" element={<RecordWrite />} />
         <Route path="memory/poll/write/:roomId" element={<PollWrite />} />
+        <Route path="memory/poll/edit/:roomId/:voteId" element={<PollWrite />} />
         <Route path="feed" element={<Feed />} />
         <Route path="feed/search" element={<UserSearch />} />
         <Route path="feed/:feedId" element={<FeedDetailPage />} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -62,6 +62,7 @@ const Router = () => {
         <Route path="memory" element={<Memory />} />
         <Route path="rooms/:roomId/memory" element={<Memory />} />
         <Route path="memory/record/write/:roomId" element={<RecordWrite />} />
+        <Route path="memory/record/edit/:roomId/:recordId" element={<RecordWrite />} />
         <Route path="memory/poll/write/:roomId" element={<PollWrite />} />
         <Route path="feed" element={<Feed />} />
         <Route path="feed/search" element={<UserSearch />} />

--- a/src/pages/recordwrite/RecordWrite.tsx
+++ b/src/pages/recordwrite/RecordWrite.tsx
@@ -338,7 +338,11 @@ const RecordWrite = () => {
           isDisabled={isEditMode} // 수정 모드일 때 비활성화
           hideToggle={isEditMode} // 수정 모드일 때 총평 토글 숨김
         />
-        <RecordContentSection content={content} onContentChange={setContent} />
+        <RecordContentSection 
+          content={content} 
+          onContentChange={setContent} 
+          autoFocus={isEditMode}
+        />
       </Container>
     </>
   );

--- a/src/pages/recordwrite/RecordWrite.tsx
+++ b/src/pages/recordwrite/RecordWrite.tsx
@@ -15,7 +15,7 @@ const RecordWrite = () => {
   const navigate = useNavigate();
   const { roomId, recordId } = useParams<{ roomId: string; recordId: string }>();
   const [searchParams] = useSearchParams();
-  
+
   // 수정 모드인지 판단
   const isEditMode = Boolean(recordId);
   const { openSnackbar } = usePopupActions();
@@ -24,7 +24,6 @@ const RecordWrite = () => {
   const [content, setContent] = useState('');
   const [isOverallEnabled, setIsOverallEnabled] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  
 
   // API에서 받아올 데이터
   const [totalPages, setTotalPages] = useState(0);
@@ -47,35 +46,35 @@ const RecordWrite = () => {
 
       try {
         setIsLoading(true);
-        
+
         if (isEditMode) {
           // 수정 모드: 쿼리 파라미터에서 기존 내용과 페이지 정보 로드
           const existingContent = searchParams.get('content');
           const existingPageRange = searchParams.get('pageRange');
           const existingRecordType = searchParams.get('recordType');
-          
+
           if (existingContent) {
             setContent(decodeURIComponent(existingContent));
           }
-          
+
           if (existingPageRange) {
             setPageRange(existingPageRange);
           }
-          
+
           if (existingRecordType === 'overall') {
             setIsOverallEnabled(true);
           }
-          
+
           // 수정 모드에서도 전체 페이지 수는 필요하므로 책 정보 조회
           const response = await getBookPage(parseInt(roomId));
           if (response.isSuccess) {
             setTotalPages(response.data.totalBookPage);
           }
-          
+
           setIsLoading(false);
           return;
         }
-        
+
         // 생성 모드: 책 페이지 정보 조회
         const response = await getBookPage(parseInt(roomId));
 
@@ -91,8 +90,6 @@ const RecordWrite = () => {
           });
         }
       } catch (error) {
-        console.error('데이터 로드 오류:', error);
-
         let errorMessage = '데이터를 불러오는 중 오류가 발생했습니다.';
 
         if (error && typeof error === 'object' && 'response' in error) {
@@ -167,14 +164,9 @@ const RecordWrite = () => {
           content: content.trim(),
         };
 
-        console.log('기록 수정 API 호출:', updateData);
-        console.log('roomId:', roomId, 'recordId:', recordId);
-
         const response = await updateRecord(parseInt(roomId), parseInt(recordId), updateData);
 
         if (response.isSuccess) {
-          console.log('기록 수정 성공:', response.data);
-          
           openSnackbar({
             message: '기록 수정을 완료했어요.',
             variant: 'top',
@@ -186,7 +178,6 @@ const RecordWrite = () => {
             replace: true,
           });
         } else {
-          console.error('기록 수정 실패:', response.message);
           openSnackbar({
             message: response.message || '기록 수정에 실패했습니다.',
             variant: 'top',
@@ -229,22 +220,15 @@ const RecordWrite = () => {
           content: content.trim(),
         };
 
-        console.log('기록 생성 API 호출:', recordData);
-        console.log('roomId:', roomId);
-
         // API 호출
         const response = await createRecord(parseInt(roomId), recordData);
 
         if (response.isSuccess) {
-          console.log('기록 생성 성공:', response.data);
-
           // 성공 시 기록장으로 이동
           navigate(`/rooms/${roomId}/memory`, {
             replace: true,
           });
         } else {
-          // API 에러 응답 처리
-          console.error('기록 생성 실패:', response.message);
           openSnackbar({
             message: response.message || '기록 작성에 실패했습니다.',
             variant: 'top',
@@ -254,10 +238,10 @@ const RecordWrite = () => {
         }
       }
     } catch (error) {
-      console.error('기록 저장 실패:', error);
-
       // 에러 타입에 따른 메시지 처리
-      let errorMessage = isEditMode ? '기록 수정 중 오류가 발생했습니다.' : '기록 저장 중 오류가 발생했습니다.';
+      let errorMessage = isEditMode
+        ? '기록 수정 중 오류가 발생했습니다.'
+        : '기록 저장 중 오류가 발생했습니다.';
 
       if (error && typeof error === 'object' && 'response' in error) {
         const axiosError = error as {
@@ -295,7 +279,7 @@ const RecordWrite = () => {
       <>
         <TitleHeader
           leftIcon={<img src={leftArrow} alt="뒤로가기" />}
-          title={isEditMode ? "기록 수정" : "기록 작성"}
+          title={isEditMode ? '기록 수정' : '기록 작성'}
           onLeftClick={handleBackClick}
         />
         <Container>
@@ -319,7 +303,7 @@ const RecordWrite = () => {
     <>
       <TitleHeader
         leftIcon={<img src={leftArrow} alt="뒤로가기" />}
-        title={isEditMode ? "기록 수정" : "기록 작성"}
+        title={isEditMode ? '기록 수정' : '기록 작성'}
         rightButton={<div className="complete">완료</div>}
         onLeftClick={handleBackClick}
         onRightClick={handleCompleteClick}
@@ -338,9 +322,9 @@ const RecordWrite = () => {
           isDisabled={isEditMode} // 수정 모드일 때 비활성화
           hideToggle={isEditMode} // 수정 모드일 때 총평 토글 숨김
         />
-        <RecordContentSection 
-          content={content} 
-          onContentChange={setContent} 
+        <RecordContentSection
+          content={content}
+          onContentChange={setContent}
           autoFocus={isEditMode}
         />
       </Container>

--- a/src/pages/recordwrite/RecordWrite.tsx
+++ b/src/pages/recordwrite/RecordWrite.tsx
@@ -1,24 +1,30 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import TitleHeader from '../../components/common/TitleHeader';
 import PageRangeSection from '../../components/recordwrite/PageRangeSection';
 import RecordContentSection from '../../components/recordwrite/RecordContentSection';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import { Container } from './RecordWrite.styled';
 import { createRecord } from '../../api/record/createRecord';
-import type { CreateRecordRequest } from '../../types/record';
+import { updateRecord } from '../../api/record/updateRecord';
+import type { CreateRecordRequest, UpdateRecordRequest } from '../../types/record';
 import { getBookPage } from '../../api/rooms/getBookPage';
 import { usePopupActions } from '../../hooks/usePopupActions';
 
 const RecordWrite = () => {
   const navigate = useNavigate();
-  const { roomId } = useParams<{ roomId: string }>();
+  const { roomId, recordId } = useParams<{ roomId: string; recordId: string }>();
+  const [searchParams] = useSearchParams();
+  
+  // 수정 모드인지 판단
+  const isEditMode = Boolean(recordId);
   const { openSnackbar } = usePopupActions();
 
   const [pageRange, setPageRange] = useState('');
   const [content, setContent] = useState('');
   const [isOverallEnabled, setIsOverallEnabled] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  
 
   // API에서 받아올 데이터
   const [totalPages, setTotalPages] = useState(0);
@@ -26,9 +32,9 @@ const RecordWrite = () => {
   const [isOverviewPossible, setIsOverviewPossible] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  // 컴포넌트 마운트 시 책 페이지 정보 조회
+  // 컴포넌트 마운트 시 책 페이지 정보 조회 (생성 모드) 또는 기록 내용 로드 (수정 모드)
   useEffect(() => {
-    const fetchBookPageInfo = async () => {
+    const initializeData = async () => {
       if (!roomId) {
         openSnackbar({
           message: '방 정보를 찾을 수 없습니다.',
@@ -41,6 +47,36 @@ const RecordWrite = () => {
 
       try {
         setIsLoading(true);
+        
+        if (isEditMode) {
+          // 수정 모드: 쿼리 파라미터에서 기존 내용과 페이지 정보 로드
+          const existingContent = searchParams.get('content');
+          const existingPageRange = searchParams.get('pageRange');
+          const existingRecordType = searchParams.get('recordType');
+          
+          if (existingContent) {
+            setContent(decodeURIComponent(existingContent));
+          }
+          
+          if (existingPageRange) {
+            setPageRange(existingPageRange);
+          }
+          
+          if (existingRecordType === 'overall') {
+            setIsOverallEnabled(true);
+          }
+          
+          // 수정 모드에서도 전체 페이지 수는 필요하므로 책 정보 조회
+          const response = await getBookPage(parseInt(roomId));
+          if (response.isSuccess) {
+            setTotalPages(response.data.totalBookPage);
+          }
+          
+          setIsLoading(false);
+          return;
+        }
+        
+        // 생성 모드: 책 페이지 정보 조회
         const response = await getBookPage(parseInt(roomId));
 
         if (response.isSuccess) {
@@ -55,9 +91,9 @@ const RecordWrite = () => {
           });
         }
       } catch (error) {
-        console.error('책 페이지 정보 조회 오류:', error);
+        console.error('데이터 로드 오류:', error);
 
-        let errorMessage = '책 정보를 불러오는 중 오류가 발생했습니다.';
+        let errorMessage = '데이터를 불러오는 중 오류가 발생했습니다.';
 
         if (error && typeof error === 'object' && 'response' in error) {
           const axiosError = error as {
@@ -90,8 +126,8 @@ const RecordWrite = () => {
       }
     };
 
-    fetchBookPageInfo();
-  }, [roomId]);
+    initializeData();
+  }, [roomId, isEditMode]);
 
   // 총평 모드가 변경될 때 isOverviewPossible 체크
   useEffect(() => {
@@ -115,67 +151,113 @@ const RecordWrite = () => {
     setIsSubmitting(true);
 
     try {
-      // 페이지 범위 결정
-      let finalPage: number;
-
-      if (isOverallEnabled) {
-        // 총평인 경우: 책의 마지막 페이지 또는 전체 페이지 수 사용
-        finalPage = totalPages;
-      } else {
-        // 일반 기록인 경우
-        if (pageRange.trim() !== '') {
-          finalPage = parseInt(pageRange.trim());
-        } else {
-          finalPage = lastRecordedPage;
+      if (isEditMode) {
+        // 수정 모드: 내용만 수정
+        if (!recordId) {
+          openSnackbar({
+            message: '기록 정보를 찾을 수 없습니다.',
+            variant: 'top',
+            onClose: () => {},
+          });
+          setIsSubmitting(false);
+          return;
         }
-      }
 
-      // 페이지 유효성 검사
-      if (finalPage <= 0 || finalPage > totalPages) {
-        openSnackbar({
-          message: `유효하지 않은 페이지입니다. (1-${totalPages} 사이의 값을 입력해주세요)`,
-          variant: 'top',
-          onClose: () => {},
-        });
-        setIsSubmitting(false);
-        return;
-      }
+        const updateData: UpdateRecordRequest = {
+          content: content.trim(),
+        };
 
-      // API 요청 데이터 생성
-      const recordData: CreateRecordRequest = {
-        page: finalPage,
-        isOverview: isOverallEnabled,
-        content: content.trim(),
-      };
+        console.log('기록 수정 API 호출:', updateData);
+        console.log('roomId:', roomId, 'recordId:', recordId);
 
-      console.log('기록 생성 API 호출:', recordData);
-      console.log('roomId:', roomId);
+        const response = await updateRecord(parseInt(roomId), parseInt(recordId), updateData);
 
-      // API 호출
-      const response = await createRecord(parseInt(roomId), recordData);
+        if (response.isSuccess) {
+          console.log('기록 수정 성공:', response.data);
+          
+          openSnackbar({
+            message: '기록 수정을 완료했어요.',
+            variant: 'top',
+            onClose: () => {},
+          });
 
-      if (response.isSuccess) {
-        console.log('기록 생성 성공:', response.data);
-
-        // 성공 시 기록장으로 이동
-        navigate(`/rooms/${roomId}/memory`, {
-          replace: true,
-        });
+          // 성공 시 기록장으로 이동
+          navigate(`/rooms/${roomId}/memory`, {
+            replace: true,
+          });
+        } else {
+          console.error('기록 수정 실패:', response.message);
+          openSnackbar({
+            message: response.message || '기록 수정에 실패했습니다.',
+            variant: 'top',
+            onClose: () => {},
+          });
+          setIsSubmitting(false);
+        }
       } else {
-        // API 에러 응답 처리
-        console.error('기록 생성 실패:', response.message);
-        openSnackbar({
-          message: response.message || '기록 작성에 실패했습니다.',
-          variant: 'top',
-          onClose: () => {},
-        });
-        setIsSubmitting(false);
+        // 생성 모드: 기존 로직 유지
+        // 페이지 범위 결정
+        let finalPage: number;
+
+        if (isOverallEnabled) {
+          // 총평인 경우: 책의 마지막 페이지 또는 전체 페이지 수 사용
+          finalPage = totalPages;
+        } else {
+          // 일반 기록인 경우
+          if (pageRange.trim() !== '') {
+            finalPage = parseInt(pageRange.trim());
+          } else {
+            finalPage = lastRecordedPage;
+          }
+        }
+
+        // 페이지 유효성 검사
+        if (finalPage <= 0 || finalPage > totalPages) {
+          openSnackbar({
+            message: `유효하지 않은 페이지입니다. (1-${totalPages} 사이의 값을 입력해주세요)`,
+            variant: 'top',
+            onClose: () => {},
+          });
+          setIsSubmitting(false);
+          return;
+        }
+
+        // API 요청 데이터 생성
+        const recordData: CreateRecordRequest = {
+          page: finalPage,
+          isOverview: isOverallEnabled,
+          content: content.trim(),
+        };
+
+        console.log('기록 생성 API 호출:', recordData);
+        console.log('roomId:', roomId);
+
+        // API 호출
+        const response = await createRecord(parseInt(roomId), recordData);
+
+        if (response.isSuccess) {
+          console.log('기록 생성 성공:', response.data);
+
+          // 성공 시 기록장으로 이동
+          navigate(`/rooms/${roomId}/memory`, {
+            replace: true,
+          });
+        } else {
+          // API 에러 응답 처리
+          console.error('기록 생성 실패:', response.message);
+          openSnackbar({
+            message: response.message || '기록 작성에 실패했습니다.',
+            variant: 'top',
+            onClose: () => {},
+          });
+          setIsSubmitting(false);
+        }
       }
     } catch (error) {
       console.error('기록 저장 실패:', error);
 
       // 에러 타입에 따른 메시지 처리
-      let errorMessage = '기록 저장 중 오류가 발생했습니다.';
+      let errorMessage = isEditMode ? '기록 수정 중 오류가 발생했습니다.' : '기록 저장 중 오류가 발생했습니다.';
 
       if (error && typeof error === 'object' && 'response' in error) {
         const axiosError = error as {
@@ -192,9 +274,9 @@ const RecordWrite = () => {
         } else if (axiosError.response?.data?.code === 400) {
           errorMessage = '입력값을 확인해 주세요.';
         } else if (axiosError.response?.data?.code === 403) {
-          errorMessage = '방 접근 권한이 없습니다.';
+          errorMessage = '접근 권한이 없습니다.';
         } else if (axiosError.response?.data?.code === 404) {
-          errorMessage = '존재하지 않는 방입니다.';
+          errorMessage = '존재하지 않는 데이터입니다.';
         }
       }
 
@@ -213,7 +295,7 @@ const RecordWrite = () => {
       <>
         <TitleHeader
           leftIcon={<img src={leftArrow} alt="뒤로가기" />}
-          title="기록 작성"
+          title={isEditMode ? "기록 수정" : "기록 작성"}
           onLeftClick={handleBackClick}
         />
         <Container>
@@ -237,7 +319,7 @@ const RecordWrite = () => {
     <>
       <TitleHeader
         leftIcon={<img src={leftArrow} alt="뒤로가기" />}
-        title="기록 작성"
+        title={isEditMode ? "기록 수정" : "기록 작성"}
         rightButton={<div className="complete">완료</div>}
         onLeftClick={handleBackClick}
         onRightClick={handleCompleteClick}
@@ -253,6 +335,8 @@ const RecordWrite = () => {
           onOverallToggle={() => setIsOverallEnabled(prev => !prev)}
           readingProgress={isOverviewPossible ? 80 : 70} // 총평 가능하면 80% 이상으로 표시
           isOverviewPossible={isOverviewPossible}
+          isDisabled={isEditMode} // 수정 모드일 때 비활성화
+          hideToggle={isEditMode} // 수정 모드일 때 총평 토글 숨김
         />
         <RecordContentSection content={content} onContentChange={setContent} />
       </Container>

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -51,6 +51,16 @@ export interface VoteData {
   voteItems: VoteItemResult[]; // 투표 결과 리스트
 }
 
+// 기록 수정 요청 데이터 타입
+export interface UpdateRecordRequest {
+  content: string; // 수정할 기록 내용
+}
+
+// 기록 수정 응답 데이터 타입
+export interface UpdateRecordData {
+  roomId: number; // 방 ID
+}
+
 // 공통 API 응답 타입
 export interface ApiResponse<T> {
   isSuccess: boolean;

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -61,6 +61,16 @@ export interface UpdateRecordData {
   roomId: number; // 방 ID
 }
 
+// 투표 수정 요청 데이터 타입
+export interface UpdateVoteRequest {
+  content: string; // 수정할 투표 내용
+}
+
+// 투표 수정 응답 데이터 타입
+export interface UpdateVoteData {
+  roomId: number; // 방 ID
+}
+
 // 공통 API 응답 타입
 export interface ApiResponse<T> {
   isSuccess: boolean;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#106 

## 📝 작업 내용

**1. 방 나가기 API 연동**
- API 함수 생성: `src/api/rooms/leaveRoom.ts`에 DELETE `/rooms/{roomId}/leave` API 연동 함수 구현
- UI 플로우: 확인 모달 → API 호출 → 성공 시 "모임 나가기를 완료했어요." 스낵바 표시 후 모임 메인페이지 (`/group`)로 이동

**2. 기록 수정 API 연동**
- API 함수 생성: `src/api/record/updateRecord.ts`에 PATCH `/rooms/{roomId}/records/{recordId}` API 연동 함수 구현
- 타입 정의: `UpdateRecordRequest`, `UpdateRecordData` 인터페이스 추가
- 라우팅: `/memory/record/edit/:roomId/:recordId` 경로 추가
- RecordWrite.tsx 개선:
  - `recordId` 파라미터를 통한 수정 모드 감지
  - 쿼리 파라미터에서 기존 기록 데이터 로드 (내용, 페이지, 기록 타입)
  - 수정 모드에서는 페이지 설정 비활성화 및 총평 토글 숨김
  - 타이틀을 "기록 수정"으로 변경
- RecordWrite.tsx 수정: 수정 버튼 클릭 시 기존 데이터를 쿼리 파라미터로 전달하며 수정 페이지로 이동

**3. 투표 수정 API 연동**
- API 함수 생성: `src/api/record/updateVote.ts`에 PATCH `/rooms/{roomId}/votes/{voteId}` API 연동 함수 구현
- 타입 정의: `UpdateVoteRequest`, `UpdateVoteData` 인터페이스 추가
- 라우팅: `/memory/poll/edit/:roomId/:voteId` 경로 추가
- PollWrite.tsx 개선:
  - `voteId` 파라미터를 통한 수정 모드 감지
  - 쿼리 파라미터에서 기존 기록 데이터 로드 (내용, 페이지, 기록 타입, 투표 옵션들)
  - 수정 모드에서는 페이지 설정 비활성화 및 총평 토글 숨김
  - 타이틀을 "기록 수정"으로 변경
- RecordWrite.tsx 수정: 투표와 기록 모두 처리하도록 `handleEdit` 함수 확장

**4. 수정 페이지 UI/UX 개선**
- PageRangeSection.tsx 개선:
  - `isDisabled`, `hideToggle` props 추가로 수정 모드에서 페이지 설정은 비활성화하되 정보는 표시
  - 총평 토글 버튼을 수정 모드에서 숨김
- PollCreationSection.tsx 개선:
  - `isEditMode` prop 추가로 투표 옵션 입력창들을 `disabled`/`readOnly` 상태로 변경
  - 수정 모드에서는 삭제 버튼들과 "항목 추가" 버튼 숨김
  - 투표 내용만 수정 가능하도록 제한

**5. 자동 포커스 및 커서 위치 개선**
- RecordContentSection.tsx:
  - `autoFocus` prop 추가 및 수정 모드 진입 시 자동 포커스
  - `setSelectionRange`를 통해 커서를 기존 텍스트 마지막 위치에 자동 배치
- PollCreationSection.tsx:
  - `autoFocus` prop 및 `contentInputRef` 추가
  - 수정 모드 진입 시 투표 내용 입력창에 자동 포커스 및 커서 위치 설정

## 🕸️ 스크린샷

https://github.com/user-attachments/assets/3d17ed23-b990-4480-92f3-42223e00f3f4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 기록·투표 수정 기능 추가: 편집 화면 라우트 및 편집 모드에서 수정 API 연동.
  * 편집 모드 UX 개선: 페이지 범위 입력 비활성화, 총평 토글 숨김, 내용·옵션 자동 포커스 등 도입.
  * 기록 항목에서 즉시 편집으로 이동(투표/일반 모두 지원).
  * 모임 나가기 기능 활성화: 성공/오류 스낵바 안내 후 그룹 목록으로 이동.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->