### PR TITLE
feat: presigned URL API 연동 및 이미지 업로드 방식 수정

### DIFF
--- a/src/api/feeds/createFeed.ts
+++ b/src/api/feeds/createFeed.ts
@@ -6,6 +6,7 @@ export interface CreateFeedBody {
   contentBody: string;
   isPublic: boolean;
   tagList?: string[];
+  imageUrls?: string[];
 }
 
 /** 성공 응답 */
@@ -29,27 +30,12 @@ export type CreateFeedResponse = CreateFeedSuccess | CreateFeedFail;
 
 /**
  * 피드 작성 API
- * - multipart/form-data
- *   - request: application/json (Blob로 감싸 전송)
- *   - images: File[] (선택값, 없으면 미첨부)
+ * - application/json (presigned URL 방식)
+ * - imageUrls: 미리 S3에 업로드한 이미지의 CloudFront URL 목록
  */
 export const createFeed = async (
   body: CreateFeedBody,
-  images?: File[],
 ): Promise<CreateFeedResponse> => {
-  const form = new FormData();
-
-  // request 파트(JSON) - 필수
-  form.append('request', new Blob([JSON.stringify(body)], { type: 'application/json' }));
-
-  // images 파트들 - 선택
-  if (images && images.length > 0) {
-    images.forEach(file => form.append('images', file));
-  }
-
-  const { data } = await apiClient.post<CreateFeedResponse>('/feeds', form, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
-
+  const { data } = await apiClient.post<CreateFeedResponse>('/feeds', body);
   return data;
 };

--- a/src/api/feeds/getPresignedUrl.ts
+++ b/src/api/feeds/getPresignedUrl.ts
@@ -1,0 +1,29 @@
+import { apiClient } from '../index';
+
+export interface PresignedUrlRequest {
+  extension: string;
+  size: number;
+}
+
+export interface PresignedUrlResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  data?: {
+    presignedUrls: Array<{
+      presignedUrl: string;
+      fileUrl: string;
+    }>;
+  };
+}
+
+export const getPresignedUrl = async (
+  requests: PresignedUrlRequest[]
+): Promise<PresignedUrlResponse> => {
+  const { data } = await apiClient.post<PresignedUrlResponse>(
+    '/feeds/images/presigned-url',
+    requests
+  );
+  
+  return data;
+};

--- a/src/api/feeds/uploadToS3.ts
+++ b/src/api/feeds/uploadToS3.ts
@@ -1,0 +1,19 @@
+export const uploadFileToS3 = async (
+  presignedUrl: string,
+  file: File
+): Promise<boolean> => {
+  try {
+    const response = await fetch(presignedUrl, {
+      method: 'PUT',
+      body: file,
+      headers: {
+        'Content-Type': file.type,
+      },
+    });
+
+    return response.ok;
+  } catch (error) {
+    console.error('S3 업로드 실패:', error);
+    return false;
+  }
+};

--- a/src/pages/post/CreatePost.tsx
+++ b/src/pages/post/CreatePost.tsx
@@ -101,7 +101,7 @@ const CreatePost = () => {
 
     const candidates = makeIsbnCandidates(selectedBook!.isbn);
 
-    // images: 선택값 (없으면 undefined 전달 → FormData에 미첨부)
+    // images: 선택값 (없으면 undefined 전달)
     const filesOrUndefined = selectedPhotos.length ? selectedPhotos : undefined;
 
     // 최대 2회까지(총 3회) 재시도: 13 → (10) → (정규화원본)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#229 

## 📝 작업 내용

기존 multipart/form-data 방식에서 S3 Presigned URL을 사용한 직접 업로드 방식으로 변경하여 서버 부하를 줄이고 보안을 강화했습니다.

**1. 새로운 API 함수 추가**
- `src/api/feeds/getPresignedUrl.ts`: 피드 이미지 업로드용 presigned URL 발급 API
- `src/api/feeds/updateToS3.ts`: S3 직접 업로드 함수

**2. 기존 피드 생성 API 함수 수정**
- `CreateFeedBody` 인터페이스에 `imageUrls` 필드 추가
- multipart 방식에서 JSON 방식으로 변경
- 이미지 파일 대신 업로드된 CloudFront URL 전송

**3. 피드 생성 플로우 개선**
- 이미지 파일 검증 (확장자, 크기, 개수) 유지
- Presigned URL 발급 → S3 직접 업로드 → 피드 생성 순서로 변경

**새로운 업로드 플로우:**
1️⃣ 이미지 파일 선택 및 클라이언트 검증
2️⃣ POST /feeds/images/presigned-url → presigned URL 발급
3️⃣ PUT to S3 → 각 이미지를 S3에 직접 업로드
4️⃣ POST /feeds → 업로드된 이미지 URL과 함께 피드 생성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 이미지가 사전 발급 URL로 업로드된 뒤 게시물에 자동 첨부되어 업로드 안정성과 속도가 향상되었습니다.
  - 다중 이미지를 병렬로 업로드해 전체 대기 시간이 단축되었습니다.
  - 업로드 실패 시 명확한 안내 메시지를 표시하고 작업을 안전하게 중단합니다.

- 문서
  - 공개 API 문서에 이미지 업로드 절차 변경 사항과 이미지 URL 기반 첨부 방식이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->