### PR TITLE
[FIX] 9월 2주차 QA 사항 - 지현

### DIFF
--- a/src/components/members/MemberList.styled.ts
+++ b/src/components/members/MemberList.styled.ts
@@ -65,13 +65,13 @@ export const MemberName = styled.div`
 export const MemberRole = styled.div<{ roleType?: string }>`
   color: ${({ roleType }) => {
     if (!roleType) return semanticColors.text.point.green;
-    
+
     const role = roleType.toLowerCase();
-    
+
     if (role.includes('예술') || role.includes('art')) {
       return semanticColors.text.character.pink;
     }
-    if (role.includes('문학') || role.includes('literature')) {
+    if (role.includes('인문') || role.includes('humanities') || role.includes('철학')) {
       return semanticColors.text.character.mint;
     }
     if (role.includes('사회') || role.includes('sociology')) {
@@ -83,7 +83,7 @@ export const MemberRole = styled.div<{ roleType?: string }>`
     if (role.includes('과학') || role.includes('science')) {
       return semanticColors.text.character.lavender;
     }
-    
+
     return semanticColors.text.point.green;
   }};
   font-size: ${typography.fontSize.xs};

--- a/src/components/members/MemberList.styled.ts
+++ b/src/components/members/MemberList.styled.ts
@@ -47,6 +47,7 @@ export const ProfileImage = styled.div`
   height: 36px;
   border-radius: 50%;
   background-color: ${colors.grey['400']};
+  border: 1px solid #888;
   flex-shrink: 0;
 `;
 

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -78,6 +78,7 @@ const ProfileImageWithSrc = styled.img`
   height: 36px;
   border-radius: 50%;
   background-color: var(--color-grey-400);
+  border: 1px solid #888;
   flex-shrink: 0;
   object-fit: cover;
 `;

--- a/src/components/memory/RecordItem/RecordItem.styled.ts
+++ b/src/components/memory/RecordItem/RecordItem.styled.ts
@@ -3,7 +3,7 @@ import { colors, typography, semanticColors } from '../../../styles/global/globa
 
 export const Container = styled.div<{ shouldBlur?: boolean }>`
   background-color: none;
-  filter: ${({ shouldBlur }) => (shouldBlur ? 'blur(2px)' : 'none')};
+  filter: ${({ shouldBlur }) => (shouldBlur ? 'blur(3px)' : 'none')};
   transition: filter 0.3s ease;
   position: relative;
 `;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#244 

## 📝 작업 내용

- 독서메이트 프로필 사진 테두리 추가
- 기록장 블라인드 처리: 2px → 3px
- 철학자 칭호 색상: 하늘색으로 표시하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 멤버 리스트에서 프로필 이미지에 1px 회색 테두리를 추가해 시각적 구분을 강화했습니다(실제 이미지가 있는 경우에만 적용).
  - 멤버 역할 색상 매핑을 조정하여 ‘인문’, ‘humanities’, ‘철학’이 포함된 역할에 민트 색상이 적용되도록 개선했습니다. 기존의 다른 색상 규칙은 유지됩니다.
  - 기록 아이템의 흐림(블러) 효과 강도를 소폭 상향(2px → 3px)해 비활성/민감 콘텐츠의 시각적 처리 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->