### PR TITLE
fix: 기록장 투표 정보 퍼센트가 아닌 득표수로 표시되도록 수정

### DIFF
--- a/src/components/memory/RecordItem/PollRecord.tsx
+++ b/src/components/memory/RecordItem/PollRecord.tsx
@@ -91,8 +91,9 @@ const PollRecord = ({ content, pollOptions, postId, shouldBlur = false, onVoteUp
             return {
               ...opt,
               percentage: updatedItem.percentage,
+              count: updatedItem.count,
               isVoted: updatedItem.isVoted,
-              isHighest: updatedItem.percentage === Math.max(...response.data.voteItems.map(item => item.percentage))
+              isHighest: updatedItem.count === Math.max(...response.data.voteItems.map(item => item.count))
             };
           }
           return opt;
@@ -142,8 +143,17 @@ const PollRecord = ({ content, pollOptions, postId, shouldBlur = false, onVoteUp
     }
   };
 
-  // 아무도 투표하지 않았는지 확인 (모든 옵션이 0%인지 확인)
-  const hasVotes = currentOptions.some(option => option.percentage > 0);
+  // 아무도 투표하지 않았는지 확인 (모든 옵션이 0표인지 확인)
+  const hasVotes = currentOptions.some(option => option.count > 0);
+
+  // 전체 투표수 계산
+  const totalVotes = currentOptions.reduce((sum, option) => sum + option.count, 0);
+
+  // 각 옵션의 퍼센트 계산 (애니메이션용)
+  const getPercentage = (count: number) => {
+    if (totalVotes === 0) return 0;
+    return (count / totalVotes) * 100;
+  };
 
   return (
     <PollSection ref={pollRef}>
@@ -162,7 +172,7 @@ const PollRecord = ({ content, pollOptions, postId, shouldBlur = false, onVoteUp
           >
             <PollBar>
               <PollBarFill
-                percentage={hasVotes ? option.percentage : 0}
+                percentage={hasVotes ? getPercentage(option.count) : 0}
                 isHighest={hasVotes && option.isHighest}
                 animate={hasVotes && animate}
                 delay={index * 200} // 각 옵션마다 200ms 지연
@@ -177,7 +187,7 @@ const PollRecord = ({ content, pollOptions, postId, shouldBlur = false, onVoteUp
               </PollText>
               {hasVotes && (
                 <PollPercentage isHighest={hasVotes && option.isHighest}>
-                  {option.percentage}%
+                  {option.count}표
                 </PollPercentage>
               )}
             </PollContent>

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -31,14 +31,18 @@ const convertPostToRecord = (post: Post): Record => {
     isWriter: post.isWriter,
     isLiked: post.isLiked,
     isLocked: post.isLocked, // 블러 처리 여부 추가
-    pollOptions: post.voteItems.map((item, index) => ({
-      id: item.voteItemId.toString(),
-      text: item.itemName,
-      percentage: item.percentage,
-      isHighest: index === 0,
-      voteItemId: item.voteItemId,
-      isVoted: item.isVoted,
-    })),
+    pollOptions: post.voteItems.map((item) => {
+      const maxCount = Math.max(...post.voteItems.map(v => v.count || 0));
+      return {
+        id: item.voteItemId.toString(),
+        text: item.itemName,
+        percentage: item.percentage,
+        count: item.count || 0,
+        isHighest: (item.count || 0) === maxCount && maxCount > 0,
+        voteItemId: item.voteItemId,
+        isVoted: item.isVoted,
+      };
+    }),
   };
 };
 

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -3,6 +3,7 @@ export interface VoteItem {
   voteItemId: number;
   itemName: string;
   percentage: number;
+  count: number;
   isVoted: boolean;
 }
 
@@ -82,6 +83,7 @@ export interface PollOption {
   id: string;
   text: string;
   percentage: number;
+  count: number;
   isHighest: boolean;
   voteItemId: number; // 투표 API에 필요한 ID
   isVoted: boolean; // 현재 사용자가 투표했는지 여부

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -35,6 +35,7 @@ export interface VoteItemResult {
   voteItemId: number; // 투표 아이템 ID
   itemName: string; // 투표 옵션 이름
   percentage: number; // 득표율
+  count: number; // 득표수
   isVoted: boolean; // 현재 사용자가 투표했는지 여부
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#246 

## 📝 작업 내용

### 기록장 투표 표시를 퍼센트에서 득표수로 변경
투표 API의 `count` 필드를 활용해서 기록장에서 투표 결과를 퍼센트(%) 대신 득표수(표)로 표시하도록 수정했습니다.

**1. 타입 정의 업데이트**
- `VoteItemResult`, `VoteItem`, `PollOption` 타입에 `count` 필드 추가
- API 응답에서 받아오는 득표수 데이터를 타입에 반영

**2. 투표 결과 표시 변경**
- `PollRecord.tsx`에서 투표 결과 텍스트를 `{percentage}%` → `{count}표`로 변경
- 투표 여부 확인 로직을 `percentage > 0` → `count > 0`으로 수정

**3. 애니메이션 로직 개선**
- 득표수를 기반으로 전체 투표수 대비 비율을 계산하는 `getPercentage` 함수 추가
- 기존 퍼센트 기반 애니메이션을 득표수 기반으로 전환

**4. 최고 득표 옵션 판별 로직 수정**
- 퍼센트 대신 득표수를 기준으로 최고 득표 옵션 판별
- API 응답 데이터 변환 시 `count` 필드 매핑 및 최고 득표 계산 로직 추가

**5. 투표 후 업데이트 로직 개선**
- 투표 API 호출 후 응답에서 받은 `count` 데이터를 상태에 반영
- 득표수를 기준으로 최고 득표 옵션 재계산

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 투표 결과가 퍼센트 대신 득표수(‘표’)로 표시됩니다.
  - 진행 바가 각 항목의 득표수를 바탕으로 퍼센트를 계산해 시각화합니다.
  - 총 투표수가 0인 경우도 자연스럽게 표시됩니다.

- 버그 수정
  - 최고 득표 항목 판정이 퍼센트 기반에서 득표수 기반으로 정확해졌으며, 동률도 올바르게 처리됩니다.
  - 투표 여부 판단 로직이 득표수 기준으로 일관되게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->