### PR TITLE
fix: 모임 검색 컴포넌트 디자인 요구상에 맞춰 수정

### DIFF
--- a/src/components/group/GroupCard.tsx
+++ b/src/components/group/GroupCard.tsx
@@ -66,9 +66,8 @@ const Card = styled.div<{ cardType: 'main' | 'search' | 'modal'; isFirstCard?: b
   border: ${({ cardType }) => (cardType === 'main' ? `1px solid ${colors.grey[300]}` : '')};
   border-radius: ${({ cardType }) => (cardType === 'search' ? `none` : '12px')};
   box-sizing: border-box;
-  padding: ${({ cardType }) => (cardType === 'search' ? '24px 12px 12px 12px' : '12px')};
+  padding: ${({ cardType }) => (cardType === 'search' ? '24px 12px' : '12px')};
   gap: 12px;
-  padding: 12px;
   min-width: 232px;
   cursor: pointer;
 `;
@@ -112,7 +111,7 @@ const Info = styled.div`
   flex-direction: column;
   justify-content: space-between;
   flex: 1;
-  min-width: 0; /* flex 아이템이 부모 너비를 넘지 않도록 */
+  min-width: 0;
 `;
 
 const Title = styled.h3<{ isRecommend: boolean }>`
@@ -126,7 +125,7 @@ const Title = styled.h3<{ isRecommend: boolean }>`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%; /* 부모 컨테이너의 전체 너비 사용 */
+  width: 100%;
 `;
 
 const Bottom = styled.div`

--- a/src/components/search/GroupSearchResult.tsx
+++ b/src/components/search/GroupSearchResult.tsx
@@ -100,7 +100,7 @@ const GroupSearchResult = ({
               key={group.id}
               group={group}
               type={'search'}
-              isOngoing={group.isOnGoing}
+              isOngoing={false}
               isFirstCard={type === 'searching' && idx === 0}
               onClick={() => onClickRoom(Number(group.id))}
               ref={idx === mapped.length - 1 ? lastRoomElementCallback : undefined}
@@ -139,7 +139,6 @@ const Tab = styled.button<{ selected?: boolean }>`
 const Content = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 12px;
   overflow-y: auto;
   padding: 0 20px 60px;
 


### PR DESCRIPTION
<img width="614" height="931" alt="image" src="https://github.com/user-attachments/assets/5dc45b29-8a8e-47fc-bca0-b7938a04f071" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 검색 카드 유형의 카드 패딩을 상하 24px, 좌우 12px로 조정하여 하단 여백이 확대되었습니다.
  - 불필요한 주석을 제거해 표시에는 변화 없고 스타일 정의만 정리되었습니다.
- 버그 수정
  - 그룹 검색 결과의 카드에서 ‘진행 중’ 상태가 더 이상 표시되지 않습니다(항상 비표시).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->