### PR TITLE
[FIX] GA 라우트 경로별 title 추가

### DIFF
--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -7,7 +7,26 @@ const Layout = () => {
   const location = useLocation();
 
   useEffect(() => {
-    sendPageView(location.pathname + location.search + location.hash);
+    // 라우트별 페이지 타이틀 설정
+    const path = location.pathname;
+    const titleRules: Array<[RegExp, string]> = [
+      [/^\/$/, 'THIP - 로그인'],
+      [/^\/feed(\/|$)/, 'THIP - 피드'],
+      [/^\/notice(\/|$)/, 'THIP - 알림'],
+      [/^\/group(\/|$)/, 'THIP - 모임'],
+      [/^\/rooms\/[^/]+\/memory(\/|$)/, 'THIP - 기록장'],
+      [/^\/mypage(\/|$)/, 'THIP - 마이페이지'],
+      [/^\/search(\/|$)/, 'THIP - 책 검색'],
+    ];
+
+    const matched = titleRules.find(([regex]) => regex.test(path));
+    if (matched) {
+      document.title = matched[1];
+    } else {
+      document.title = 'THIP';
+    }
+
+    sendPageView(path + location.search + location.hash);
   }, [location.pathname, location.search, location.hash]);
 
   return (


### PR DESCRIPTION
## #️⃣연관된 이슈
없음

## 📝작업 내용
라우트 변경 시 document.title을 경로별로 설정하고, 그 뒤에 sendPageView를 호출하게 수정함.
GA가 라우트마다 다른 제목을 받아서 구분함.

## 💬리뷰 요구사항
없음