### PR TITLE
[API] AI 독서감상문 생성 및 AI 이용횟수 조회 API 연동

### DIFF
--- a/src/api/record/createAiReview.ts
+++ b/src/api/record/createAiReview.ts
@@ -1,0 +1,31 @@
+import { apiClient } from '../index';
+import type { CreateAiReviewData, ApiResponse } from '@/types/record';
+
+// API 응답 타입
+export type CreateAiReviewResponse = ApiResponse<CreateAiReviewData>;
+
+// AI 독서감상문 생성 API 함수
+export const createAiReview = async (roomId: number) => {
+  const response = await apiClient.post<CreateAiReviewResponse>(
+    `/rooms/${roomId}/record/ai-review`,
+  );
+  return response.data;
+};
+
+/*
+사용 예시:
+try {
+  const result = await createAiReview(1);
+  if (result.isSuccess) {
+    console.log("생성된 독서감상문:", result.data.content);
+    console.log("잔여 이용 횟수:", result.data.count);
+    // 성공 처리 로직
+  } else {
+    console.error("AI 독서감상문 생성 실패:", result.message);
+    // 실패 처리 로직
+  }
+} catch (error) {
+  console.error("API 호출 오류:", error);
+  // 에러 처리 로직
+}
+*/

--- a/src/api/record/getAiUsage.ts
+++ b/src/api/record/getAiUsage.ts
@@ -1,0 +1,31 @@
+import { apiClient } from '../index';
+import type { AiUsageData, ApiResponse } from '@/types/record';
+
+// API 응답 타입
+export type GetAiUsageResponse = ApiResponse<AiUsageData>;
+
+// AI 이용 횟수 조회 API 함수
+export const getAiUsage = async (roomId: number) => {
+  const response = await apiClient.get<GetAiUsageResponse>(
+    `/rooms/${roomId}/users/ai-usage`,
+  );
+  return response.data;
+};
+
+/*
+사용 예시:
+try {
+  const result = await getAiUsage(1);
+  if (result.isSuccess) {
+    console.log("AI 독서감상문 작성 가능 횟수:", result.data.recordReviewCount);
+    console.log("기록 작성 횟수:", result.data.recordCount);
+    // 성공 처리 로직
+  } else {
+    console.error("AI 이용 횟수 조회 실패:", result.message);
+    // 실패 처리 로직
+  }
+} catch (error) {
+  console.error("API 호출 오류:", error);
+  // 에러 처리 로직
+}
+*/

--- a/src/api/record/index.ts
+++ b/src/api/record/index.ts
@@ -5,3 +5,4 @@ export * from './deleteVote';
 export * from './postVote';
 export * from './pinRecordToFeed';
 export * from './createAiReview';
+export * from './getAiUsage';

--- a/src/api/record/index.ts
+++ b/src/api/record/index.ts
@@ -4,3 +4,4 @@ export * from './deleteRecord';
 export * from './deleteVote';
 export * from './postVote';
 export * from './pinRecordToFeed';
+export * from './createAiReview';

--- a/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
+++ b/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
@@ -77,8 +77,8 @@ const MemoryAddButton = () => {
           return;
         }
 
-        // 잔여 횟수가 0인 경우
-        if (recordReviewCount <= 0) {
+        // 잔여 횟수가 5회 이상인 경우 (이미 5회 모두 사용)
+        if (recordReviewCount >= 5) {
           openSnackbar({
             message: '사용자의 독후감 작성 수가 5회를 초과했습니다.',
             variant: 'top',
@@ -88,7 +88,7 @@ const MemoryAddButton = () => {
           return;
         }
 
-        // 모달 표시
+        // 모달 표시 (잔여 횟수 = 5 - 사용한 횟수)
         openConfirm({
           title: 'AI 독서감상문 생성 (Beta)',
           disc: `기록장에서 작성한 기록을 기반으로<br/>독서감상문을 생성하시겠어요?<br/>(서비스 내 잔여 이용횟수 : ${recordReviewCount}/5)`,

--- a/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
+++ b/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { usePopupActions } from '@/hooks/usePopupActions';
+import { getAiUsage } from '@/api/record';
 import plusIcon from '../../../assets/memory/plus.svg';
 import penIcon from '../../../assets/memory/pen.svg';
 import voteIcon from '../../../assets/memory/vote.svg';
@@ -10,7 +11,7 @@ import { AddButton, DropdownContainer, DropdownItem } from './MemoryAddButton.st
 const MemoryAddButton = () => {
   const navigate = useNavigate();
   const { roomId } = useParams<{ roomId: string }>(); // useParams 추가
-  const { openConfirm, closePopup } = usePopupActions();
+  const { openConfirm, closePopup, openSnackbar } = usePopupActions();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -55,20 +56,67 @@ const MemoryAddButton = () => {
     console.log('투표 생성하기 - roomId:', currentRoomId);
   };
 
-  const handleAIWrite = () => {
+  const handleAIWrite = async () => {
     setIsOpen(false);
-    openConfirm({
-      title: 'AI 독서감상문 생성 (Beta)',
-      disc: '기록장에서 작성한 기록을 기반으로<br/>독서감상문을 생성하시겠어요?<br/>(서비스 내 잔여 이용횟수 : n/5)',
-      confirmText: '확인',
-      cancelText: '취소',
-      onConfirm: () => {
-        closePopup();
-        const currentRoomId = roomId || '1';
-        navigate(`/aiwrite/${currentRoomId}`);
-        console.log('AI 독서 감상문 생성 시작 - roomId:', currentRoomId);
-      },
-    });
+    const currentRoomId = roomId || '1';
+
+    try {
+      const result = await getAiUsage(Number(currentRoomId));
+
+      if (result.isSuccess) {
+        const { recordCount, recordReviewCount } = result.data;
+
+        // 기록이 2개 미만인 경우 에러 표시
+        if (recordCount < 2) {
+          openSnackbar({
+            message: `독후감 생성을 위해서는 최소 2개의 기록이 필요합니다. 현재 기록 개수: ${recordCount}`,
+            variant: 'top',
+            isError: true,
+            onClose: () => {},
+          });
+          return;
+        }
+
+        // 잔여 횟수가 0인 경우
+        if (recordReviewCount <= 0) {
+          openSnackbar({
+            message: '사용자의 독후감 작성 수가 5회를 초과했습니다.',
+            variant: 'top',
+            isError: true,
+            onClose: () => {},
+          });
+          return;
+        }
+
+        // 모달 표시
+        openConfirm({
+          title: 'AI 독서감상문 생성 (Beta)',
+          disc: `기록장에서 작성한 기록을 기반으로<br/>독서감상문을 생성하시겠어요?<br/>(서비스 내 잔여 이용횟수 : ${recordReviewCount}/5)`,
+          confirmText: '확인',
+          cancelText: '취소',
+          onConfirm: () => {
+            closePopup();
+            navigate(`/aiwrite/${currentRoomId}`);
+            console.log('AI 독서 감상문 생성 시작 - roomId:', currentRoomId);
+          },
+        });
+      } else {
+        openSnackbar({
+          message: result.message,
+          variant: 'top',
+          isError: true,
+          onClose: () => {},
+        });
+      }
+    } catch (error) {
+      console.error('AI 이용 횟수 조회 실패:', error);
+      openSnackbar({
+        message: 'AI 이용 횟수 조회에 실패했습니다',
+        variant: 'top',
+        isError: true,
+        onClose: () => {},
+      });
+    }
   };
 
   return (

--- a/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
+++ b/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
@@ -88,7 +88,7 @@ const MemoryAddButton = () => {
           return;
         }
 
-        // 모달 표시 (잔여 횟수 = 5 - 사용한 횟수)
+        // 모달 표시
         openConfirm({
           title: 'AI 독서감상문 생성 (Beta)',
           disc: `기록장에서 작성한 기록을 기반으로<br/>독서감상문을 생성하시겠어요?<br/>(서비스 내 잔여 이용횟수 : ${recordReviewCount}/5)`,

--- a/src/pages/aiwrite/AIWrite.tsx
+++ b/src/pages/aiwrite/AIWrite.tsx
@@ -132,8 +132,10 @@ const AIWrite = () => {
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
+  min-width: 320px;
+  max-width: 767px;
   min-height: 100vh;
+  margin: 0 auto;
   background-color: ${colors.black.main};
   padding-top: 56px;
 `;
@@ -210,7 +212,10 @@ const ContentText = styled.div`
 const CopyButton = styled.button`
   position: fixed;
   bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
   width: 100%;
+  max-width: 767px;
   height: 50px;
   background-color: ${colors.purple.main};
   color: ${colors.white};

--- a/src/pages/aiwrite/AIWrite.tsx
+++ b/src/pages/aiwrite/AIWrite.tsx
@@ -7,21 +7,65 @@ import TitleHeader from '@/components/common/TitleHeader';
 import { usePopupActions } from '@/hooks/usePopupActions';
 import leftArrow from '@/assets/common/leftArrow.svg';
 import infoIcon from '@/assets/common/infoIcon_white.svg';
-import { MOCK_AI_WRITING } from '@/mocks/aiwrite.mock';
+import { createAiReview } from '@/api/record';
 
 const AIWrite = () => {
   const navigate = useNavigate();
   const { roomId } = useParams<{ roomId: string }>();
   const { openSnackbar, openConfirm, closePopup } = usePopupActions();
   const [isLoading, setIsLoading] = useState(true);
+  const [aiContent, setAiContent] = useState('');
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-    }, 5000);
+    const fetchAiReview = async () => {
+      if (!roomId) return;
 
-    return () => clearTimeout(timer);
-  }, []);
+      try {
+        const result = await createAiReview(Number(roomId));
+
+        if (result.isSuccess) {
+          setAiContent(result.data.content);
+        } else {
+          openSnackbar({
+            message: result.message,
+            variant: 'top',
+            isError: true,
+            onClose: () => {},
+          });
+          navigate(`/rooms/${roomId}/memory`);
+        }
+      } catch (error) {
+        console.error('AI 독서감상문 생성 실패:', error);
+        let errorMessage = 'AI 독서감상문 생성에 실패했습니다';
+
+        if (error && typeof error === 'object' && 'response' in error) {
+          const axiosError = error as {
+            response?: {
+              data?: {
+                message?: string;
+              };
+            };
+          };
+          if (axiosError.response?.data?.message) {
+            errorMessage = axiosError.response.data.message;
+          }
+        }
+
+        openSnackbar({
+          message: errorMessage,
+          variant: 'top',
+          isError: true,
+          onClose: () => {},
+        });
+        navigate(`/rooms/${roomId}/memory`);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchAiReview();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roomId]);
 
   const handleBackClick = () => {
     openConfirm({
@@ -38,7 +82,7 @@ const AIWrite = () => {
 
   const handleCopyToClipboard = async () => {
     try {
-      await navigator.clipboard.writeText(MOCK_AI_WRITING);
+      await navigator.clipboard.writeText(aiContent);
       openSnackbar({
         message: '클립보드에 복사가 완료되었어요',
         variant: 'top',
@@ -77,7 +121,7 @@ const AIWrite = () => {
             <img src={infoIcon} alt="정보" />
             <span>내 기록과 총평을 바탕으로 생성된 감상문입니다.</span>
           </InfoBanner>
-          <ContentText>{MOCK_AI_WRITING}</ContentText>
+          <ContentText>{aiContent}</ContentText>
           <CopyButton onClick={handleCopyToClipboard}>클립보드에 복사</CopyButton>
         </ResultContent>
       )}

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -72,6 +72,12 @@ export interface UpdateVoteData {
   roomId: number; // 방 ID
 }
 
+// AI 독서감상문 생성 응답 데이터 타입
+export interface CreateAiReviewData {
+  content: string; // 생성된 독서감상문 내용
+  count: number; // 잔여 이용 횟수
+}
+
 // 공통 API 응답 타입
 export interface ApiResponse<T> {
   isSuccess: boolean;

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -78,6 +78,12 @@ export interface CreateAiReviewData {
   count: number; // 잔여 이용 횟수
 }
 
+// AI 이용 횟수 조회 응답 데이터 타입
+export interface AiUsageData {
+  recordReviewCount: number; // AI 독서감상문 작성 가능 횟수
+  recordCount: number; // 기록 작성 횟수
+}
+
 // 공통 API 응답 타입
 export interface ApiResponse<T> {
   isSuccess: boolean;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#287 

## 📝 작업 내용

### AI 독서감상문 API 연동 완료
이번 PR에서는 AI 독서감상문 생성 기능과 관련된 2개의 API를 연동하였습니다.

**1. API 연동**
- **AI 독서감상문 생성 API** (`POST /rooms/{roomId}/record/ai-review`)
  - 컴포넌트 마운트 시 자동으로 API 호출
  - 생성 중 로딩 스피너 표시
  - 성공 시 생성된 독서감상문 표시 및 클립보드 복사 기능
  - 실패 시 서버 에러 메시지를 스낵바로 표시하고 기록장 페이지로 이동
- **AI 이용 횟수 조회 API** (`GET /rooms/{roomId}/users/ai-usage`)
  - AI 작성 버튼 클릭 시 호출하여 사전 검증
  - `recordCount`: 사용자가 작성한 기록 개수
  - `recordReviewCount`: AI 독서감상문 사용 횟수 (0~5)

**2. 사용자 검증 로직 구현**
- **AI 작성 버튼 클릭 시 3가지 케이스 처리:**
  - **Case 1: 기록 개수 부족 (recordCount < 2)**
    - 스낵바로 에러 메시지 표시
    - 모달 표시하지 않고 즉시 종료
    - 메시지: "독후감 생성을 위해서는 최소 2개의 기록이 필요합니다. 현재 기록 개수: {recordCount}"

  - **Case 2: 이용 횟수 초과 (recordReviewCount >= 5)**
    - 스낵바로 에러 메시지 표시
    - 모달 표시하지 않고 즉시 종료
    - 메시지: "사용자의 독후감 작성 수가 5회를 초과했습니다."

  - **Case 3: 정상 (recordCount >= 2 && recordReviewCount < 5)**
    - 확인 모달 표시
    - 실시간 잔여 이용 횟수 표시: `(서비스 내 잔여 이용횟수 : {recordReviewCount}/5)`
    - 확인 버튼 클릭 시 AI 독서감상문 생성 페이지로 이동

**3. 버그 수정**
- 무한 루프 수정: AIWrite 컴포넌트의 useEffect dependency array에서 `navigate`, `openSnackbar` 제거

**4. 파일 변경 사항**
- **신규 파일:**
  - `src/api/record/createAiReview.ts` - AI 독서감상문 생성 API
  - `src/api/record/getAiUsage.ts` - AI 이용 횟수 조회 API
- **수정 파일:**
  - `src/types/record.ts` - `CreateAiReviewData`, `AiUsageData` 타입 추가
  - `src/api/record/index.ts` - 신규 API export 추가
  - `src/pages/aiwrite/AIWrite.tsx` - API 연동 및 로딩/에러 처리
  - `src/components/memory/MemoryAddButton/MemoryAddButton.tsx` - 검증 로직 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 방 기반 AI 리뷰 생성 및 내용 표시 기능 추가
  * 방별 AI 사용량 조회 기능 추가(남은 횟수 확인)

* **UI/동작 개선**
  * AI 작성 흐름을 API 기반 비동기로 전환하여 로딩과 복사 대상이 실제 응답에 따라 갱신
  * 확인 모달에 남은 사용 횟수 표시 후 이동

* **버그 수정 / 오류 처리**
  * API 오류 시 스낵바 안내 및 이전 화면 복귀 처리 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->