### PR TITLE
feat: 모임 만들기 책 선택에서 모임 책 탭 제거

### DIFF
--- a/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
@@ -36,7 +36,6 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBott
     performSearch,
     loadMoreSearchResults,
     loadMoreSavedBooks,
-    loadMoreGroupBooks,
   } = useBookSearch();
 
   // 컴포넌트가 열릴 때 초기 데이터 로드
@@ -89,7 +88,7 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBott
     if (isSearchMode) {
       return loadMoreSearchResults;
     }
-    return activeTab === 'saved' ? loadMoreSavedBooks : loadMoreGroupBooks;
+    return loadMoreSavedBooks;
   };
   
   // 현재 상태에 맞는 무한 스크롤 정보

--- a/src/components/common/BookSearchBottomSheet/BookSearchTabs.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchTabs.tsx
@@ -1,6 +1,6 @@
 import { TabContainer, Tab } from './BookSearchBottomSheet.styled';
 
-export type TabType = 'saved' | 'group';
+export type TabType = 'saved';
 
 interface BookSearchTabsProps {
   activeTab: TabType;
@@ -12,9 +12,6 @@ const BookSearchTabs = ({ activeTab, onTabChange }: BookSearchTabsProps) => {
     <TabContainer>
       <Tab active={activeTab === 'saved'} onClick={() => onTabChange('saved')}>
         저장한 책
-      </Tab>
-      <Tab active={activeTab === 'group'} onClick={() => onTabChange('group')}>
-        모임 책
       </Tab>
     </TabContainer>
   );

--- a/src/components/common/BookSearchBottomSheet/useBookSearch.ts
+++ b/src/components/common/BookSearchBottomSheet/useBookSearch.ts
@@ -9,7 +9,6 @@ export const useBookSearch = () => {
   const [filteredBooks, setFilteredBooks] = useState<Book[]>([]);
   const [activeTab, setActiveTab] = useState<TabType>('saved');
   const [savedBooks, setSavedBooks] = useState<SavedBook[]>([]);
-  const [groupBooks, setGroupBooks] = useState<SavedBook[]>([]);
   const [searchResults, setSearchResults] = useState<SearchedBook[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -17,14 +16,11 @@ export const useBookSearch = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [hasNextPage, setHasNextPage] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  
-  // 저장한 책/모임 책 무한 스크롤 관련 상태
+
+  // 저장한 책 무한 스크롤 관련 상태
   const [savedBooksCursor, setSavedBooksCursor] = useState<string | null>(null);
-  const [groupBooksCursor, setGroupBooksCursor] = useState<string | null>(null);
   const [hasSavedBooksNext, setHasSavedBooksNext] = useState(false);
-  const [hasGroupBooksNext, setHasGroupBooksNext] = useState(false);
   const [isLoadingMoreSavedBooks, setIsLoadingMoreSavedBooks] = useState(false);
-  const [isLoadingMoreGroupBooks, setIsLoadingMoreGroupBooks] = useState(false);
 
   // API에서 받은 데이터를 Book 타입으로 변환하는 함수
   const convertSavedBookToBook = (savedBook: SavedBook): Book => ({
@@ -81,42 +77,6 @@ export const useBookSearch = () => {
     }
   };
 
-  // 모임 책 데이터 가져오기 (무한 스크롤)
-  const fetchGroupBooks = async (isLoadMore: boolean = false) => {
-    try {
-      if (isLoadMore) {
-        setIsLoadingMoreGroupBooks(true);
-      } else {
-        setIsLoading(true);
-        setGroupBooksCursor(null);
-      }
-      setError(null);
-
-      const cursor = isLoadMore ? groupBooksCursor : null;
-      const response = await getSavedBooks('joining', cursor);
-
-      if (response.isSuccess && response.data) {
-        if (isLoadMore) {
-          setGroupBooks(prev => [...prev, ...response.data.bookList]);
-        } else {
-          setGroupBooks(response.data.bookList);
-        }
-        setGroupBooksCursor(response.data.nextCursor);
-        setHasGroupBooksNext(!response.data.isLast);
-      } else {
-        setError(response.message || '모임 책을 불러오는데 실패했습니다.');
-      }
-    } catch (err) {
-      console.error('모임 책 조회 오류:', err);
-      setError('모임 책을 불러오는데 실패했습니다.');
-    } finally {
-      if (isLoadMore) {
-        setIsLoadingMoreGroupBooks(false);
-      } else {
-        setIsLoading(false);
-      }
-    }
-  };
 
   // 실제 검색 API 호출 함수
   const performSearch = async (query: string, page: number = 1, isNewSearch: boolean = true) => {
@@ -189,14 +149,6 @@ export const useBookSearch = () => {
     await fetchSavedBooks(true);
   };
 
-  // 더 많은 모임 책 로드
-  const loadMoreGroupBooks = async () => {
-    if (isLoadingMoreGroupBooks || !hasGroupBooksNext) {
-      return;
-    }
-    
-    await fetchGroupBooks(true);
-  };
 
   // 검색어 변경 핸들러 (디바운싱 적용)
   const handleSearchQueryChange = (query: string) => {
@@ -229,10 +181,9 @@ export const useBookSearch = () => {
     }
 
     // 검색어가 없으면 저장된 책들을 표시
-    const currentTabBooks = activeTab === 'saved' ? savedBooks : groupBooks;
-    const convertedBooks = currentTabBooks.map(convertSavedBookToBook);
+    const convertedBooks = savedBooks.map(convertSavedBookToBook);
     setFilteredBooks(convertedBooks);
-  }, [searchQuery, activeTab, savedBooks, groupBooks, searchResults]);
+  }, [searchQuery, savedBooks, searchResults]);
 
   // 탭 변경 핸들러
   const handleTabChange = async (tab: TabType) => {
@@ -242,8 +193,6 @@ export const useBookSearch = () => {
     // 탭 변경 시 해당 탭의 데이터가 없으면 API 호출
     if (tab === 'saved' && savedBooks.length === 0) {
       await fetchSavedBooks();
-    } else if (tab === 'group' && groupBooks.length === 0) {
-      await fetchGroupBooks();
     }
   };
 
@@ -251,21 +200,18 @@ export const useBookSearch = () => {
   const loadInitialData = () => {
     if (activeTab === 'saved' && savedBooks.length === 0) {
       fetchSavedBooks();
-    } else if (activeTab === 'group' && groupBooks.length === 0) {
-      fetchGroupBooks();
     }
   };
 
   // 현재 상태 계산
   const isSearchMode = searchQuery.trim() !== '';
-  const currentTabBooks = activeTab === 'saved' ? savedBooks : groupBooks;
-  const hasBooks = isSearchMode ? searchResults.length > 0 : currentTabBooks.length > 0;
+  const hasBooks = isSearchMode ? searchResults.length > 0 : savedBooks.length > 0;
   const showEmptyState = !isLoading && !error && !hasBooks;
   const showTabs = !isSearchMode; // 검색 모드가 아닐 때는 항상 탭 표시
-  
+
   // 현재 탭의 무한 스크롤 상태
-  const currentTabHasNext = activeTab === 'saved' ? hasSavedBooksNext : hasGroupBooksNext;
-  const currentTabIsLoadingMore = activeTab === 'saved' ? isLoadingMoreSavedBooks : isLoadingMoreGroupBooks;
+  const currentTabHasNext = hasSavedBooksNext;
+  const currentTabIsLoadingMore = isLoadingMoreSavedBooks;
 
   // 컴포넌트 언마운트 시 타이머 정리
   useEffect(() => {
@@ -298,6 +244,5 @@ export const useBookSearch = () => {
     performSearch,
     loadMoreSearchResults,
     loadMoreSavedBooks,
-    loadMoreGroupBooks,
   };
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#289

## 📝 작업 내용

모임 만들기 시 책 선택 바텀 시트에서 "모임 책" 탭을 제거하고, "저장한 책" 탭만 표시되도록 개선했습니다.

### 주요 변경사항

**1️⃣ UI 컴포넌트 수정**
- `BookSearchTabs.tsx`: "모임 책" 탭 제거, "저장한 책" 탭만 표시
- `TabType` 타입 정의 변경: `'saved' | 'group'` → `'saved'`

**2️⃣ 상태 관리 로직 간소화**
- `useBookSearch.ts`에서 모임 책 관련 상태 변수 제거
  - `groupBooks`, `groupBooksCursor`, `hasGroupBooksNext`, `isLoadingMoreGroupBooks` 제거
- 모임 책 관련 함수 제거
  - `fetchGroupBooks()` 제거
  - `loadMoreGroupBooks()` 제거
- 탭 변경 및 필터링 로직에서 모임 책 관련 분기 처리 제거

**3️⃣ 무한 스크롤 로직 단순화**
- `BookSearchBottomSheet.tsx`의 `getLoadMoreHandler()`에서 모임 책 관련 핸들러 제거
- 저장한 책에 대한 무한 스크롤만 지원

### 변경된 파일
- `src/components/common/BookSearchBottomSheet/BookSearchTabs.tsx`
- `src/components/common/BookSearchBottomSheet/useBookSearch.ts`
- `src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx`

### 기능 영향 범위
- ✅ 모임 만들기 > 책 선택 기능
- ✅ 저장한 책 표시 및 무한 스크롤 정상 작동
- ✅ 책 검색 기능 정상 작동
- ⚠️ 모임 책 탭 관련 기능 완전 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 책 검색 기능에서 모임 책 탭이 제거되었습니다.
  * 저장된 책만 검색하고 표시하도록 단순화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->