### PR TITLE
feat: 모임 생성 시 책 선택에서 모임 책 탭 숨김 처리

### DIFF
--- a/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
@@ -15,9 +15,10 @@ interface BookSearchBottomSheetProps {
   isOpen: boolean;
   onClose: () => void;
   onSelectBook: (book: Book) => void;
+  showGroupTab?: boolean;
 }
 
-const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBottomSheetProps) => {
+const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook, showGroupTab = true }: BookSearchBottomSheetProps) => {
   const {
     searchQuery,
     filteredBooks,
@@ -36,7 +37,8 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBott
     performSearch,
     loadMoreSearchResults,
     loadMoreSavedBooks,
-  } = useBookSearch();
+    loadMoreGroupBooks,
+  } = useBookSearch(showGroupTab);
 
   // 컴포넌트가 열릴 때 초기 데이터 로드
   useEffect(() => {
@@ -88,7 +90,7 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBott
     if (isSearchMode) {
       return loadMoreSearchResults;
     }
-    return loadMoreSavedBooks;
+    return activeTab === 'saved' ? loadMoreSavedBooks : loadMoreGroupBooks;
   };
   
   // 현재 상태에 맞는 무한 스크롤 정보
@@ -108,7 +110,7 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBott
           />
 
           {/* 탭 영역 */}
-          {showTabs && <BookSearchTabs activeTab={activeTab} onTabChange={handleTabChange} />}
+          {showTabs && <BookSearchTabs activeTab={activeTab} onTabChange={handleTabChange} showGroupTab={showGroupTab} />}
 
           {/* 책 목록 영역 */}
           <BookListContainer>

--- a/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
@@ -36,7 +36,6 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBott
     performSearch,
     loadMoreSearchResults,
     loadMoreSavedBooks,
-    loadMoreGroupBooks,
   } = useBookSearch();
 
   // 컴포넌트가 열릴 때 초기 데이터 로드
@@ -89,7 +88,7 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook }: BookSearchBott
     if (isSearchMode) {
       return loadMoreSearchResults;
     }
-    return activeTab === 'saved' ? loadMoreSavedBooks : loadMoreGroupBooks;
+    return loadMoreSavedBooks;
   };
   
   // 현재 상태에 맞는 무한 스크롤 정보

--- a/src/components/common/BookSearchBottomSheet/BookSearchTabs.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchTabs.tsx
@@ -1,18 +1,24 @@
 import { TabContainer, Tab } from './BookSearchBottomSheet.styled';
 
-export type TabType = 'saved';
+export type TabType = 'saved' | 'group';
 
 interface BookSearchTabsProps {
   activeTab: TabType;
   onTabChange: (tab: TabType) => void;
+  showGroupTab?: boolean;
 }
 
-const BookSearchTabs = ({ activeTab, onTabChange }: BookSearchTabsProps) => {
+const BookSearchTabs = ({ activeTab, onTabChange, showGroupTab = true }: BookSearchTabsProps) => {
   return (
     <TabContainer>
       <Tab active={activeTab === 'saved'} onClick={() => onTabChange('saved')}>
         저장한 책
       </Tab>
+      {showGroupTab && (
+        <Tab active={activeTab === 'group'} onClick={() => onTabChange('group')}>
+          모임 책
+        </Tab>
+      )}
     </TabContainer>
   );
 };

--- a/src/components/common/BookSearchBottomSheet/BookSearchTabs.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchTabs.tsx
@@ -1,6 +1,6 @@
 import { TabContainer, Tab } from './BookSearchBottomSheet.styled';
 
-export type TabType = 'saved' | 'group';
+export type TabType = 'saved';
 
 interface BookSearchTabsProps {
   activeTab: TabType;
@@ -12,9 +12,6 @@ const BookSearchTabs = ({ activeTab, onTabChange }: BookSearchTabsProps) => {
     <TabContainer>
       <Tab active={activeTab === 'saved'} onClick={() => onTabChange('saved')}>
         저장한 책
-      </Tab>
-      <Tab active={activeTab === 'group'} onClick={() => onTabChange('group')}>
-        모임 책
       </Tab>
     </TabContainer>
   );

--- a/src/components/common/BookSearchBottomSheet/useBookSearch.ts
+++ b/src/components/common/BookSearchBottomSheet/useBookSearch.ts
@@ -4,11 +4,12 @@ import { getSearchBooks, convertToSearchedBooks, type SearchedBook } from '@/api
 import type { Book } from './BookList';
 import type { TabType } from './BookSearchTabs';
 
-export const useBookSearch = () => {
+export const useBookSearch = (showGroupTab: boolean = true) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [filteredBooks, setFilteredBooks] = useState<Book[]>([]);
   const [activeTab, setActiveTab] = useState<TabType>('saved');
   const [savedBooks, setSavedBooks] = useState<SavedBook[]>([]);
+  const [groupBooks, setGroupBooks] = useState<SavedBook[]>([]);
   const [searchResults, setSearchResults] = useState<SearchedBook[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -17,10 +18,13 @@ export const useBookSearch = () => {
   const [hasNextPage, setHasNextPage] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
 
-  // 저장한 책 무한 스크롤 관련 상태
+  // 저장한 책/모임 책 무한 스크롤 관련 상태
   const [savedBooksCursor, setSavedBooksCursor] = useState<string | null>(null);
+  const [groupBooksCursor, setGroupBooksCursor] = useState<string | null>(null);
   const [hasSavedBooksNext, setHasSavedBooksNext] = useState(false);
+  const [hasGroupBooksNext, setHasGroupBooksNext] = useState(false);
   const [isLoadingMoreSavedBooks, setIsLoadingMoreSavedBooks] = useState(false);
+  const [isLoadingMoreGroupBooks, setIsLoadingMoreGroupBooks] = useState(false);
 
   // API에서 받은 데이터를 Book 타입으로 변환하는 함수
   const convertSavedBookToBook = (savedBook: SavedBook): Book => ({
@@ -77,6 +81,42 @@ export const useBookSearch = () => {
     }
   };
 
+  // 모임 책 데이터 가져오기 (무한 스크롤)
+  const fetchGroupBooks = async (isLoadMore: boolean = false) => {
+    try {
+      if (isLoadMore) {
+        setIsLoadingMoreGroupBooks(true);
+      } else {
+        setIsLoading(true);
+        setGroupBooksCursor(null);
+      }
+      setError(null);
+
+      const cursor = isLoadMore ? groupBooksCursor : null;
+      const response = await getSavedBooks('joining', cursor);
+
+      if (response.isSuccess && response.data) {
+        if (isLoadMore) {
+          setGroupBooks(prev => [...prev, ...response.data.bookList]);
+        } else {
+          setGroupBooks(response.data.bookList);
+        }
+        setGroupBooksCursor(response.data.nextCursor);
+        setHasGroupBooksNext(!response.data.isLast);
+      } else {
+        setError(response.message || '모임 책을 불러오는데 실패했습니다.');
+      }
+    } catch (err) {
+      console.error('모임 책 조회 오류:', err);
+      setError('모임 책을 불러오는데 실패했습니다.');
+    } finally {
+      if (isLoadMore) {
+        setIsLoadingMoreGroupBooks(false);
+      } else {
+        setIsLoading(false);
+      }
+    }
+  };
 
   // 실제 검색 API 호출 함수
   const performSearch = async (query: string, page: number = 1, isNewSearch: boolean = true) => {
@@ -145,10 +185,18 @@ export const useBookSearch = () => {
     if (isLoadingMoreSavedBooks || !hasSavedBooksNext) {
       return;
     }
-    
+
     await fetchSavedBooks(true);
   };
 
+  // 더 많은 모임 책 로드
+  const loadMoreGroupBooks = async () => {
+    if (isLoadingMoreGroupBooks || !hasGroupBooksNext) {
+      return;
+    }
+
+    await fetchGroupBooks(true);
+  };
 
   // 검색어 변경 핸들러 (디바운싱 적용)
   const handleSearchQueryChange = (query: string) => {
@@ -181,9 +229,10 @@ export const useBookSearch = () => {
     }
 
     // 검색어가 없으면 저장된 책들을 표시
-    const convertedBooks = savedBooks.map(convertSavedBookToBook);
+    const currentTabBooks = activeTab === 'saved' ? savedBooks : groupBooks;
+    const convertedBooks = currentTabBooks.map(convertSavedBookToBook);
     setFilteredBooks(convertedBooks);
-  }, [searchQuery, savedBooks, searchResults]);
+  }, [searchQuery, activeTab, savedBooks, groupBooks, searchResults]);
 
   // 탭 변경 핸들러
   const handleTabChange = async (tab: TabType) => {
@@ -193,6 +242,8 @@ export const useBookSearch = () => {
     // 탭 변경 시 해당 탭의 데이터가 없으면 API 호출
     if (tab === 'saved' && savedBooks.length === 0) {
       await fetchSavedBooks();
+    } else if (tab === 'group' && groupBooks.length === 0) {
+      await fetchGroupBooks();
     }
   };
 
@@ -200,18 +251,21 @@ export const useBookSearch = () => {
   const loadInitialData = () => {
     if (activeTab === 'saved' && savedBooks.length === 0) {
       fetchSavedBooks();
+    } else if (activeTab === 'group' && groupBooks.length === 0 && showGroupTab) {
+      fetchGroupBooks();
     }
   };
 
   // 현재 상태 계산
   const isSearchMode = searchQuery.trim() !== '';
-  const hasBooks = isSearchMode ? searchResults.length > 0 : savedBooks.length > 0;
+  const currentTabBooks = activeTab === 'saved' ? savedBooks : groupBooks;
+  const hasBooks = isSearchMode ? searchResults.length > 0 : currentTabBooks.length > 0;
   const showEmptyState = !isLoading && !error && !hasBooks;
   const showTabs = !isSearchMode; // 검색 모드가 아닐 때는 항상 탭 표시
 
   // 현재 탭의 무한 스크롤 상태
-  const currentTabHasNext = hasSavedBooksNext;
-  const currentTabIsLoadingMore = isLoadingMoreSavedBooks;
+  const currentTabHasNext = activeTab === 'saved' ? hasSavedBooksNext : hasGroupBooksNext;
+  const currentTabIsLoadingMore = activeTab === 'saved' ? isLoadingMoreSavedBooks : isLoadingMoreGroupBooks;
 
   // 컴포넌트 언마운트 시 타이머 정리
   useEffect(() => {
@@ -244,5 +298,6 @@ export const useBookSearch = () => {
     performSearch,
     loadMoreSearchResults,
     loadMoreSavedBooks,
+    loadMoreGroupBooks,
   };
 };

--- a/src/components/common/BookSearchBottomSheet/useBookSearch.ts
+++ b/src/components/common/BookSearchBottomSheet/useBookSearch.ts
@@ -9,7 +9,6 @@ export const useBookSearch = () => {
   const [filteredBooks, setFilteredBooks] = useState<Book[]>([]);
   const [activeTab, setActiveTab] = useState<TabType>('saved');
   const [savedBooks, setSavedBooks] = useState<SavedBook[]>([]);
-  const [groupBooks, setGroupBooks] = useState<SavedBook[]>([]);
   const [searchResults, setSearchResults] = useState<SearchedBook[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -17,14 +16,11 @@ export const useBookSearch = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [hasNextPage, setHasNextPage] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  
-  // 저장한 책/모임 책 무한 스크롤 관련 상태
+
+  // 저장한 책 무한 스크롤 관련 상태
   const [savedBooksCursor, setSavedBooksCursor] = useState<string | null>(null);
-  const [groupBooksCursor, setGroupBooksCursor] = useState<string | null>(null);
   const [hasSavedBooksNext, setHasSavedBooksNext] = useState(false);
-  const [hasGroupBooksNext, setHasGroupBooksNext] = useState(false);
   const [isLoadingMoreSavedBooks, setIsLoadingMoreSavedBooks] = useState(false);
-  const [isLoadingMoreGroupBooks, setIsLoadingMoreGroupBooks] = useState(false);
 
   // API에서 받은 데이터를 Book 타입으로 변환하는 함수
   const convertSavedBookToBook = (savedBook: SavedBook): Book => ({
@@ -81,42 +77,6 @@ export const useBookSearch = () => {
     }
   };
 
-  // 모임 책 데이터 가져오기 (무한 스크롤)
-  const fetchGroupBooks = async (isLoadMore: boolean = false) => {
-    try {
-      if (isLoadMore) {
-        setIsLoadingMoreGroupBooks(true);
-      } else {
-        setIsLoading(true);
-        setGroupBooksCursor(null);
-      }
-      setError(null);
-
-      const cursor = isLoadMore ? groupBooksCursor : null;
-      const response = await getSavedBooks('joining', cursor);
-
-      if (response.isSuccess && response.data) {
-        if (isLoadMore) {
-          setGroupBooks(prev => [...prev, ...response.data.bookList]);
-        } else {
-          setGroupBooks(response.data.bookList);
-        }
-        setGroupBooksCursor(response.data.nextCursor);
-        setHasGroupBooksNext(!response.data.isLast);
-      } else {
-        setError(response.message || '모임 책을 불러오는데 실패했습니다.');
-      }
-    } catch (err) {
-      console.error('모임 책 조회 오류:', err);
-      setError('모임 책을 불러오는데 실패했습니다.');
-    } finally {
-      if (isLoadMore) {
-        setIsLoadingMoreGroupBooks(false);
-      } else {
-        setIsLoading(false);
-      }
-    }
-  };
 
   // 실제 검색 API 호출 함수
   const performSearch = async (query: string, page: number = 1, isNewSearch: boolean = true) => {
@@ -189,14 +149,6 @@ export const useBookSearch = () => {
     await fetchSavedBooks(true);
   };
 
-  // 더 많은 모임 책 로드
-  const loadMoreGroupBooks = async () => {
-    if (isLoadingMoreGroupBooks || !hasGroupBooksNext) {
-      return;
-    }
-    
-    await fetchGroupBooks(true);
-  };
 
   // 검색어 변경 핸들러 (디바운싱 적용)
   const handleSearchQueryChange = (query: string) => {
@@ -229,10 +181,9 @@ export const useBookSearch = () => {
     }
 
     // 검색어가 없으면 저장된 책들을 표시
-    const currentTabBooks = activeTab === 'saved' ? savedBooks : groupBooks;
-    const convertedBooks = currentTabBooks.map(convertSavedBookToBook);
+    const convertedBooks = savedBooks.map(convertSavedBookToBook);
     setFilteredBooks(convertedBooks);
-  }, [searchQuery, activeTab, savedBooks, groupBooks, searchResults]);
+  }, [searchQuery, savedBooks, searchResults]);
 
   // 탭 변경 핸들러
   const handleTabChange = async (tab: TabType) => {
@@ -242,8 +193,6 @@ export const useBookSearch = () => {
     // 탭 변경 시 해당 탭의 데이터가 없으면 API 호출
     if (tab === 'saved' && savedBooks.length === 0) {
       await fetchSavedBooks();
-    } else if (tab === 'group' && groupBooks.length === 0) {
-      await fetchGroupBooks();
     }
   };
 
@@ -251,21 +200,18 @@ export const useBookSearch = () => {
   const loadInitialData = () => {
     if (activeTab === 'saved' && savedBooks.length === 0) {
       fetchSavedBooks();
-    } else if (activeTab === 'group' && groupBooks.length === 0) {
-      fetchGroupBooks();
     }
   };
 
   // 현재 상태 계산
   const isSearchMode = searchQuery.trim() !== '';
-  const currentTabBooks = activeTab === 'saved' ? savedBooks : groupBooks;
-  const hasBooks = isSearchMode ? searchResults.length > 0 : currentTabBooks.length > 0;
+  const hasBooks = isSearchMode ? searchResults.length > 0 : savedBooks.length > 0;
   const showEmptyState = !isLoading && !error && !hasBooks;
   const showTabs = !isSearchMode; // 검색 모드가 아닐 때는 항상 탭 표시
-  
+
   // 현재 탭의 무한 스크롤 상태
-  const currentTabHasNext = activeTab === 'saved' ? hasSavedBooksNext : hasGroupBooksNext;
-  const currentTabIsLoadingMore = activeTab === 'saved' ? isLoadingMoreSavedBooks : isLoadingMoreGroupBooks;
+  const currentTabHasNext = hasSavedBooksNext;
+  const currentTabIsLoadingMore = isLoadingMoreSavedBooks;
 
   // 컴포넌트 언마운트 시 타이머 정리
   useEffect(() => {
@@ -298,6 +244,5 @@ export const useBookSearch = () => {
     performSearch,
     loadMoreSearchResults,
     loadMoreSavedBooks,
-    loadMoreGroupBooks,
   };
 };

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -246,6 +246,7 @@ const CreateGroup = () => {
           isOpen={isBookSearchOpen}
           onClose={handleBookSearchClose}
           onSelectBook={handleBookSelect}
+          showGroupTab={false}
         />
       </Container>
     </>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#289

## 📝 작업 내용

모임 만들기 시 책 선택 바텀 시트에서 "모임 책" 탭을 제거하고, "저장한 책" 탭만 표시되도록 개선했습니다.

### 주요 변경사항

**1️⃣ BookSearchTabs 컴포넌트 개선**
- `showGroupTab` prop 추가 (기본값: `true`)
- "모임 책" 탭을 조건부로 렌더링하도록 수정
- 기존 다른 페이지에서는 기본값으로 두 탭 모두 표시

**2️⃣ useBookSearch 훅 파라미터 추가**
- `showGroupTab` 파라미터 추가하여 모임 책 관련 로직 제어
- 모임 책 탭이 숨겨진 경우에도 기존 로직은 모두 유지 (다른 페이지 호환성)
- 초기 데이터 로드 시 `showGroupTab` 값에 따라 조건부 로드

**3️⃣ BookSearchBottomSheet 컴포넌트 업데이트**
- `showGroupTab` prop 추가하여 상위 컴포넌트에서 제어 가능하도록 수정
- 하위 컴포넌트(BookSearchTabs, useBookSearch)에 prop 전달

**4️⃣ CreateGroup 페이지 적용**
- `BookSearchBottomSheet`에 `showGroupTab={false}` 전달
- 모임 생성 시에만 "저장한 책" 탭만 표시

### 변경된 파일
- src/components/common/BookSearchBottomSheet/BookSearchTabs.tsx
- src/components/common/BookSearchBottomSheet/useBookSearch.ts
- src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
- src/pages/group/CreateGroup.tsx

### 기능 영향 범위
- ✅ 모임 생성 페이지: "저장한 책" 탭만 표시
- ✅ 기타 페이지: 기존처럼 "저장한 책", "모임 책" 탭 모두 표시
- ✅ 저장한 책 표시 및 무한 스크롤 정상 작동
- ✅ 모임 책 표시 및 무한 스크롤 정상 작동 (showGroupTab=true인 경우)
- ✅ 책 검색 기능 정상 작동
- ✅ 기존 코드 호환성 유지 (기본값으로 모든 기능 동작)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 도서 검색 화면에서 그룹 탭을 선택적으로 표시하거나 숨길 수 있도록 개선되었습니다. 일부 페이지에서는 그룹 탭이 기본적으로 비활성화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->