### PR TITLE
THIP-389: 지현 주석 및 개발 로그 제거

### DIFF
--- a/src/api/feeds/createFeed.ts
+++ b/src/api/feeds/createFeed.ts
@@ -1,6 +1,5 @@
 import { apiClient } from '../index';
 
-/** 서버에 보낼 request JSON 페이로드 */
 export interface CreateFeedBody {
   isbn: string;
   contentBody: string;
@@ -9,7 +8,6 @@ export interface CreateFeedBody {
   imageUrls?: string[];
 }
 
-/** 성공 응답 */
 export interface CreateFeedSuccess {
   isSuccess: true;
   code: number;
@@ -19,7 +17,6 @@ export interface CreateFeedSuccess {
   };
 }
 
-/** 실패 응답 */
 export interface CreateFeedFail {
   isSuccess: false;
   code: number;
@@ -28,14 +25,7 @@ export interface CreateFeedFail {
 
 export type CreateFeedResponse = CreateFeedSuccess | CreateFeedFail;
 
-/**
- * 피드 작성 API
- * - application/json (presigned URL 방식)
- * - imageUrls: 미리 S3에 업로드한 이미지의 CloudFront URL 목록
- */
-export const createFeed = async (
-  body: CreateFeedBody,
-): Promise<CreateFeedResponse> => {
+export const createFeed = async (body: CreateFeedBody): Promise<CreateFeedResponse> => {
   const { data } = await apiClient.post<CreateFeedResponse>('/feeds', body);
   return data;
 };

--- a/src/api/feeds/getWriteInfo.ts
+++ b/src/api/feeds/getWriteInfo.ts
@@ -1,17 +1,14 @@
 import { apiClient } from '../index';
 
-// 카테고리 및 태그 데이터 타입
 export interface CategoryData {
   category: string;
   tagList: string[];
 }
 
-// API 응답 데이터 타입
 export interface WriteInfoData {
   categoryList: CategoryData[];
 }
 
-// API 응답 타입
 export interface GetWriteInfoResponse {
   isSuccess: boolean;
   code: number;
@@ -19,20 +16,7 @@ export interface GetWriteInfoResponse {
   data: WriteInfoData;
 }
 
-// 새 글 작성을 위한 카테고리 및 태그 조회 API 함수
 export const getWriteInfo = async () => {
   const response = await apiClient.get<GetWriteInfoResponse>('/feeds/write-info');
   return response.data;
 };
-
-/*
-사용 예시:
-const writeInfo = await getWriteInfo();
-console.log(writeInfo.data.categoryList); // CategoryData[]
-
-// 카테고리별 태그 접근
-writeInfo.data.categoryList.forEach(category => {
-  console.log(`카테고리: ${category.category}`);
-  console.log(`태그: ${category.tagList.join(', ')}`);
-});
-*/

--- a/src/api/feeds/updateFeed.ts
+++ b/src/api/feeds/updateFeed.ts
@@ -1,6 +1,5 @@
 import { apiClient } from '../index';
 
-/** 피드 수정 요청 바디 타입 */
 export interface UpdateFeedBody {
   contentBody: string;
   isPublic: boolean;
@@ -8,14 +7,11 @@ export interface UpdateFeedBody {
   remainImageUrls?: string[];
 }
 
-/** 성공 응답 */
 export interface UpdateFeedSuccess {
   isSuccess: true;
   code: number;
   message: string;
 }
-
-/** 실패 응답 */
 export interface UpdateFeedFail {
   isSuccess: false;
   code: number;
@@ -24,12 +20,6 @@ export interface UpdateFeedFail {
 
 export type UpdateFeedResponse = UpdateFeedSuccess | UpdateFeedFail;
 
-/**
- * 피드 수정 API
- * - multipart/form-data
- *   - request: application/json (Blob로 감싸 전송)
- *   - 이미지 추가는 불가능, 기존 이미지 삭제만 가능
- */
 export const updateFeed = async (
   feedId: number,
   body: UpdateFeedBody,
@@ -53,36 +43,3 @@ export const updateFeed = async (
     return data;
   }
 };
-
-/*
-사용 예시:
-
-// 기존 이미지 일부 유지 (새 이미지 추가는 불가)
-const updateBody: UpdateFeedBody = {
-  contentBody: "수정된 글 내용입니다!",
-  isPublic: true,
-  tagList: ["한국소설", "책추천", "역사"],
-  remainImageUrls: ["https://img.domain.com/1.jpg"] // 기존 이미지 중 유지할 것들
-};
-
-try {
-  const result = await updateFeed(123, updateBody);
-  if (result.isSuccess) {
-    console.log('피드 수정 성공:', result.message);
-  } else {
-    console.error('피드 수정 실패:', result.message);
-  }
-} catch (error) {
-  console.error('네트워크 오류:', error);
-}
-
-// 모든 이미지 삭제 후 텍스트만 수정
-const textOnlyUpdate: UpdateFeedBody = {
-  contentBody: "텍스트만 수정",
-  isPublic: false,
-  tagList: [],
-  remainImageUrls: [] // 모든 기존 이미지 삭제
-};
-
-const result = await updateFeed(123, textOnlyUpdate);
-*/

--- a/src/api/images/uploadImage.ts
+++ b/src/api/images/uploadImage.ts
@@ -1,45 +1,35 @@
 import { apiClient } from '../index';
 
-/** 단일 이미지 업로드 성공 시 데이터 */
 export interface UploadImageData {
   imageUrl: string;
 }
 
-/** 서버 공통 응답 타입 */
 export interface UploadImageResponse {
   isSuccess: boolean;
   code: number;
   message: string;
-  data?: UploadImageData; // 성공 시에만 존재
+  data?: UploadImageData;
 }
 
-/** 내부 유틸: 허용 확장자 */
 const IMAGE_EXT_REGEX = /\.(jpe?g|png|gif)$/i;
-/** 가이드 최대 업로드 개수 (서버는 FEED 생성 시 최대 3장 제약) */
 export const MAX_IMAGES = 3;
 
-/** 파일 사전 검증: 빈 파일 / 확장자 */
 function validateFile(file: File) {
   if (!file || file.size === 0) {
-    // 서버 코드 170001과 의미 일치
     throw new Error('업로드하려는 이미지가 비어있습니다.');
   }
   if (!IMAGE_EXT_REGEX.test(file.name)) {
-    // 서버 코드 170003과 의미 일치
     throw new Error('파일 형식은 jpg, jpeg, png, gif만 가능합니다.');
   }
 }
 
-/** 단일 이미지 업로드 */
 export const uploadImage = async (
   file: File,
   options?: { signal?: AbortSignal },
 ): Promise<UploadImageResponse> => {
-  // 사전 검증
   validateFile(file);
 
   const formData = new FormData();
-  // 서버가 단일 업로드에서 기대하는 필드명이 image라면 유지
   formData.append('image', file);
 
   const { data } = await apiClient.post<UploadImageResponse>('/images/upload', formData, {
@@ -50,24 +40,16 @@ export const uploadImage = async (
   return data;
 };
 
-/**
- * 다중 이미지 업로드
- * - 전부 성공하면 URL 배열 반환
- * - 하나라도 실패하면 실패 내역을 포함해 throw
- */
 export const uploadMultipleImages = async (
   files: File[],
   options?: { signal?: AbortSignal; enforceMax?: boolean },
 ): Promise<string[]> => {
-  // 개수 제한(선택) – FEED 생성 정책에 맞춰 사전 차단하고 싶을 때 사용
   if (options?.enforceMax && files.length > MAX_IMAGES) {
     throw new Error(`이미지는 최대 ${MAX_IMAGES}장까지 업로드할 수 있습니다.`);
   }
 
-  // 파일별 사전 검증
   files.forEach(validateFile);
 
-  // 병렬 업로드 (각 요청 독립)
   const results = await Promise.allSettled(
     files.map(file => uploadImage(file, { signal: options?.signal })),
   );
@@ -95,34 +77,9 @@ export const uploadMultipleImages = async (
   });
 
   if (failures.length > 0) {
-    // 어떤 항목이 왜 실패했는지 상세 메시지
     const detail = failures.map(f => `#${f.index + 1}: ${f.reason}`).join(' / ');
     throw new Error(`일부 이미지 업로드에 실패했습니다. (${detail})`);
   }
 
   return successUrls;
 };
-
-/*
-사용 예시:
-
-// 단일
-try {
-  const res = await uploadImage(file);
-  if (res.isSuccess) {
-    console.log('업로드된 URL:', res.data?.imageUrl);
-  } else {
-    console.error('실패:', res.message);
-  }
-} catch (e) {
-  console.error('오류:', e);
-}
-
-// 다중
-try {
-  const urls = await uploadMultipleImages(files, { enforceMax: true });
-  console.log('업로드된 URL들:', urls);
-} catch (e) {
-  console.error('다중 업로드 실패:', e);
-}
-*/

--- a/src/api/memory/getMemoryPosts.ts
+++ b/src/api/memory/getMemoryPosts.ts
@@ -1,40 +1,35 @@
 import { apiClient } from '../index';
 import type { GetMemoryPostsParams, GetMemoryPostsResponse } from '@/types/memory';
 
-// 기록장 조회 API 함수
 export const getMemoryPosts = async (
   params: GetMemoryPostsParams,
 ): Promise<GetMemoryPostsResponse> => {
   const { roomId, ...queryParams } = params;
 
-  // 쿼리 파라미터 생성
   const searchParams = new URLSearchParams();
 
-  // 기본값 적용
   searchParams.append('type', queryParams.type || 'group');
 
-  // type이 group인 경우만 sort 파라미터 추가
   if ((queryParams.type || 'group') === 'group' && queryParams.sort) {
     searchParams.append('sort', queryParams.sort);
   }
 
-  // 페이지 필터 파라미터
   if (queryParams.pageStart !== undefined && queryParams.pageStart !== null) {
     searchParams.append('pageStart', queryParams.pageStart.toString());
   }
+
   if (queryParams.pageEnd !== undefined && queryParams.pageEnd !== null) {
     searchParams.append('pageEnd', queryParams.pageEnd.toString());
   }
 
-  // 필터 파라미터
   if (queryParams.isOverview !== undefined) {
     searchParams.append('isOverview', queryParams.isOverview.toString());
   }
+
   if (queryParams.isPageFilter !== undefined) {
     searchParams.append('isPageFilter', queryParams.isPageFilter.toString());
   }
 
-  // 커서 파라미터
   if (queryParams.cursor) {
     searchParams.append('cursor', queryParams.cursor);
   }
@@ -49,51 +44,3 @@ export const getMemoryPosts = async (
     throw error;
   }
 };
-
-/*
-사용 예시:
-
-// 그룹 기록 전체 조회 (기본)
-const groupPosts = await getMemoryPosts({
-  roomId: 1
-});
-
-// 내 기록만 조회
-const myPosts = await getMemoryPosts({
-  roomId: 1,
-  type: 'mine'
-});
-
-// 그룹 기록 인기순 정렬
-const popularPosts = await getMemoryPosts({
-  roomId: 1,
-  type: 'group',
-  sort: 'like'
-});
-
-// 페이지 필터 적용 (10-20페이지)
-const pagePosts = await getMemoryPosts({
-  roomId: 1,
-  type: 'group',
-  pageStart: 10,
-  pageEnd: 20,
-  isPageFilter: true
-});
-
-// 총평 보기 필터
-const overviewPosts = await getMemoryPosts({
-  roomId: 1,
-  type: 'group',
-  isOverview: true
-});
-
-// 페이지네이션 (다음 페이지)
-const nextPagePosts = await getMemoryPosts({
-  roomId: 1,
-  cursor: 'some-cursor-value'
-});
-
-console.log('Posts:', groupPosts.data.postList);
-console.log('Next cursor:', groupPosts.data.nextCursor);
-console.log('Is last page:', groupPosts.data.isLast);
-*/

--- a/src/api/record/createAiReview.ts
+++ b/src/api/record/createAiReview.ts
@@ -1,31 +1,11 @@
 import { apiClient } from '../index';
 import type { CreateAiReviewData, ApiResponse } from '@/types/record';
 
-// API 응답 타입
 export type CreateAiReviewResponse = ApiResponse<CreateAiReviewData>;
 
-// AI 독서감상문 생성 API 함수
 export const createAiReview = async (roomId: number) => {
   const response = await apiClient.post<CreateAiReviewResponse>(
     `/rooms/${roomId}/record/ai-review`,
   );
   return response.data;
 };
-
-/*
-사용 예시:
-try {
-  const result = await createAiReview(1);
-  if (result.isSuccess) {
-    console.log("생성된 독서감상문:", result.data.content);
-    console.log("잔여 이용 횟수:", result.data.count);
-    // 성공 처리 로직
-  } else {
-    console.error("AI 독서감상문 생성 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/record/createRecord.ts
+++ b/src/api/record/createRecord.ts
@@ -1,10 +1,8 @@
 import { apiClient } from '../index';
 import type { CreateRecordRequest, CreateRecordData, ApiResponse } from '@/types/record';
 
-// API 응답 타입
 export type CreateRecordResponse = ApiResponse<CreateRecordData>;
 
-// 기록 생성 API 함수
 export const createRecord = async (roomId: number, recordData: CreateRecordRequest) => {
   const response = await apiClient.post<CreateRecordResponse>(
     `/rooms/${roomId}/record`,
@@ -12,27 +10,3 @@ export const createRecord = async (roomId: number, recordData: CreateRecordReque
   );
   return response.data;
 };
-
-/*
-사용 예시:
-const recordData: CreateRecordRequest = {
-  page: 20,
-  isOverview: false,
-  content: "맘은 최고의 새버린다."
-};
-
-try {
-  const result = await createRecord(1, recordData);
-  if (result.isSuccess) {
-    console.log("생성된 기록 ID:", result.data.recordId);
-    console.log("방 ID:", result.data.roomId);
-    // 성공 처리 로직
-  } else {
-    console.error("기록 생성 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/record/createVote.ts
+++ b/src/api/record/createVote.ts
@@ -1,39 +1,9 @@
 import { apiClient } from '../index';
 import type { CreateVoteRequest, CreateVoteData, ApiResponse } from '@/types/record';
 
-// API 응답 타입
 export type CreateVoteResponse = ApiResponse<CreateVoteData>;
 
-// 투표 생성 API 함수
 export const createVote = async (roomId: number, voteData: CreateVoteRequest) => {
   const response = await apiClient.post<CreateVoteResponse>(`/rooms/${roomId}/vote`, voteData);
   return response.data;
 };
-
-/*
-사용 예시:
-const voteData: CreateVoteRequest = {
-  page: 20,
-  isOverview: true,
-  content: "맘은 최고의 새버린다. 셰익스피어의?",
-  voteItemList: [
-    { itemName: "네" },
-    { itemName: "아니오" }
-  ]
-};
-
-try {
-  const result = await createVote(1, voteData);
-  if (result.isSuccess) {
-    console.log("생성된 투표 ID:", result.data.voteId);
-    console.log("방 ID:", result.data.roomId);
-    // 성공 처리 로직
-  } else {
-    console.error("투표 생성 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/record/deleteRecord.ts
+++ b/src/api/record/deleteRecord.ts
@@ -1,15 +1,12 @@
 import { apiClient } from '../index';
 import type { ApiResponse } from '@/types/record';
 
-// 기록 삭제 응답 데이터 타입
 export interface DeleteRecordData {
-  roomId: number; // 삭제된 기록이 속한 방 ID
+  roomId: number;
 }
 
-// API 응답 타입
 export type DeleteRecordResponse = ApiResponse<DeleteRecordData>;
 
-// 기록 삭제 API 함수
 export const deleteRecord = async (
   roomId: number,
   recordId: number,
@@ -24,20 +21,3 @@ export const deleteRecord = async (
     throw error;
   }
 };
-
-/*
-사용 예시:
-try {
-  const result = await deleteRecord(1, 123);
-  if (result.isSuccess) {
-    console.log("기록 삭제 성공:", result.data.roomId);
-    // 성공 처리 로직 (예: 목록에서 제거, 성공 메시지 표시)
-  } else {
-    console.error("기록 삭제 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/record/deleteVote.ts
+++ b/src/api/record/deleteVote.ts
@@ -1,15 +1,12 @@
 import { apiClient } from '../index';
 import type { ApiResponse } from '@/types/record';
 
-// 투표 삭제 응답 데이터 타입
 export interface DeleteVoteData {
-  roomId: number; // 삭제된 투표가 속한 방 ID
+  roomId: number;
 }
 
-// API 응답 타입
 export type DeleteVoteResponse = ApiResponse<DeleteVoteData>;
 
-// 투표 삭제 API 함수
 export const deleteVote = async (roomId: number, voteId: number): Promise<DeleteVoteResponse> => {
   try {
     const response = await apiClient.delete<DeleteVoteResponse>(`/rooms/${roomId}/vote/${voteId}`);
@@ -19,20 +16,3 @@ export const deleteVote = async (roomId: number, voteId: number): Promise<Delete
     throw error;
   }
 };
-
-/*
-사용 예시:
-try {
-  const result = await deleteVote(1, 456);
-  if (result.isSuccess) {
-    console.log("투표 삭제 성공:", result.data.roomId);
-    // 성공 처리 로직 (예: 목록에서 제거, 성공 메시지 표시)
-  } else {
-    console.error("투표 삭제 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/record/getAiUsage.ts
+++ b/src/api/record/getAiUsage.ts
@@ -1,31 +1,9 @@
 import { apiClient } from '../index';
 import type { AiUsageData, ApiResponse } from '@/types/record';
 
-// API 응답 타입
 export type GetAiUsageResponse = ApiResponse<AiUsageData>;
 
-// AI 이용 횟수 조회 API 함수
 export const getAiUsage = async (roomId: number) => {
-  const response = await apiClient.get<GetAiUsageResponse>(
-    `/rooms/${roomId}/users/ai-usage`,
-  );
+  const response = await apiClient.get<GetAiUsageResponse>(`/rooms/${roomId}/users/ai-usage`);
   return response.data;
 };
-
-/*
-사용 예시:
-try {
-  const result = await getAiUsage(1);
-  if (result.isSuccess) {
-    console.log("AI 독서감상문 작성 가능 횟수:", result.data.recordReviewCount);
-    console.log("기록 작성 횟수:", result.data.recordCount);
-    // 성공 처리 로직
-  } else {
-    console.error("AI 이용 횟수 조회 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/record/pinRecordToFeed.ts
+++ b/src/api/record/pinRecordToFeed.ts
@@ -1,7 +1,6 @@
 import { apiClient } from '../index';
 import type { ApiResponse } from '@/types/record';
 
-// 피드 핀 응답 데이터 타입
 export interface PinRecordData {
   bookTitle: string;
   authorName: string;
@@ -9,33 +8,11 @@ export interface PinRecordData {
   isbn: string;
 }
 
-// API 응답 타입
 export type PinRecordResponse = ApiResponse<PinRecordData>;
 
-// 기록을 피드에 핀하기 API 함수
 export const pinRecordToFeed = async (roomId: number, recordId: number) => {
   const response = await apiClient.get<PinRecordResponse>(
-    `/rooms/${roomId}/records/${recordId}/pin`
+    `/rooms/${roomId}/records/${recordId}/pin`,
   );
   return response.data;
 };
-
-/*
-사용 예시:
-try {
-  const result = await pinRecordToFeed(1, 123);
-  if (result.isSuccess) {
-    console.log("책 제목:", result.data.bookTitle);
-    console.log("저자명:", result.data.authorName);
-    console.log("책 이미지:", result.data.bookImageUrl);
-    console.log("ISBN:", result.data.isbn);
-    // 성공 처리 로직 - 피드 작성 화면으로 이동
-  } else {
-    console.error("핀하기 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/record/postVote.ts
+++ b/src/api/record/postVote.ts
@@ -1,47 +1,20 @@
 import { apiClient } from '../index';
 import type { VoteRequest, VoteData, ApiResponse } from '@/types/record';
 
-// API 응답 타입
 export type VoteResponse = ApiResponse<VoteData>;
 
-// 투표하기 API 함수
 export const postVote = async (roomId: number, voteId: number, voteData: VoteRequest) => {
   try {
-    const response = await apiClient.post<VoteResponse>(`/rooms/${roomId}/vote/${voteId}`, voteData);
+    const response = await apiClient.post<VoteResponse>(
+      `/rooms/${roomId}/vote/${voteId}`,
+      voteData,
+    );
     return response.data;
   } catch (error: any) {
     console.error('투표 API 오류:', error);
-    // 서버에서 에러 응답을 보낸 경우 해당 응답을 반환
     if (error.response?.data) {
       return error.response.data;
     }
     throw error;
   }
 };
-
-/*
-사용 예시:
-const voteData: VoteRequest = {
-  voteItemId: 1,
-  type: true // true: 투표하기, false: 투표취소
-};
-
-try {
-  const result = await postVote(1, 1, voteData);
-  if (result.isSuccess) {
-    console.log("투표 성공:", result.data);
-    console.log("포스트 ID:", result.data.postId);
-    console.log("방 ID:", result.data.roomId);
-    console.log("투표 결과:", result.data.voteItems);
-    // 성공 처리 로직
-  } else {
-    console.error("투표 실패:", result.message);
-    // 실패 처리 로직 (에러 코드별 분기 처리 가능)
-    // 120001: 이미 투표한 투표항목입니다.
-    // 120002: 투표하지 않은 투표항목은 취소할 수 없습니다.
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/record/updateRecord.ts
+++ b/src/api/record/updateRecord.ts
@@ -1,10 +1,8 @@
 import { apiClient } from '../index';
 import type { UpdateRecordRequest, UpdateRecordData, ApiResponse } from '@/types/record';
 
-// API 응답 타입
 export type UpdateRecordResponse = ApiResponse<UpdateRecordData>;
 
-// 기록 수정 API 함수
 export const updateRecord = async (
   roomId: number,
   recordId: number,
@@ -21,24 +19,3 @@ export const updateRecord = async (
     throw error;
   }
 };
-
-/*
-사용 예시:
-const recordData: UpdateRecordRequest = {
-  content: "수정된 기록 내용입니다~~"
-};
-
-try {
-  const result = await updateRecord(1, 123, recordData);
-  if (result.isSuccess) {
-    console.log("수정된 방 ID:", result.data.roomId);
-    // 성공 처리 로직
-  } else {
-    console.error("기록 수정 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/record/updateVote.ts
+++ b/src/api/record/updateVote.ts
@@ -1,10 +1,8 @@
 import { apiClient } from '../index';
 import type { UpdateVoteRequest, UpdateVoteData, ApiResponse } from '@/types/record';
 
-// API 응답 타입
 export type UpdateVoteResponse = ApiResponse<UpdateVoteData>;
 
-// 투표 수정 API 함수
 export const updateVote = async (
   roomId: number,
   voteId: number,
@@ -21,24 +19,3 @@ export const updateVote = async (
     throw error;
   }
 };
-
-/*
-사용 예시:
-const voteData: UpdateVoteRequest = {
-  content: "수정된 투표 내용입니다~"
-};
-
-try {
-  const result = await updateVote(1, 123, voteData);
-  if (result.isSuccess) {
-    console.log("수정된 방 ID:", result.data.roomId);
-    // 성공 처리 로직
-  } else {
-    console.error("투표 수정 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/roomPosts/postRoomPostLike.ts
+++ b/src/api/roomPosts/postRoomPostLike.ts
@@ -1,7 +1,6 @@
 import { apiClient } from '../index';
 import type { RoomPostLikeRequest, RoomPostLikeResponse } from '@/types/roomPostLike';
 
-// 방 게시물(기록,투표) 좋아요 상태변경 API 함수
 export const postRoomPostLike = async (
   postId: number,
   requestData: RoomPostLikeRequest,
@@ -14,55 +13,9 @@ export const postRoomPostLike = async (
     return response.data;
   } catch (error: any) {
     console.error('방 게시물 좋아요 API 오류:', error);
-    // 서버에서 에러 응답을 보낸 경우 해당 응답을 반환
     if (error.response?.data) {
       return error.response.data;
     }
     throw error;
   }
 };
-
-/*
-사용 예시:
-
-// 기록 게시물 좋아요
-const likeRecordPost = async (postId: number, isLiked: boolean) => {
-  try {
-    const result = await postRoomPostLike(postId, {
-      type: !isLiked, // 현재 상태 반대로 전송
-      roomPostType: 'RECORD'
-    });
-    
-    if (result.isSuccess) {
-      console.log('좋아요 상태 변경 성공:', result.data.isLiked);
-      console.log('게시물 ID:', result.data.postId);
-      // UI 업데이트 로직
-    } else {
-      console.error('좋아요 상태 변경 실패:', result.message);
-      // 에러 처리 로직
-    }
-  } catch (error) {
-    console.error('API 호출 오류:', error);
-    // 네트워크 에러 처리 로직
-  }
-};
-
-// 투표 게시물 좋아요
-const likeVotePost = async (postId: number, isLiked: boolean) => {
-  try {
-    const result = await postRoomPostLike(postId, {
-      type: !isLiked, // 현재 상태 반대로 전송
-      roomPostType: 'VOTE'
-    });
-    
-    if (result.isSuccess) {
-      console.log('좋아요 상태 변경 성공:', result.data.isLiked);
-      // UI 업데이트 로직
-    } else {
-      console.error('좋아요 상태 변경 실패:', result.message);
-    }
-  } catch (error) {
-    console.error('API 호출 오류:', error);
-  }
-};
-*/

--- a/src/api/rooms/createDailyGreeting.ts
+++ b/src/api/rooms/createDailyGreeting.ts
@@ -1,16 +1,13 @@
 import { apiClient } from '../index';
 
-// 오늘의 한마디 작성 요청 데이터 타입
 export interface CreateDailyGreetingRequest {
-  content: string; // 오늘의 한마디 작성 내용
+  content: string;
 }
 
-// 오늘의 한마디 작성 응답 데이터 타입
 export interface CreateDailyGreetingData {
-  attendanceCheckId: number; // 출석체크 ID
+  attendanceCheckId: number;
 }
 
-// API 응답 타입
 export interface CreateDailyGreetingResponse {
   isSuccess: boolean;
   code: number;
@@ -18,7 +15,6 @@ export interface CreateDailyGreetingResponse {
   data: CreateDailyGreetingData;
 }
 
-// 오늘의 한마디 작성 API 함수
 export const createDailyGreeting = async (
   roomId: number,
   content: string,
@@ -39,20 +35,3 @@ export const createDailyGreeting = async (
     throw error;
   }
 };
-
-/*
-사용 예시:
-try {
-  const result = await createDailyGreeting(1, "오늘도 좋은 하루 보내세요!");
-  if (result.isSuccess) {
-    console.log("오늘의 한마디 작성 성공:", result.data.attendanceCheckId);
-    // 성공 처리 로직 (예: 성공 메시지 표시, 페이지 새로고침 등)
-  } else {
-    console.error("오늘의 한마디 작성 실패:", result.message);
-    // 실패 처리 로직 (예: 에러 메시지 표시)
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 네트워크 에러 처리 로직
-}
-*/

--- a/src/api/rooms/createRoom.ts
+++ b/src/api/rooms/createRoom.ts
@@ -1,40 +1,9 @@
 import { apiClient } from '../index';
 import type { CreateRoomRequest, CreateRoomData, ApiResponse } from '@/types/room';
 
-// API 응답 타입
 export type CreateRoomResponse = ApiResponse<CreateRoomData>;
 
-// 방 생성 API 함수
 export const createRoom = async (roomData: CreateRoomRequest) => {
   const response = await apiClient.post<CreateRoomResponse>('rooms', roomData);
   return response.data;
 };
-
-/*
-사용 예시:
-const roomData: CreateRoomRequest = {
-  isbn: "9788936434632",
-  category: "문학",
-  roomName: "문학 모임",
-  description: "문학을 사랑하는 사람들의 모임입니다.",
-  progressStartDate: "2023.10.01",
-  progressEndDate: "2023.10.31",
-  recruitCount: 5,
-  password: "1234",
-  isPublic: true
-};
-
-try {
-  const result = await createRoom(roomData);
-  if (result.isSuccess) {
-    console.log("생성된 방 ID:", result.data.roomId);
-    // 성공 처리 로직
-  } else {
-    console.error("방 생성 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직
-}
-*/

--- a/src/api/rooms/deleteDailyGreeting.ts
+++ b/src/api/rooms/deleteDailyGreeting.ts
@@ -1,6 +1,5 @@
 import { apiClient } from '../index';
 
-// 오늘의 한마디 삭제 응답 타입
 export interface DeleteDailyGreetingResponse {
   isSuccess: boolean;
   code: number;
@@ -10,7 +9,6 @@ export interface DeleteDailyGreetingResponse {
   };
 }
 
-// 오늘의 한마디 삭제 API 함수
 export const deleteDailyGreeting = async (
   roomId: number,
   attendanceCheckId: number,

--- a/src/api/rooms/getBookPage.ts
+++ b/src/api/rooms/getBookPage.ts
@@ -1,14 +1,12 @@
 import { apiClient } from '../index';
 
-// 책 페이지 정보 응답 데이터 타입
 export interface BookPageData {
-  totalBookPage: number; // 책 전체 페이지 수
-  recentBookPage: number; // 최근 기록한 페이지 번호
-  isOverviewPossible: boolean; // 총평 작성 가능 여부
-  roomId: number; // 방 ID
+  totalBookPage: number;
+  recentBookPage: number;
+  isOverviewPossible: boolean;
+  roomId: number;
 }
 
-// API 응답 타입
 export interface BookPageResponse {
   isSuccess: boolean;
   code: number;
@@ -16,7 +14,6 @@ export interface BookPageResponse {
   data: BookPageData;
 }
 
-// 책 전체 페이지수 및 총평 작성 가능 여부 조회 API 함수
 export const getBookPage = async (roomId: number): Promise<BookPageResponse> => {
   try {
     const response = await apiClient.get<BookPageResponse>(`/rooms/${roomId}/book-page`);
@@ -26,23 +23,3 @@ export const getBookPage = async (roomId: number): Promise<BookPageResponse> => 
     throw error;
   }
 };
-
-/*
-사용 예시:
-try {
-  const result = await getBookPage(1);
-  if (result.isSuccess) {
-    console.log("책 전체 페이지 수:", result.data.totalBookPage);
-    console.log("최근 기록한 페이지:", result.data.recentBookPage);
-    console.log("총평 작성 가능:", result.data.isOverviewPossible);
-    console.log("방 ID:", result.data.roomId);
-    // 성공 처리 로직
-  } else {
-    console.error("책 페이지 정보 조회 실패:", result.message);
-    // 실패 처리 로직
-  }
-} catch (error) {
-  console.error("API 호출 오류:", error);
-  // 에러 처리 로직 (400: 파라미터 잘못, 403: 접근 권한 없음, 404: 방 없음)
-}
-*/

--- a/src/api/rooms/getDailyGreeting.ts
+++ b/src/api/rooms/getDailyGreeting.ts
@@ -1,7 +1,6 @@
 import { apiClient } from '../index';
 import { type TodayCommentItem } from '../../types/today';
 
-// 오늘의 한마디 조회 응답 타입
 export interface DailyGreetingResponse {
   isSuccess: boolean;
   code: number;
@@ -13,17 +12,19 @@ export interface DailyGreetingResponse {
   };
 }
 
-// 오늘의 한마디 조회 요청 파라미터 타입
 export interface DailyGreetingParams {
   roomId: number;
   cursor?: string;
 }
 
-export const getDailyGreeting = async ({ roomId, cursor }: DailyGreetingParams): Promise<DailyGreetingResponse> => {
+export const getDailyGreeting = async ({
+  roomId,
+  cursor,
+}: DailyGreetingParams): Promise<DailyGreetingResponse> => {
   try {
     const params = cursor ? { cursor } : {};
     const response = await apiClient.get<DailyGreetingResponse>(`/rooms/${roomId}/daily-greeting`, {
-      params
+      params,
     });
     return response.data;
   } catch (error) {

--- a/src/api/rooms/getRoomMembers.ts
+++ b/src/api/rooms/getRoomMembers.ts
@@ -10,7 +10,6 @@ export interface RoomMember {
   isMyself: boolean;
 }
 
-// 독서메이트 조회 응답 타입
 export interface RoomMembersResponse {
   isSuccess: boolean;
   code: number;
@@ -20,7 +19,6 @@ export interface RoomMembersResponse {
   };
 }
 
-// 기존 Member 타입과 연결하기 위한 변환 함수
 export interface Member {
   id: string;
   nickname: string;
@@ -53,12 +51,11 @@ export const getRoomMembers = async (roomId: number): Promise<RoomMembersRespons
     return response.data;
   } catch (error: unknown) {
     console.error('독서메이트 조회 API 오류:', error);
-    
-    // 방 접근 권한이 없는 경우
+
     if (error instanceof AxiosError && error.response?.data?.code === 140011) {
       throw new Error('방 접근 권한이 없습니다.');
     }
-    
+
     throw error;
   }
 };

--- a/src/api/rooms/getRoomPlaying.ts
+++ b/src/api/rooms/getRoomPlaying.ts
@@ -1,12 +1,10 @@
 import { apiClient } from '../index';
 import { AxiosError } from 'axios';
 
-// 투표 아이템 타입
 export interface VoteItem {
   itemName: string;
 }
 
-// 현재 투표 타입
 export interface CurrentVote {
   content: string;
   page: number;
@@ -14,7 +12,6 @@ export interface CurrentVote {
   voteItems: VoteItem[];
 }
 
-// 진행중인 방 상세 정보 응답 타입
 export interface RoomPlayingResponse {
   isSuccess: boolean;
   code: number;
@@ -41,7 +38,6 @@ export interface RoomPlayingResponse {
   };
 }
 
-// HotTopicSection에서 사용할 Poll 타입 (API 데이터를 변환)
 export interface Poll {
   id: string;
   question: string;
@@ -49,7 +45,6 @@ export interface Poll {
   pageNumber: number;
 }
 
-// API 데이터를 Poll 형태로 변환하는 함수
 export const convertVotesToPolls = (currentVotes: CurrentVote[]): Poll[] => {
   return currentVotes.map((vote, index) => ({
     id: index.toString(),
@@ -69,7 +64,6 @@ export const getRoomPlaying = async (roomId: number): Promise<RoomPlayingRespons
   } catch (error: unknown) {
     console.error('진행중인 방 상세 정보 조회 API 오류:', error);
 
-    // 방 접근 권한이 없는 경우
     if (error instanceof AxiosError && error.response?.data?.code === 140011) {
       throw new Error('방 접근 권한이 없습니다.');
     }

--- a/src/api/rooms/leaveRoom.ts
+++ b/src/api/rooms/leaveRoom.ts
@@ -1,6 +1,5 @@
 import { apiClient } from '../index';
 
-// 방 나가기 응답 타입
 export interface LeaveRoomResponse {
   isSuccess: boolean;
   code: number;
@@ -8,7 +7,6 @@ export interface LeaveRoomResponse {
   data: string;
 }
 
-// 방 나가기 API 함수
 export const leaveRoom = async (roomId: number): Promise<LeaveRoomResponse> => {
   try {
     const response = await apiClient.delete<LeaveRoomResponse>(`/rooms/${roomId}/leave`);

--- a/src/components/common/BookSearchBottomSheet/BookList.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookList.tsx
@@ -26,13 +26,13 @@ interface BookListProps {
   isSearchMode?: boolean;
 }
 
-const BookList = ({ 
-  books, 
-  onBookSelect, 
-  onLoadMore, 
-  hasNextPage = false, 
+const BookList = ({
+  books,
+  onBookSelect,
+  onLoadMore,
+  hasNextPage = false,
   isLoadingMore = false,
-  isSearchMode = false 
+  isSearchMode = false,
 }: BookListProps) => {
   const observerRef = useRef<IntersectionObserver | null>(null);
   const loadingRef = useRef<HTMLDivElement | null>(null);
@@ -41,20 +41,22 @@ const BookList = ({
     e.currentTarget.style.display = 'none';
   };
 
-  // 무한스크롤을 위한 Intersection Observer 설정
-  const lastBookElementRef = useCallback((node: HTMLDivElement | null) => {
-    if (isLoadingMore) return;
-    
-    if (observerRef.current) observerRef.current.disconnect();
-    
-    observerRef.current = new IntersectionObserver(entries => {
-      if (entries[0].isIntersecting && hasNextPage && onLoadMore) {
-        onLoadMore();
-      }
-    });
-    
-    if (node) observerRef.current.observe(node);
-  }, [isLoadingMore, hasNextPage, onLoadMore, isSearchMode]);
+  const lastBookElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (isLoadingMore) return;
+
+      if (observerRef.current) observerRef.current.disconnect();
+
+      observerRef.current = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting && hasNextPage && onLoadMore) {
+          onLoadMore();
+        }
+      });
+
+      if (node) observerRef.current.observe(node);
+    },
+    [isLoadingMore, hasNextPage, onLoadMore, isSearchMode],
+  );
 
   useEffect(() => {
     return () => {
@@ -67,8 +69,8 @@ const BookList = ({
   return (
     <StyledBookList>
       {books.map((book, index) => (
-        <BookItem 
-          key={`${book.id}-${book.isbn}`} 
+        <BookItem
+          key={`${book.id}-${book.isbn}`}
           onClick={() => onBookSelect(book)}
           ref={index === books.length - 1 ? lastBookElementRef : null}
         >
@@ -80,8 +82,7 @@ const BookList = ({
           </BookInfo>
         </BookItem>
       ))}
-      
-      {/* 더 많은 데이터가 있고 로딩 중일 때 로딩 표시 */}
+
       {isLoadingMore && (
         <LoadingContainer ref={loadingRef}>
           <LoadingText>더 많은 책을 불러오는 중...</LoadingText>

--- a/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.styled.ts
+++ b/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.styled.ts
@@ -209,7 +209,6 @@ export const BookTitle = styled.h3`
   -webkit-box-orient: vertical;
 `;
 
-// 로딩 상태 스타일
 export const LoadingContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -223,7 +222,6 @@ export const LoadingText = styled.p`
   margin: 0;
 `;
 
-// 에러 상태 스타일
 export const ErrorContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -238,7 +236,6 @@ export const ErrorText = styled.p`
   text-align: center;
 `;
 
-// 빈 상태 스타일
 export const EmptyContainer = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
+++ b/src/components/common/BookSearchBottomSheet/BookSearchBottomSheet.tsx
@@ -18,7 +18,12 @@ interface BookSearchBottomSheetProps {
   showGroupTab?: boolean;
 }
 
-const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook, showGroupTab = true }: BookSearchBottomSheetProps) => {
+const BookSearchBottomSheet = ({
+  isOpen,
+  onClose,
+  onSelectBook,
+  showGroupTab = true,
+}: BookSearchBottomSheetProps) => {
   const {
     searchQuery,
     filteredBooks,
@@ -40,14 +45,12 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook, showGroupTab = t
     loadMoreGroupBooks,
   } = useBookSearch(showGroupTab);
 
-  // 컴포넌트가 열릴 때 초기 데이터 로드
   useEffect(() => {
     if (isOpen) {
       loadInitialData();
     }
   }, [isOpen]);
 
-  // 바디 스크롤 제어
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
@@ -60,7 +63,6 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook, showGroupTab = t
     };
   }, [isOpen]);
 
-  // Handlers
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
       onClose();
@@ -84,16 +86,14 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook, showGroupTab = t
 
   const showBookList = !isLoading && !error && !showEmptyState;
   const isSearchMode = searchQuery.trim() !== '';
-  
-  // 현재 탭에 맞는 무한 스크롤 핸들러 결정
+
   const getLoadMoreHandler = () => {
     if (isSearchMode) {
       return loadMoreSearchResults;
     }
     return activeTab === 'saved' ? loadMoreSavedBooks : loadMoreGroupBooks;
   };
-  
-  // 현재 상태에 맞는 무한 스크롤 정보
+
   const currentHasNextPage = isSearchMode ? hasNextPage : currentTabHasNext;
   const currentIsLoadingMore = isSearchMode ? isLoadingMore : currentTabIsLoadingMore;
 
@@ -101,7 +101,6 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook, showGroupTab = t
     <Overlay isVisible={isOpen} onClick={handleOverlayClick}>
       <BottomSheetContainer isVisible={isOpen}>
         <Content>
-          {/* 검색 헤더 */}
           <BookSearchHeader
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
@@ -109,10 +108,14 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook, showGroupTab = t
             onClear={handleClearSearch}
           />
 
-          {/* 탭 영역 */}
-          {showTabs && <BookSearchTabs activeTab={activeTab} onTabChange={handleTabChange} showGroupTab={showGroupTab} />}
+          {showTabs && (
+            <BookSearchTabs
+              activeTab={activeTab}
+              onTabChange={handleTabChange}
+              showGroupTab={showGroupTab}
+            />
+          )}
 
-          {/* 책 목록 영역 */}
           <BookListContainer>
             <BookSearchStates
               isLoading={isLoading}
@@ -123,8 +126,8 @@ const BookSearchBottomSheet = ({ isOpen, onClose, onSelectBook, showGroupTab = t
             />
 
             {showBookList && (
-              <BookList 
-                books={filteredBooks} 
+              <BookList
+                books={filteredBooks}
                 onBookSelect={handleBookSelect}
                 onLoadMore={getLoadMoreHandler()}
                 hasNextPage={currentHasNextPage}

--- a/src/components/common/BookSearchBottomSheet/useBookSearch.ts
+++ b/src/components/common/BookSearchBottomSheet/useBookSearch.ts
@@ -1,6 +1,10 @@
 import { useState, useEffect } from 'react';
 import { getSavedBooks, type SavedBook } from '@/api/books/getSavedBooks';
-import { getSearchBooks, convertToSearchedBooks, type SearchedBook } from '@/api/books/getSearchBooks';
+import {
+  getSearchBooks,
+  convertToSearchedBooks,
+  type SearchedBook,
+} from '@/api/books/getSearchBooks';
 import type { Book } from './BookList';
 import type { TabType } from './BookSearchTabs';
 
@@ -17,8 +21,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [hasNextPage, setHasNextPage] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-
-  // 저장한 책/모임 책 무한 스크롤 관련 상태
   const [savedBooksCursor, setSavedBooksCursor] = useState<string | null>(null);
   const [groupBooksCursor, setGroupBooksCursor] = useState<string | null>(null);
   const [hasSavedBooksNext, setHasSavedBooksNext] = useState(false);
@@ -26,7 +28,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
   const [isLoadingMoreSavedBooks, setIsLoadingMoreSavedBooks] = useState(false);
   const [isLoadingMoreGroupBooks, setIsLoadingMoreGroupBooks] = useState(false);
 
-  // API에서 받은 데이터를 Book 타입으로 변환하는 함수
   const convertSavedBookToBook = (savedBook: SavedBook): Book => ({
     id: savedBook.bookId,
     title: savedBook.bookTitle,
@@ -35,7 +36,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     isbn: savedBook.isbn,
   });
 
-  // 검색 결과를 Book 타입으로 변환하는 함수
   const convertSearchedBookToBook = (searchedBook: SearchedBook): Book => ({
     id: searchedBook.id,
     title: searchedBook.title,
@@ -44,7 +44,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     isbn: searchedBook.isbn,
   });
 
-  // 저장한 책 데이터 가져오기 (무한 스크롤)
   const fetchSavedBooks = async (isLoadMore: boolean = false) => {
     try {
       if (isLoadMore) {
@@ -81,7 +80,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     }
   };
 
-  // 모임 책 데이터 가져오기 (무한 스크롤)
   const fetchGroupBooks = async (isLoadMore: boolean = false) => {
     try {
       if (isLoadMore) {
@@ -118,7 +116,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     }
   };
 
-  // 실제 검색 API 호출 함수
   const performSearch = async (query: string, page: number = 1, isNewSearch: boolean = true) => {
     if (!query.trim()) {
       setSearchResults([]);
@@ -135,19 +132,19 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
         setIsLoadingMore(true);
       }
       setError(null);
-      
+
       const response = await getSearchBooks(query.trim(), page, true);
-      
+
       if (response.isSuccess) {
         const startIndex = isNewSearch ? 0 : searchResults.length;
         const convertedResults = convertToSearchedBooks(response.data.searchResult, startIndex);
-        
+
         if (isNewSearch) {
           setSearchResults(convertedResults);
         } else {
           setSearchResults(prev => [...prev, ...convertedResults]);
         }
-        
+
         setCurrentPage(page);
         setHasNextPage(!response.data.last);
       } else {
@@ -171,16 +168,14 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     }
   };
 
-  // 더 많은 검색 결과 로드
   const loadMoreSearchResults = async () => {
     if (!searchQuery.trim() || isLoadingMore || !hasNextPage) {
       return;
     }
-    
+
     await performSearch(searchQuery.trim(), currentPage + 1, false);
   };
 
-  // 더 많은 저장한 책 로드
   const loadMoreSavedBooks = async () => {
     if (isLoadingMoreSavedBooks || !hasSavedBooksNext) {
       return;
@@ -189,7 +184,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     await fetchSavedBooks(true);
   };
 
-  // 더 많은 모임 책 로드
   const loadMoreGroupBooks = async () => {
     if (isLoadingMoreGroupBooks || !hasGroupBooksNext) {
       return;
@@ -198,10 +192,9 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     await fetchGroupBooks(true);
   };
 
-  // 검색어 변경 핸들러 (디바운싱 적용)
   const handleSearchQueryChange = (query: string) => {
     setSearchQuery(query);
-    
+
     if (searchTimeoutId) {
       clearTimeout(searchTimeoutId);
     }
@@ -219,27 +212,22 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     }
   };
 
-  // 필터링 로직
   useEffect(() => {
-    // 검색어가 있으면 검색 결과를 표시
     if (searchQuery.trim()) {
       const convertedSearchResults = searchResults.map(convertSearchedBookToBook);
       setFilteredBooks(convertedSearchResults);
       return;
     }
 
-    // 검색어가 없으면 저장된 책들을 표시
     const currentTabBooks = activeTab === 'saved' ? savedBooks : groupBooks;
     const convertedBooks = currentTabBooks.map(convertSavedBookToBook);
     setFilteredBooks(convertedBooks);
   }, [searchQuery, activeTab, savedBooks, groupBooks, searchResults]);
 
-  // 탭 변경 핸들러
   const handleTabChange = async (tab: TabType) => {
     setActiveTab(tab);
     setError(null);
 
-    // 탭 변경 시 해당 탭의 데이터가 없으면 API 호출
     if (tab === 'saved' && savedBooks.length === 0) {
       await fetchSavedBooks();
     } else if (tab === 'group' && groupBooks.length === 0) {
@@ -247,7 +235,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     }
   };
 
-  // 초기 데이터 로드
   const loadInitialData = () => {
     if (activeTab === 'saved' && savedBooks.length === 0) {
       fetchSavedBooks();
@@ -256,18 +243,15 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     }
   };
 
-  // 현재 상태 계산
   const isSearchMode = searchQuery.trim() !== '';
   const currentTabBooks = activeTab === 'saved' ? savedBooks : groupBooks;
   const hasBooks = isSearchMode ? searchResults.length > 0 : currentTabBooks.length > 0;
   const showEmptyState = !isLoading && !error && !hasBooks;
-  const showTabs = !isSearchMode; // 검색 모드가 아닐 때는 항상 탭 표시
-
-  // 현재 탭의 무한 스크롤 상태
+  const showTabs = !isSearchMode;
   const currentTabHasNext = activeTab === 'saved' ? hasSavedBooksNext : hasGroupBooksNext;
-  const currentTabIsLoadingMore = activeTab === 'saved' ? isLoadingMoreSavedBooks : isLoadingMoreGroupBooks;
+  const currentTabIsLoadingMore =
+    activeTab === 'saved' ? isLoadingMoreSavedBooks : isLoadingMoreGroupBooks;
 
-  // 컴포넌트 언마운트 시 타이머 정리
   useEffect(() => {
     return () => {
       if (searchTimeoutId) {
@@ -277,7 +261,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
   }, [searchTimeoutId]);
 
   return {
-    // State
     searchQuery,
     filteredBooks,
     activeTab,
@@ -290,8 +273,6 @@ export const useBookSearch = (showGroupTab: boolean = true) => {
     isLoadingMore,
     currentTabHasNext,
     currentTabIsLoadingMore,
-
-    // Actions
     setSearchQuery: handleSearchQueryChange,
     handleTabChange,
     loadInitialData,

--- a/src/components/common/CommentBottomSheet/GlobalCommentBottomSheet.tsx
+++ b/src/components/common/CommentBottomSheet/GlobalCommentBottomSheet.tsx
@@ -29,12 +29,11 @@ const GlobalCommentBottomSheet = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isSending, setIsSending] = useState(false);
   const [roomCompleted, setRoomCompleted] = useState(false);
-  
+
   const { nickname, isReplying, cancelReply } = useReplyActions();
   const { parentId } = useReplyStore();
   const { openSnackbar } = usePopupActions();
 
-  // 댓글 목록 로드
   const loadComments = useCallback(async () => {
     if (!isOpen || !postId || !postType) return;
 
@@ -55,7 +54,6 @@ const GlobalCommentBottomSheet = () => {
     }
   }, [isOpen, postId, postType]);
 
-  // 댓글 전송
   const handleSendComment = async () => {
     if (!inputValue.trim() || isSending || !postId || !postType) return;
 
@@ -65,18 +63,16 @@ const GlobalCommentBottomSheet = () => {
         content: inputValue.trim(),
         isReplyRequest: isReplying,
         parentId: isReplying ? parentId : null,
-        postType: postType as 'FEED' | 'RECORD' | 'VOTE'
+        postType: postType as 'FEED' | 'RECORD' | 'VOTE',
       };
 
       const response = await postReply(postId, requestData);
 
       if (response.isSuccess) {
         setInputValue('');
-        cancelReply(); // 답글 상태 초기화
-        // 댓글 목록 새로고침
+        cancelReply();
         await loadComments();
       } else {
-        // 서버에서 받은 에러 메시지 표시
         openSnackbar({
           message: response.message || '댓글 작성 중 오류가 발생했습니다.',
           variant: 'top',
@@ -95,19 +91,16 @@ const GlobalCommentBottomSheet = () => {
     }
   };
 
-  // 답글 취소
   const handleCancelReply = () => {
     cancelReply();
   };
 
-  // Overlay 클릭 처리
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
       closeCommentBottomSheet();
     }
   };
 
-  // 모임방 상태 확인
   useEffect(() => {
     const checkRoomStatus = async () => {
       if (!roomId) return;
@@ -128,14 +121,12 @@ const GlobalCommentBottomSheet = () => {
     }
   }, [isOpen, roomId]);
 
-  // 바텀시트가 열릴 때 댓글 로드
   useEffect(() => {
     if (isOpen) {
       loadComments();
     }
   }, [isOpen, postId, loadComments]);
 
-  // 바텀시트가 닫힐 때 상태 초기화
   useEffect(() => {
     if (!isOpen) {
       setInputValue('');
@@ -152,15 +143,12 @@ const GlobalCommentBottomSheet = () => {
         <Header>
           <Title>댓글</Title>
         </Header>
-        
+
         <Content>
           {isLoading ? (
             <LoadingState>댓글을 불러오는 중...</LoadingState>
           ) : (
-            <ReplyList 
-              commentList={commentList} 
-              onReload={loadComments}
-            />
+            <ReplyList commentList={commentList} onReload={loadComments} />
           )}
         </Content>
 

--- a/src/components/common/Post/Reply.tsx
+++ b/src/components/common/Post/Reply.tsx
@@ -42,11 +42,9 @@ const Reply = ({
       const response = await postLike(commentId, !liked);
 
       if (response.isSuccess) {
-        console.log('좋아요 상태 변경 성공:', response);
         setLiked(response.data.isLiked);
         setLikeCount(prev => (response.data.isLiked ? prev + 1 : prev - 1));
       } else {
-        console.error('좋아요 상태 변경 실패:', response.message);
         openSnackbar({
           message: response.message || '좋아요 처리 중 오류가 발생했습니다.',
           variant: 'top',

--- a/src/components/common/Post/SubReply.tsx
+++ b/src/components/common/Post/SubReply.tsx
@@ -49,7 +49,6 @@ const SubReply = ({
 
       if (response.isSuccess) {
         console.log('좋아요 상태 변경 성공:', response);
-        // 서버 응답으로 상태 업데이트
         setLiked(response.data.isLiked);
         setCurrentLikeCount(prev => (response.data.isLiked ? prev + 1 : prev - 1));
       } else {

--- a/src/components/common/Post/SubReply.tsx
+++ b/src/components/common/Post/SubReply.tsx
@@ -48,7 +48,6 @@ const SubReply = ({
       const response = await postLike(commentId, !liked);
 
       if (response.isSuccess) {
-        console.log('좋아요 상태 변경 성공:', response);
         setLiked(response.data.isLiked);
         setCurrentLikeCount(prev => (response.data.isLiked ? prev + 1 : prev - 1));
       } else {

--- a/src/components/creategroup/ActivityPeriodSection/ActivityPeriodSection.tsx
+++ b/src/components/creategroup/ActivityPeriodSection/ActivityPeriodSection.tsx
@@ -26,14 +26,10 @@ const ActivityPeriodSection = ({
   onEndDateChange,
   onValidationChange,
 }: ActivityPeriodSectionProps) => {
-  // 현재 년도와 다음 년도
   const currentYear = new Date().getFullYear();
   const years = [currentYear, currentYear + 1];
-
-  // 월 배열 (1-12)
   const months = Array.from({ length: 12 }, (_, i) => i + 1);
 
-  // 일 배열 계산 (선택된 년/월에 따라 동적으로 변경)
   const getDaysInMonth = (year: number, month: number) => {
     const daysInMonth = new Date(year, month, 0).getDate();
     return Array.from({ length: daysInMonth }, (_, i) => i + 1);
@@ -42,40 +38,33 @@ const ActivityPeriodSection = ({
   const startDays = getDaysInMonth(startDate.year, startDate.month);
   const endDays = getDaysInMonth(endDate.year, endDate.month);
 
-  // 날짜 간 일수 계산
   const calculateDaysDifference = (start: Date, end: Date): number => {
     const timeDiff = end.getTime() - start.getTime();
-    return Math.ceil(timeDiff / (1000 * 3600 * 24)) + 1; // +1은 시작일 포함
+    return Math.ceil(timeDiff / (1000 * 3600 * 24)) + 1;
   };
 
-  // 현재 선택된 날짜들로 일수 계산
   const daysDifference = useMemo(() => {
     const startDateObj = new Date(startDate.year, startDate.month - 1, startDate.day);
     const endDateObj = new Date(endDate.year, endDate.month - 1, endDate.day);
     return calculateDaysDifference(startDateObj, endDateObj);
   }, [startDate, endDate]);
 
-  // 90일 초과 여부 확인
   const isOverMaxDays = daysDifference > 90;
 
-  // 종료일이 시작일보다 빠른지 확인 (추가)
   const isEndDateBeforeStart = useMemo(() => {
     const startDateObj = new Date(startDate.year, startDate.month - 1, startDate.day);
     const endDateObj = new Date(endDate.year, endDate.month - 1, endDate.day);
     return endDateObj < startDateObj;
   }, [startDate, endDate]);
 
-  // 날짜 유효성 검사 결과
   const isDateValid = !isOverMaxDays && !isEndDateBeforeStart;
 
-  // 유효성 변경 시 부모에게 알림
   useEffect(() => {
     if (onValidationChange) {
       onValidationChange(isDateValid);
     }
   }, [isDateValid, onValidationChange]);
 
-  // 오늘 날짜로 초기값 설정
   const getInitialDate = () => {
     const today = new Date();
     return {
@@ -95,7 +84,6 @@ const ActivityPeriodSection = ({
     };
   };
 
-  // 날짜 유효성 검사 및 조정
   const validateAndAdjustDate = (
     date: { year: number; month: number; day: number },
     isEndDate = false,
@@ -106,23 +94,19 @@ const ActivityPeriodSection = ({
 
     let adjustedDate = { ...date };
 
-    // 일수가 해당 월의 최대 일수를 초과하는 경우 조정
     if (date.day > daysInSelectedMonth) {
       adjustedDate.day = daysInSelectedMonth;
     }
 
-    // 시작일이 오늘보다 이른 경우 조정
     if (!isEndDate && selectedDate < today) {
       adjustedDate = getInitialDate();
     }
 
-    // 종료일 검증
     if (isEndDate) {
       const startDateObj = new Date(startDate.year, startDate.month - 1, startDate.day);
       const tomorrow = new Date();
       tomorrow.setDate(tomorrow.getDate() + 1);
 
-      // 종료일이 내일보다 이르거나 시작일보다 이른 경우 조정
       if (selectedDate < tomorrow || selectedDate < startDateObj) {
         adjustedDate = getInitialEndDate();
       }
@@ -131,12 +115,10 @@ const ActivityPeriodSection = ({
     return adjustedDate;
   };
 
-  // 시작일 변경 핸들러
   const handleStartYearChange = (year: number) => {
     const newDate = validateAndAdjustDate({ ...startDate, year });
     onStartDateChange(newDate);
 
-    // 종료일도 재검증
     const adjustedEndDate = validateAndAdjustDate(endDate, true);
     if (JSON.stringify(adjustedEndDate) !== JSON.stringify(endDate)) {
       onEndDateChange(adjustedEndDate);
@@ -147,7 +129,6 @@ const ActivityPeriodSection = ({
     const newDate = validateAndAdjustDate({ ...startDate, month });
     onStartDateChange(newDate);
 
-    // 종료일도 재검증
     const adjustedEndDate = validateAndAdjustDate(endDate, true);
     if (JSON.stringify(adjustedEndDate) !== JSON.stringify(endDate)) {
       onEndDateChange(adjustedEndDate);
@@ -158,14 +139,12 @@ const ActivityPeriodSection = ({
     const newDate = validateAndAdjustDate({ ...startDate, day });
     onStartDateChange(newDate);
 
-    // 종료일도 재검증
     const adjustedEndDate = validateAndAdjustDate(endDate, true);
     if (JSON.stringify(adjustedEndDate) !== JSON.stringify(endDate)) {
       onEndDateChange(adjustedEndDate);
     }
   };
 
-  // 종료일 변경 핸들러
   const handleEndYearChange = (year: number) => {
     const newDate = validateAndAdjustDate({ ...endDate, year }, true);
     onEndDateChange(newDate);
@@ -181,7 +160,6 @@ const ActivityPeriodSection = ({
     onEndDateChange(newDate);
   };
 
-  // 컴포넌트 마운트 시 초기 날짜 유효성 검사
   useEffect(() => {
     const validatedStartDate = validateAndAdjustDate(startDate);
     const validatedEndDate = validateAndAdjustDate(endDate, true);
@@ -200,7 +178,6 @@ const ActivityPeriodSection = ({
       <SectionTitle>모임 활동기간</SectionTitle>
       <DatePickerContainer>
         <DateRangeContainer>
-          {/* 시작일 */}
           <DateGroup alignItems="end">
             <DateWheel
               values={years}
@@ -229,7 +206,6 @@ const ActivityPeriodSection = ({
 
           <SeparatorText>~</SeparatorText>
 
-          {/* 종료일 */}
           <DateGroup alignItems="start">
             <DateWheel
               values={years}

--- a/src/components/creategroup/ActivityPeriodSection/DateWheel.tsx
+++ b/src/components/creategroup/ActivityPeriodSection/DateWheel.tsx
@@ -133,7 +133,6 @@ const DateWheel = ({ values, selectedValue, onChange, label, width = 50 }: DateW
     document.addEventListener('mouseup', handleMouseUp);
   };
 
-  // 터치 및 휠 이벤트를 non-passive로 등록하기 위한 useEffect
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -160,7 +159,6 @@ const DateWheel = ({ values, selectedValue, onChange, label, width = 50 }: DateW
       moveToIndex(delta);
     };
 
-    // non-passive 옵션으로 이벤트 리스너 등록
     container.addEventListener('touchstart', handleTouchStartNonPassive, { passive: false });
     container.addEventListener('touchmove', handleTouchMoveNonPassive, { passive: false });
     container.addEventListener('touchend', handleTouchEndNonPassive, { passive: false });

--- a/src/components/creategroup/MemberLimitSection.tsx
+++ b/src/components/creategroup/MemberLimitSection.tsx
@@ -12,7 +12,6 @@ interface MemberLimitSectionProps {
 }
 
 const MemberLimitSection = ({ memberLimit, onMemberLimitChange }: MemberLimitSectionProps) => {
-  // 1부터 30까지의 배열 생성
   const memberNumbers = Array.from({ length: 30 }, (_, i) => i + 1);
 
   return (

--- a/src/components/creategroup/PrivacySettingSection/PasswordInputSection.styled.ts
+++ b/src/components/creategroup/PrivacySettingSection/PasswordInputSection.styled.ts
@@ -32,7 +32,6 @@ export const PasswordInput = styled.input`
     color: ${colors.grey[300]};
   }
 
-  /* 숫자만 입력 가능하도록 설정 */
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button {
     -webkit-appearance: none;

--- a/src/components/creategroup/PrivacySettingSection/PasswordInputSection.tsx
+++ b/src/components/creategroup/PrivacySettingSection/PasswordInputSection.tsx
@@ -15,7 +15,6 @@ interface PasswordInputSectionProps {
 const PasswordInputSection = ({ password, onPasswordChange }: PasswordInputSectionProps) => {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    // 숫자만 허용하고 최대 4자리까지만 입력 가능
     const numericValue = value.replace(/[^0-9]/g, '');
     if (numericValue.length <= 4) {
       onPasswordChange(numericValue);
@@ -23,11 +22,10 @@ const PasswordInputSection = ({ password, onPasswordChange }: PasswordInputSecti
   };
 
   const handleClose = () => {
-    onPasswordChange(''); // 입력된 숫자 전체 삭제
+    onPasswordChange('');
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    // 숫자, 백스페이스, 삭제, 탭, 엔터만 허용
     const allowedKeys = ['Backspace', 'Delete', 'Tab', 'Enter', 'ArrowLeft', 'ArrowRight'];
     const isNumber = /^[0-9]$/;
 
@@ -35,7 +33,6 @@ const PasswordInputSection = ({ password, onPasswordChange }: PasswordInputSecti
       e.preventDefault();
     }
 
-    // 이미 4자리면 새로운 숫자 입력 방지
     if (password.length >= 4 && isNumber.test(e.key)) {
       e.preventDefault();
     }

--- a/src/components/createpost/PhotoSection.tsx
+++ b/src/components/createpost/PhotoSection.tsx
@@ -45,16 +45,13 @@ const PhotoSection = ({
     if (files.length > 0) {
       onPhotoAdd(files);
     }
-    // input 값 초기화 (같은 파일을 다시 선택할 수 있도록)
     e.target.value = '';
   };
 
-  // 사진 파일들을 blob URL로 변환 (메모리 누수 방지)
   const photoUrls = useMemo(() => {
     return photos.map(file => URL.createObjectURL(file));
   }, [photos]);
 
-  // 컴포넌트 언마운트 또는 photos 변경 시 기존 blob URL 해제
   useEffect(() => {
     return () => {
       photoUrls.forEach(url => URL.revokeObjectURL(url));

--- a/src/components/createpost/PostContentSection.styled.ts
+++ b/src/components/createpost/PostContentSection.styled.ts
@@ -22,7 +22,6 @@ export const TextArea = styled.textarea<{ readOnly?: boolean }>`
   padding: 0;
   caret-color: ${colors.neongreen};
 
-  /* 얇은 스크롤바 스타일 */
   &::-webkit-scrollbar {
     width: 4px;
   }
@@ -40,7 +39,6 @@ export const TextArea = styled.textarea<{ readOnly?: boolean }>`
     background-color: ${semanticColors.text.tertiary};
   }
 
-  /* Firefox 스크롤바 스타일 */
   scrollbar-width: thin;
   scrollbar-color: ${semanticColors.text.ghost} transparent;
 

--- a/src/components/createpost/TagSelectionSection.tsx
+++ b/src/components/createpost/TagSelectionSection.tsx
@@ -25,7 +25,6 @@ const TagSelectionSection = ({ selectedTags, onTagToggle }: TagSelectionSectionP
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [loading, setLoading] = useState(true);
 
-  // API에서 카테고리 및 태그 데이터 로드
   useEffect(() => {
     const loadWriteInfo = async () => {
       try {
@@ -34,7 +33,6 @@ const TagSelectionSection = ({ selectedTags, onTagToggle }: TagSelectionSectionP
 
         if (response.isSuccess && response.data.categoryList.length > 0) {
           setCategories(response.data.categoryList);
-          // 첫 번째 카테고리를 기본 선택
           setSelectedCategory(response.data.categoryList[0].category);
         }
       } catch (error) {
@@ -52,13 +50,11 @@ const TagSelectionSection = ({ selectedTags, onTagToggle }: TagSelectionSectionP
   };
 
   const handleTagToggle = (tag: string) => {
-    // 이미 선택된 태그면 해제
     if (selectedTags.includes(tag)) {
       onTagToggle(tag);
       return;
     }
 
-    // 5개 미만이면 추가 가능
     if (selectedTags.length < 5) {
       onTagToggle(tag);
     }
@@ -68,7 +64,6 @@ const TagSelectionSection = ({ selectedTags, onTagToggle }: TagSelectionSectionP
     onTagToggle(tag);
   };
 
-  // 현재 선택된 카테고리의 태그 목록
   const currentTags = categories.find(cat => cat.category === selectedCategory)?.tagList || [];
 
   if (loading) {
@@ -111,10 +106,8 @@ const TagSelectionSection = ({ selectedTags, onTagToggle }: TagSelectionSectionP
           ))}
         </SubTagGrid>
 
-        {/* 태그 선택 개수 표시 */}
         <TagCount>{selectedTags.length} / 5개</TagCount>
 
-        {/* 선택된 태그 목록 */}
         {selectedTags.length > 0 && (
           <SelectedTagsSection>
             <SelectedTagsTitle>선택된 태그</SelectedTagsTitle>

--- a/src/components/group/GroupActionBottomSheet.tsx
+++ b/src/components/group/GroupActionBottomSheet.tsx
@@ -9,11 +9,11 @@ import {
 
 interface GroupActionBottomSheetProps {
   isOpen: boolean;
-  isGroupOwner: boolean; // 모임방 생성자인지 여부
+  isGroupOwner: boolean;
   onClose: () => void;
-  onDeleteGroup?: () => void; // 방 삭제하기
-  onLeaveGroup?: () => void; // 방 나가기
-  onReportGroup?: () => void; // 방 신고하기
+  onDeleteGroup?: () => void;
+  onLeaveGroup?: () => void;
+  onReportGroup?: () => void;
 }
 
 const GroupActionBottomSheet = ({
@@ -52,10 +52,8 @@ const GroupActionBottomSheet = ({
       <BottomSheet isOpen={isOpen}>
         <ActionItemsContainer>
           {isGroupOwner ? (
-            // 모임방 생성자인 경우 - 방 삭제하기만 표시
             <DeleteGroupActionItem onClick={handleDeleteGroup}>방 삭제하기</DeleteGroupActionItem>
           ) : (
-            // 참여자인 경우 - 방 나가기, 방 신고하기 표시
             <>
               <LeaveGroupActionItem onClick={handleLeaveGroup}>방 나가기</LeaveGroupActionItem>
               <ReportGroupActionItem onClick={handleReportGroup}>방 신고하기</ReportGroupActionItem>

--- a/src/components/group/HotTopicSection.tsx
+++ b/src/components/group/HotTopicSection.tsx
@@ -42,16 +42,14 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
   const [isDragging, setIsDragging] = useState(false);
   const [translateX, setTranslateX] = useState(0);
 
-  // useRef로 드래그 상태 관리
   const dragStateRef = useRef({
     startX: 0,
     startTranslateX: 0,
     hasMoved: false,
   });
 
-  const containerWidth = 100; // 각 슬라이드의 width %
+  const containerWidth = 100;
 
-  // 투표 옵션 클릭 시 해당 페이지로 이동
   const handleVoteClick = (e: React.MouseEvent | React.TouchEvent, poll: Poll) => {
     e.stopPropagation();
     if (!isDragging || !dragStateRef.current.hasMoved) {
@@ -59,7 +57,6 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
     }
   };
 
-  // 터치 이벤트 핸들러
   const handleVoteTouchEnd = (e: React.TouchEvent, poll: Poll) => {
     e.preventDefault();
     e.stopPropagation();
@@ -72,17 +69,14 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
     e.stopPropagation();
   };
 
-  // 슬라이드 위치 계산
   const getTargetTranslateX = (index: number) => {
     return -index * containerWidth;
   };
 
-  // 가장 가까운 슬라이드로 스냅
   const snapToClosest = useCallback(() => {
     const currentTranslate = translateX;
     let closestIndex = Math.round(Math.abs(currentTranslate) / containerWidth);
 
-    // 범위 제한
     closestIndex = Math.max(0, Math.min(closestIndex, polls.length - 1));
 
     const targetTranslate = getTargetTranslateX(closestIndex);
@@ -90,7 +84,6 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
     setCurrentPollIndex(closestIndex);
   }, [translateX, polls.length]);
 
-  // 드래그 시작 (마우스/터치 공통)
   const handleDragStart = useCallback(
     (clientX: number) => {
       setIsDragging(true);
@@ -101,7 +94,6 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
     [translateX],
   );
 
-  // 드래그 중 (마우스/터치 공통)
   const handleDragMove = useCallback(
     (clientX: number) => {
       if (!isDragging) return;
@@ -115,7 +107,6 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
       const newTranslateX =
         dragStateRef.current.startTranslateX + (deltaX / window.innerWidth) * 100;
 
-      // 드래그 범위 제한
       const minTranslate = getTargetTranslateX(polls.length - 1) - 20;
       const maxTranslate = getTargetTranslateX(0) + 20;
 
@@ -125,7 +116,6 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
     [isDragging, polls.length],
   );
 
-  // 드래그 끝 (마우스/터치 공통)
   const handleDragEnd = useCallback(() => {
     if (isDragging) {
       setIsDragging(false);
@@ -133,7 +123,6 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
     }
   }, [isDragging, snapToClosest]);
 
-  // 터치 이벤트
   const handleTouchStart = (e: React.TouchEvent) => {
     e.preventDefault();
     handleDragStart(e.touches[0].clientX);
@@ -149,13 +138,11 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
     handleDragEnd();
   };
 
-  // 마우스 이벤트
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
     handleDragStart(e.clientX);
   };
 
-  // 전역 마우스 이벤트 리스너
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
       handleDragMove(e.clientX);
@@ -176,7 +163,6 @@ const HotTopicSection = ({ polls, hasPolls, onPollClick }: HotTopicSectionProps)
     };
   }, [isDragging, handleDragMove, handleDragEnd]);
 
-  // 인덱스 변경 시 translateX 업데이트
   useEffect(() => {
     if (!isDragging) {
       setTranslateX(getTargetTranslateX(currentPollIndex));

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -27,7 +27,6 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
     if (onMemberClick) {
       onMemberClick(member.id);
     } else {
-      // isMyself가 true면 본인 프로필 페이지로, 아니면 다른 유저 페이지로 이동
       if (member.isMyself) {
         navigate(`/myfeed/${member.id}`);
       } else {
@@ -72,7 +71,6 @@ const MemberList = ({ members, onMemberClick }: MemberListProps) => {
   );
 };
 
-// 프로필 이미지가 있을 때 사용하는 스타일드 컴포넌트
 const ProfileImageWithSrc = styled.img`
   width: 36px;
   height: 36px;

--- a/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
+++ b/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
@@ -10,12 +10,11 @@ import { AddButton, DropdownContainer, DropdownItem } from './MemoryAddButton.st
 
 const MemoryAddButton = () => {
   const navigate = useNavigate();
-  const { roomId } = useParams<{ roomId: string }>(); // useParams 추가
+  const { roomId } = useParams<{ roomId: string }>();
   const { openConfirm, closePopup, openSnackbar } = usePopupActions();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // 외부 클릭 시 드롭다운 닫기
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
@@ -39,7 +38,6 @@ const MemoryAddButton = () => {
   const handleRecordWrite = () => {
     setIsOpen(false);
 
-    // URL에서 roomId를 가져오거나 기본값 1 사용
     const currentRoomId = roomId || '1';
 
     navigate(`/memory/record/write/${currentRoomId}`);
@@ -49,7 +47,6 @@ const MemoryAddButton = () => {
   const handlePollCreate = () => {
     setIsOpen(false);
 
-    // URL에서 roomId를 가져오거나 기본값 1 사용
     const currentRoomId = roomId || '1';
 
     navigate(`/memory/poll/write/${currentRoomId}`);
@@ -66,7 +63,6 @@ const MemoryAddButton = () => {
       if (result.isSuccess) {
         const { recordCount, recordReviewCount } = result.data;
 
-        // 기록이 2개 미만인 경우 에러 표시
         if (recordCount < 2) {
           openSnackbar({
             message: `독후감 생성을 위해서는 최소 2개의 기록이 필요합니다. 현재 기록 개수: ${recordCount}`,
@@ -77,7 +73,6 @@ const MemoryAddButton = () => {
           return;
         }
 
-        // 잔여 횟수가 5회 이상인 경우 (이미 5회 모두 사용)
         if (recordReviewCount >= 5) {
           openSnackbar({
             message: '사용자의 독후감 작성 수가 5회를 초과했습니다.',
@@ -88,7 +83,6 @@ const MemoryAddButton = () => {
           return;
         }
 
-        // 모달 표시
         openConfirm({
           title: 'AI 독서감상문 생성 (Beta)',
           disc: `기록장에서 작성한 기록을 기반으로<br/>독서감상문을 생성하시겠어요?<br/>(서비스 내 잔여 이용횟수 : ${recordReviewCount}/5)`,

--- a/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
+++ b/src/components/memory/MemoryAddButton/MemoryAddButton.tsx
@@ -41,7 +41,6 @@ const MemoryAddButton = () => {
     const currentRoomId = roomId || '1';
 
     navigate(`/memory/record/write/${currentRoomId}`);
-    console.log('기록 작성하기 - roomId:', currentRoomId);
   };
 
   const handlePollCreate = () => {
@@ -50,7 +49,6 @@ const MemoryAddButton = () => {
     const currentRoomId = roomId || '1';
 
     navigate(`/memory/poll/write/${currentRoomId}`);
-    console.log('투표 생성하기 - roomId:', currentRoomId);
   };
 
   const handleAIWrite = async () => {
@@ -91,7 +89,6 @@ const MemoryAddButton = () => {
           onConfirm: () => {
             closePopup();
             navigate(`/aiwrite/${currentRoomId}`);
-            console.log('AI 독서 감상문 생성 시작 - roomId:', currentRoomId);
           },
         });
       } else {

--- a/src/components/memory/MemoryContent/MemoryContent.tsx
+++ b/src/components/memory/MemoryContent/MemoryContent.tsx
@@ -42,14 +42,11 @@ const MemoryContent = ({
 }: MemoryContentProps) => {
   return (
     <Content>
-      {/* 고정 영역: 탭과 필터만 */}
       <FixedSection>
         <RecordTabs activeTab={activeTab} onTabChange={onTabChange} />
 
-        {/* 업로드 프로그레스 바 - 탭 바로 아래에 위치 */}
         <UploadProgressBar isVisible={showUploadProgress} onComplete={onUploadComplete} />
 
-        {/* 그룹 기록일 때만 필터 표시 */}
         {activeTab === 'group' && (
           <RecordFilters
             activeFilter={activeFilter}
@@ -64,15 +61,11 @@ const MemoryContent = ({
         )}
       </FixedSection>
 
-      {/* 스크롤 가능한 영역: 안내 메시지부터 기록 목록까지 모두 */}
       <ScrollableSection>
-        {/* 그룹 기록이고 기록이 있을 때만 안내 메시지 표시 */}
         {activeTab === 'group' && records.length > 0 && <RecordInfoMessage />}
 
-        {/* 기록이 없을 때 빈 상태 표시 */}
         {records.length === 0 && <EmptyRecord type={activeTab} />}
 
-        {/* 기록 목록 */}
         {records.length > 0 && <RecordList records={records} />}
       </ScrollableSection>
     </Content>

--- a/src/components/memory/RecordFilters/PageInputMode.styled.ts
+++ b/src/components/memory/RecordFilters/PageInputMode.styled.ts
@@ -38,14 +38,12 @@ export const PageInput = styled.input`
     color: ${semanticColors.text.tertiary};
   }
 
-  /* 숫자 입력 스피너 제거 (inputMode="numeric" 사용으로 불필요하지만 안전장치) */
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
 
-  /* Firefox에서 숫자 타입 기본 스타일 제거 */
   -moz-appearance: textfield;
 `;
 

--- a/src/components/memory/RecordFilters/RecordFilters.tsx
+++ b/src/components/memory/RecordFilters/RecordFilters.tsx
@@ -33,20 +33,17 @@ const RecordFilters = ({
 
   const handlePageFilterClick = () => {
     if (selectedPageRange) {
-      // 이미 선택된 범위가 있으면 초기화
       if (onPageRangeClear) {
         onPageRangeClear();
         setShowInputMode(false);
       }
     } else {
-      // 입력 모드로 전환
       setShowInputMode(true);
       onFilterChange('page');
     }
   };
 
   const handleInputChange = (type: 'start' | 'end', value: string) => {
-    // 숫자만 입력 허용 (빈 문자열 또는 숫자)
     if (value === '' || /^\d+$/.test(value)) {
       if (type === 'start') {
         setStartPage(value);
@@ -65,9 +62,7 @@ const RecordFilters = ({
     const start = parseInt(startPage);
     const end = parseInt(endPage);
 
-    // NaN 체크 포함한 유효성 검사
     if (!isNaN(start) && !isNaN(end) && start > 0 && end > 0 && start <= end) {
-      // 페이지 범위를 상위 컴포넌트에 전달
       if (onPageRangeSet) {
         onPageRangeSet({ start, end });
       }
@@ -101,13 +96,13 @@ const RecordFilters = ({
   };
 
   const isValid = Boolean(
-    startPage && 
-    endPage && 
-    !isNaN(parseInt(startPage)) && 
-    !isNaN(parseInt(endPage)) && 
-    parseInt(startPage) > 0 && 
-    parseInt(endPage) > 0 && 
-    parseInt(startPage) <= parseInt(endPage)
+    startPage &&
+      endPage &&
+      !isNaN(parseInt(startPage)) &&
+      !isNaN(parseInt(endPage)) &&
+      parseInt(startPage) > 0 &&
+      parseInt(endPage) > 0 &&
+      parseInt(startPage) <= parseInt(endPage),
   );
   const hasAnyInput = startPage.length > 0 || endPage.length > 0;
   const isPageInputMode = showInputMode && activeFilter === 'page' && !selectedPageRange;

--- a/src/components/memory/RecordItem/PollRecord.tsx
+++ b/src/components/memory/RecordItem/PollRecord.tsx
@@ -19,9 +19,9 @@ import {
 interface PollRecordProps {
   content: string;
   pollOptions: PollOption[];
-  postId: number; // 투표 API 호출에 필요한 postId
-  shouldBlur?: boolean; // 블라인드 처리 여부
-  onVoteUpdate?: (updatedOptions: PollOption[]) => void; // 투표 결과 업데이트 콜백
+  postId: number;
+  shouldBlur?: boolean;
+  onVoteUpdate?: (updatedOptions: PollOption[]) => void;
 }
 
 const PollRecord = ({
@@ -43,7 +43,6 @@ const PollRecord = ({
       entries => {
         entries.forEach(entry => {
           if (entry.isIntersecting && !animate) {
-            // 약간의 지연 후 애니메이션 시작
             setTimeout(() => {
               setAnimate(true);
             }, 100);
@@ -51,7 +50,7 @@ const PollRecord = ({
         });
       },
       {
-        threshold: 0.3, // 30% 보일 때 애니메이션 시작
+        threshold: 0.3,
         rootMargin: '0px 0px -50px 0px',
       },
     );
@@ -68,14 +67,12 @@ const PollRecord = ({
     };
   }, [animate]);
 
-  // pollOptions가 변경되면 currentOptions 업데이트
   useEffect(() => {
     setCurrentOptions(pollOptions);
   }, [pollOptions]);
 
-  // 투표 옵션 클릭 핸들러
   const handleOptionClick = async (e: React.MouseEvent, option: PollOption) => {
-    e.stopPropagation(); // 이벤트 버블링 방지
+    e.stopPropagation();
     if (isVoting || !roomId || shouldBlur) return;
 
     setIsVoting(true);
@@ -83,13 +80,12 @@ const PollRecord = ({
     try {
       const voteData = {
         voteItemId: option.voteItemId,
-        type: !option.isVoted, // 현재 투표 상태의 반대로 설정
+        type: !option.isVoted,
       };
 
       const response = await postVote(parseInt(roomId), postId, voteData);
 
       if (response.isSuccess) {
-        // API 응답으로 받은 투표 결과를 현재 옵션 형태로 변환
         const updatedOptions = currentOptions.map(opt => {
           const updatedItem = response.data.voteItems.find(
             (item: PollOption) => item.voteItemId === opt.voteItemId,
@@ -111,7 +107,6 @@ const PollRecord = ({
         setCurrentOptions(updatedOptions);
         onVoteUpdate?.(updatedOptions);
 
-        // 성공 메시지
         const actionText = voteData.type ? '투표했습니다' : '투표를 취소했습니다';
         openSnackbar({
           message: actionText,
@@ -119,7 +114,6 @@ const PollRecord = ({
           onClose: () => {},
         });
       } else {
-        // 에러 처리
         let errorMessage = '투표 처리 중 오류가 발생했습니다.';
 
         if (response.code === 120001) {
@@ -131,7 +125,7 @@ const PollRecord = ({
         } else if (response.code === 120000) {
           errorMessage = '투표는 존재하지만 투표항목이 비어있습니다.';
         } else if (response.message) {
-          errorMessage = response.message; // 서버에서 보낸 메시지 사용
+          errorMessage = response.message;
         }
 
         openSnackbar({
@@ -152,13 +146,10 @@ const PollRecord = ({
     }
   };
 
-  // 아무도 투표하지 않았는지 확인 (모든 옵션이 0표인지 확인)
   const hasVotes = currentOptions.some(option => option.count > 0);
 
-  // 전체 투표수 계산
   const totalVotes = currentOptions.reduce((sum, option) => sum + option.count, 0);
 
-  // 각 옵션의 퍼센트 계산 (애니메이션용)
   const getPercentage = (count: number) => {
     if (totalVotes === 0) return 0;
     return (count / totalVotes) * 100;
@@ -184,7 +175,7 @@ const PollRecord = ({
                 percentage={hasVotes ? getPercentage(option.count) : 0}
                 isHighest={hasVotes && option.isHighest}
                 animate={hasVotes && animate}
-                delay={index * 200} // 각 옵션마다 200ms 지연
+                delay={index * 200}
               />
             </PollBar>
             <PollContent>

--- a/src/components/memory/RecordItem/RecordItem.tsx
+++ b/src/components/memory/RecordItem/RecordItem.tsx
@@ -51,30 +51,24 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
     isWriter,
   } = record;
 
-  // 좋아요 상태 관리 - record 객체에서 isLiked 속성 가져오기
   const [isLiked, setIsLiked] = useState(record.isLiked || false);
   const [currentLikeCount, setCurrentLikeCount] = useState(likeCount);
 
-  // 전역 댓글 바텀시트
   const { openCommentBottomSheet } = useCommentBottomSheetStore();
 
-
-  // API에서 받은 isWriter 속성으로 내 기록인지 판단
   const isMyRecord = isWriter ?? false;
 
-  // 좋아요 클릭 핸들러 - API 연동
   const handleLikeClick = async () => {
     try {
       const postId = parseInt(id);
       const roomPostType = type === 'poll' ? 'VOTE' : 'RECORD';
 
       const response = await postRoomPostLike(postId, {
-        type: !isLiked, // 현재 상태 반대로 전송
+        type: !isLiked,
         roomPostType,
       });
 
       if (response.isSuccess) {
-        // 서버 응답으로 상태 업데이트
         setIsLiked(response.data.isLiked);
         setCurrentLikeCount((prev: number) => (response.data.isLiked ? prev + 1 : prev - 1));
         console.log('좋아요 상태 변경 성공:', response.data.isLiked);
@@ -97,40 +91,36 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
     }
   };
 
-  // 페이지 정보 표시 함수
   const renderPageInfo = () => {
     if (recordType === 'overall') {
       return '총평';
     } else if (pageRange) {
       return `${pageRange}p`;
     }
-    return '0p'; // 기본값
+    return '0p';
   };
 
   const handleEdit = useCallback(() => {
     if (!roomId) return;
-    
-    // 바텀시트 닫기
+
     closePopup();
-    
+
     if (type === 'poll') {
-      // 투표 수정 페이지로 이동 (투표 정보를 쿼리 파라미터로 전달)
       const params = new URLSearchParams({
         content: content,
         pageRange: pageRange || '',
         recordType: recordType || 'normal',
-        options: JSON.stringify(pollOptions?.map(option => option.text) || [])
+        options: JSON.stringify(pollOptions?.map(option => option.text) || []),
       });
-      
+
       navigate(`/memory/poll/edit/${roomId}/${record.id}?${params.toString()}`);
     } else {
-      // 기록 수정 페이지로 이동 (기록 정보를 쿼리 파라미터로 전달)
       const params = new URLSearchParams({
         content: content,
         pageRange: pageRange || '',
-        recordType: recordType || 'normal'
+        recordType: recordType || 'normal',
       });
-      
+
       navigate(`/memory/record/edit/${roomId}/${record.id}?${params.toString()}`);
     }
   }, [roomId, record.id, content, pageRange, recordType, type, pollOptions, navigate, closePopup]);
@@ -155,9 +145,6 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
           variant: 'top',
           onClose: () => {},
         });
-
-        // TODO: 목록에서 해당 기록 제거 (부모 컴포넌트 업데이트 필요)
-        // 현재는 페이지 새로고침으로 임시 처리
         window.location.reload();
       } else {
         openSnackbar({
@@ -194,7 +181,6 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
     });
   }, [openSnackbar]);
 
-  // 기록을 피드에 핀하기 핸들러
   const handlePinRecord = useCallback(async () => {
     const currentRoomId = roomId || '1';
     const recordId = parseInt(record.id);
@@ -203,10 +189,8 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
       const response = await pinRecordToFeed(parseInt(currentRoomId), recordId);
 
       if (response.isSuccess) {
-        // 팝업 먼저 닫기
         closePopup();
-        
-        // 피드 작성 페이지로 이동하면서 데이터 전달
+
         navigate('/feed/write', {
           state: {
             pinData: {
@@ -233,7 +217,6 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
           errorMessage = '존재하지 않는 책입니다.';
         }
 
-        // 실패한 경우에도 팝업 닫기
         closePopup();
 
         openSnackbar({
@@ -244,10 +227,9 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
       }
     } catch (error) {
       console.error('핀하기 API 호출 실패:', error);
-      
-      // 네트워크 오류 시에도 팝업 닫기
+
       closePopup();
-      
+
       openSnackbar({
         message: '네트워크 오류가 발생했습니다. 다시 시도해주세요.',
         variant: 'top',
@@ -256,68 +238,64 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
     }
   }, [roomId, record.id, content, navigate, openSnackbar, closePopup]);
 
-  // 핀하기 확인 팝업 핸들러
   const handlePinConfirm = useCallback(() => {
     openConfirm({
       title: '이 기록을 피드에 핀할까요?',
       disc: '핀하면 내 피드에 글을 옮길 수 있어요.',
       onConfirm: handlePinRecord,
-      onClose: closePopup, // "아니오" 버튼 클릭 시 팝업 닫기
+      onClose: closePopup,
     });
   }, [openConfirm, handlePinRecord, closePopup]);
 
-  // 댓글 버튼 클릭 핸들러
   const handleCommentClick = useCallback(() => {
     openCommentBottomSheet(parseInt(id), type === 'poll' ? 'VOTE' : 'RECORD');
   }, [openCommentBottomSheet, id, type]);
 
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (shouldBlur) {
+        e.stopPropagation();
+        return;
+      }
 
-  const handleClick = useCallback((e: React.MouseEvent) => {
-    // 블라인드된 상태에서는 클릭 이벤트 무시
-    if (shouldBlur) {
-      e.stopPropagation();
-      return;
-    }
-    
-    // 클릭으로 더보기 메뉴 표시
-    if (isMyRecord) {
-      if (type === 'text') {
-        // 기록(text)일 때는 핀하기 기능 포함
-        openMoreMenu({
-          onEdit: handleEdit,
-          onDelete: handleDeleteConfirm,
-          onClose: closePopup,
-          onPin: handlePinConfirm,
-          type: 'post' as const,
-          isWriter: true,
-        });
+      if (isMyRecord) {
+        if (type === 'text') {
+          openMoreMenu({
+            onEdit: handleEdit,
+            onDelete: handleDeleteConfirm,
+            onClose: closePopup,
+            onPin: handlePinConfirm,
+            type: 'post' as const,
+            isWriter: true,
+          });
+        } else {
+          openMoreMenu({
+            onEdit: handleEdit,
+            onDelete: handleDeleteConfirm,
+            onClose: closePopup,
+            type: 'post' as const,
+            isWriter: true,
+          });
+        }
       } else {
-        // 투표일 때는 핀하기 기능 제외
         openMoreMenu({
-          onEdit: handleEdit,
-          onDelete: handleDeleteConfirm,
+          onReport: handleReport,
           onClose: closePopup,
-          type: 'post' as const,
-          isWriter: true,
         });
       }
-    } else {
-      openMoreMenu({
-        onReport: handleReport,
-        onClose: closePopup,
-      });
-    }
-  }, [
-    isMyRecord,
-    type,
-    openMoreMenu,
-    handleReport,
-    handleEdit,
-    handleDeleteConfirm,
-    handlePinConfirm,
-    closePopup,
-    shouldBlur,
-  ]);
+    },
+    [
+      isMyRecord,
+      type,
+      openMoreMenu,
+      handleReport,
+      handleEdit,
+      handleDeleteConfirm,
+      handlePinConfirm,
+      closePopup,
+      shouldBlur,
+    ],
+  );
 
   return (
     <Container
@@ -339,7 +317,7 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
             zIndex: 10,
             cursor: 'default',
           }}
-          onClick={(e) => {
+          onClick={e => {
             e.stopPropagation();
           }}
         />
@@ -363,7 +341,6 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
             postId={parseInt(id)}
             shouldBlur={shouldBlur}
             onVoteUpdate={updatedOptions => {
-              // TODO: 부모 컴포넌트로 투표 결과 업데이트 전달
               console.log('투표 결과 업데이트:', updatedOptions);
             }}
           />
@@ -414,7 +391,7 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
               shouldBlur
                 ? undefined
                 : e => {
-                    e.stopPropagation(); // 이벤트 버블링 방지
+                    e.stopPropagation();
                     handlePinConfirm();
                   }
             }

--- a/src/components/memory/RecordItem/RecordItem.tsx
+++ b/src/components/memory/RecordItem/RecordItem.tsx
@@ -71,10 +71,7 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
       if (response.isSuccess) {
         setIsLiked(response.data.isLiked);
         setCurrentLikeCount((prev: number) => (response.data.isLiked ? prev + 1 : prev - 1));
-        console.log('좋아요 상태 변경 성공:', response.data.isLiked);
       } else {
-        console.error('좋아요 상태 변경 실패:', response.message);
-
         openSnackbar({
           message: response.message || '좋아요 처리 중 오류가 발생했습니다.',
           variant: 'top',
@@ -340,9 +337,7 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
             pollOptions={pollOptions || []}
             postId={parseInt(id)}
             shouldBlur={shouldBlur}
-            onVoteUpdate={updatedOptions => {
-              console.log('투표 결과 업데이트:', updatedOptions);
-            }}
+            onVoteUpdate={() => {}}
           />
         )}
       </ContentSection>

--- a/src/components/memory/SortDropdown.tsx
+++ b/src/components/memory/SortDropdown.tsx
@@ -16,13 +16,11 @@ const SortDropdown = ({ isOpen, selectedSort, onSortSelect }: SortDropdownProps)
   useEffect(() => {
     if (isOpen) {
       setShouldRender(true);
-      // 다음 프레임에서 애니메이션 시작
       requestAnimationFrame(() => {
         setIsAnimating(true);
       });
     } else {
       setIsAnimating(false);
-      // 애니메이션 완료 후 DOM에서 제거
       setTimeout(() => {
         setShouldRender(false);
       }, 150);

--- a/src/components/memory/UploadProgressBar/UploadProgressBar.tsx
+++ b/src/components/memory/UploadProgressBar/UploadProgressBar.tsx
@@ -18,8 +18,8 @@ const UploadProgressBar = ({ isVisible, onComplete }: UploadProgressBarProps) =>
       return;
     }
 
-    const duration = 3000; // 3초
-    const interval = 50; // 50ms마다 업데이트
+    const duration = 3000;
+    const interval = 50;
     const increment = (100 / duration) * interval;
 
     const timer = setInterval(() => {
@@ -30,7 +30,7 @@ const UploadProgressBar = ({ isVisible, onComplete }: UploadProgressBarProps) =>
           setIsCompleted(true);
           setTimeout(() => {
             onComplete();
-          }, 1000); // 1초 후 완료 (완료 메시지를 보여주기 위해)
+          }, 1000);
         }
         return newProgress;
       });

--- a/src/components/pollwrite/PollCreationSection.tsx
+++ b/src/components/pollwrite/PollCreationSection.tsx
@@ -17,8 +17,8 @@ interface PollCreationSectionProps {
   onContentChange: (value: string) => void;
   options: string[];
   onOptionsChange: (options: string[]) => void;
-  isEditMode?: boolean; // 수정 모드 여부
-  autoFocus?: boolean; // 자동 포커스 및 커서 위치 설정 여부
+  isEditMode?: boolean;
+  autoFocus?: boolean;
 }
 
 const PollCreationSection = ({
@@ -73,7 +73,6 @@ const PollCreationSection = ({
       onOptionsChange(newOptions);
       setFocusStates(newFocusStates);
 
-      // refs 배열도 업데이트
       inputRefs.current = inputRefs.current.filter((_, i) => i !== index);
     }
   };
@@ -92,12 +91,10 @@ const PollCreationSection = ({
     }
   }, [options.length, focusStates.length]);
 
-  // autoFocus 처리
   useEffect(() => {
     if (autoFocus && contentInputRef.current) {
       const input = contentInputRef.current;
       input.focus();
-      // 커서를 텍스트 끝으로 이동
       const length = input.value.length;
       input.setSelectionRange(length, length);
     }
@@ -131,16 +128,13 @@ const PollCreationSection = ({
               disabled={isEditMode}
               readOnly={isEditMode}
             />
-            {/* 수정 모드가 아니어야만 삭제 버튼 표시 */}
             {!isEditMode && (
               <>
-                {/* 텍스트가 있을 때는 X 아이콘으로 텍스트 삭제 */}
                 {option.trim() !== '' && (
                   <DeleteButton onClick={() => handleClearOption(index)}>
                     <img src={closeIcon} alt="텍스트 삭제" />
                   </DeleteButton>
                 )}
-                {/* 텍스트가 없고 3번째 항목(index >= 2)부터만 쓰레기통 아이콘으로 항목 삭제 */}
                 {option.trim() === '' && index >= 2 && (
                   <DeleteButton onClick={() => handleRemoveOption(index)}>
                     <img src={trashIcon} alt="항목 삭제" />

--- a/src/components/recordwrite/PageRangeSection.styled.ts
+++ b/src/components/recordwrite/PageRangeSection.styled.ts
@@ -63,14 +63,12 @@ export const PageInput = styled.input<{ inputLength?: number }>`
     color: ${semanticColors.text.ghost};
   }
 
-  /* 숫자 입력 스피너 제거 */
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
 
-  /* Firefox에서 기본 스타일 제거 */
   -moz-appearance: textfield;
 `;
 

--- a/src/components/recordwrite/PageRangeSection.tsx
+++ b/src/components/recordwrite/PageRangeSection.tsx
@@ -36,7 +36,7 @@ interface PageRangeSectionProps {
   readingProgress: number;
   isOverviewPossible: boolean;
   isDisabled?: boolean;
-  hideToggle?: boolean; // 총평 토글 버튼 숨김 여부
+  hideToggle?: boolean;
 }
 
 const PageRangeSection = ({
@@ -53,21 +53,16 @@ const PageRangeSection = ({
   const [hasError, setHasError] = useState(false);
   const [showRedTooltip, setShowRedTooltip] = useState(false);
   const [showGreenTooltip, setShowGreenTooltip] = useState(false);
-
-  // 80% 이상일 때만 총평 활성화
   const canUseOverall = readingProgress >= 80;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
 
-    // 숫자만 입력 허용 (빈 문자열 또는 양수)
     if (value === '' || /^\d+$/.test(value)) {
       onPageRangeChange(value);
 
-      // 전체 페이지 수를 초과하면 에러 상태로 변경
       if (value !== '') {
         const page = parseInt(value);
-        // NaN 체크도 포함하여 안전성 확보
         setHasError(isNaN(page) || page <= 0 || page > totalPages);
       } else {
         setHasError(false);
@@ -84,14 +79,12 @@ const PageRangeSection = ({
     if (canUseOverall) {
       onOverallToggle();
     } else {
-      // 80% 미만이면 빨간 툴팁 표시
       setShowRedTooltip(true);
       setShowGreenTooltip(false);
     }
   };
 
   const handleInfoClick = () => {
-    // i 아이콘 클릭 시 초록 툴팁 표시
     setShowGreenTooltip(true);
     setShowRedTooltip(false);
   };

--- a/src/components/recordwrite/RecordContentSection.tsx
+++ b/src/components/recordwrite/RecordContentSection.tsx
@@ -10,7 +10,7 @@ import {
 interface RecordContentSectionProps {
   content: string;
   onContentChange: (value: string) => void;
-  autoFocus?: boolean; // 자동 포커스 및 커서 위치 설정 여부
+  autoFocus?: boolean;
 }
 
 const RecordContentSection = ({
@@ -21,30 +21,24 @@ const RecordContentSection = ({
   const maxLength = 500;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // 텍스트 변경 시 높이 자동 조절
   const adjustHeight = () => {
     const textarea = textareaRef.current;
     if (textarea) {
-      // 높이를 초기화한 후 scrollHeight로 설정
       textarea.style.height = 'auto';
       textarea.style.height = `${textarea.scrollHeight}px`;
     }
   };
 
-  // content가 변경될 때마다 높이 조절
   useEffect(() => {
     adjustHeight();
   }, [content]);
 
-  // 컴포넌트 마운트 시 초기 높이 설정 및 autoFocus 처리
   useEffect(() => {
     adjustHeight();
-    
-    // autoFocus가 true이고 textarea가 있으면 포커스 및 커서를 끝으로 이동
+
     if (autoFocus && textareaRef.current) {
       const textarea = textareaRef.current;
       textarea.focus();
-      // 커서를 텍스트 끝으로 이동
       const length = textarea.value.length;
       textarea.setSelectionRange(length, length);
     }

--- a/src/components/today-words/MessageInput.styled.ts
+++ b/src/components/today-words/MessageInput.styled.ts
@@ -80,7 +80,6 @@ export const MessageInput = styled.textarea`
     color: ${semanticColors.text.ghost};
   }
 
-  /* 스크롤바 숨기기 */
   scrollbar-width: none;
   -ms-overflow-style: none;
   &::-webkit-scrollbar {

--- a/src/components/today-words/MessageInput.tsx
+++ b/src/components/today-words/MessageInput.tsx
@@ -64,7 +64,6 @@ const MessageInput = ({
 
   return (
     <Wrapper>
-      {/* 답글 작성 중일 때만 표시 */}
       {isReplying && nickname && (
         <ReplyContainer>
           <div className="left">
@@ -87,11 +86,11 @@ const MessageInput = ({
         <MessageInputWrapper>
           <StyledMessageInput
             ref={inputRef}
-            placeholder={disabled ? '전송 중...' : placeholder} // disabled일 때 placeholder 변경
+            placeholder={disabled ? '전송 중...' : placeholder}
             value={value}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
-            onCompositionStart={() => !disabled && setIsComposing(true)} // disabled일 때는 composing 상태 변경 안함
+            onCompositionStart={() => !disabled && setIsComposing(true)}
             onCompositionEnd={() => !disabled && setIsComposing(false)}
             rows={1}
             disabled={disabled}

--- a/src/components/today-words/MessageList/MessageActionBottomSheet.tsx
+++ b/src/components/today-words/MessageList/MessageActionBottomSheet.tsx
@@ -32,10 +32,8 @@ const MessageActionBottomSheet = ({
     <Overlay isOpen={isOpen} onClick={handleOverlayClick}>
       <BottomSheet isOpen={isOpen}>
         {isMyMessage ? (
-          // 내 댓글인 경우 - 삭제하기만 표시
           <DeleteActionItem onClick={onDelete}>삭제하기</DeleteActionItem>
         ) : (
-          // 타인의 댓글인 경우 - 신고하기만 표시
           <ReportActionItem onClick={onReport}>신고하기</ReportActionItem>
         )}
       </BottomSheet>

--- a/src/components/today-words/MessageList/MessageList.tsx
+++ b/src/components/today-words/MessageList/MessageList.tsx
@@ -140,7 +140,6 @@ const MessageList = forwardRef<MessageListRef, MessageListProps>(
     };
 
     const handleReport = () => {
-      console.log('메시지 신고');
       setSelectedMessageId(null);
     };
 

--- a/src/components/today-words/MessageList/MessageList.tsx
+++ b/src/components/today-words/MessageList/MessageList.tsx
@@ -33,15 +33,7 @@ export interface MessageListRef {
 }
 
 const MessageList = forwardRef<MessageListRef, MessageListProps>(
-  (
-    {
-      messages: initialMessages,
-      currentUserId = 'user.01',
-      onMessageDelete,
-      roomId,
-    },
-    ref,
-  ) => {
+  ({ messages: initialMessages, currentUserId = 'user.01', onMessageDelete, roomId }, ref) => {
     const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
     const [messages, setMessages] = useState(initialMessages);
     const { openSnackbar } = usePopupActions();
@@ -71,16 +63,12 @@ const MessageList = forwardRef<MessageListRef, MessageListProps>(
       setMessages(prevMessages => [...prevMessages, newMessage]);
     };
 
-    // ref를 통해 외부에서 addMessage 함수에 접근할 수 있도록 함
     useImperativeHandle(ref, () => ({
       addMessage,
     }));
 
-    // 먼저 모든 메시지를 시간순으로 정렬 (아래로 올수록 최신)
-    // ID를 기준으로 정렬 (ID가 클수록 최신)
     const sortedMessages = messages.sort((a, b) => parseInt(a.id) - parseInt(b.id));
 
-    // 날짜별로 메시지 그룹화
     const groupedMessages = sortedMessages.reduce(
       (groups, message) => {
         const date = message.timestamp;
@@ -93,7 +81,6 @@ const MessageList = forwardRef<MessageListRef, MessageListProps>(
       {} as Record<string, Message[]>,
     );
 
-    // 날짜를 오래된 순으로 정렬 (아래로 올수록 최신)
     const sortedDates = Object.keys(groupedMessages).sort((a, b) => a.localeCompare(b));
 
     const handleMoreClick = (messageId: string) => {
@@ -107,22 +94,17 @@ const MessageList = forwardRef<MessageListRef, MessageListProps>(
     const handleDelete = async () => {
       if (selectedMessageId && roomId) {
         try {
-          // API에서는 attendanceCheckId가 필요하므로 selectedMessageId를 사용
           const attendanceCheckId = parseInt(selectedMessageId);
-          
+
           const result = await deleteDailyGreeting(roomId, attendanceCheckId);
-          
+
           if (result.isSuccess) {
-            // 로컬 상태에서 메시지 제거
-            setMessages(prevMessages => 
-              prevMessages.filter(msg => msg.id !== selectedMessageId)
-            );
-            
-            // 부모 컴포넌트에 삭제 알림
+            setMessages(prevMessages => prevMessages.filter(msg => msg.id !== selectedMessageId));
+
             if (onMessageDelete) {
               onMessageDelete(selectedMessageId);
             }
-            
+
             openSnackbar({
               message: '오늘의 한마디가 삭제되었습니다.',
               variant: 'top',
@@ -192,7 +174,6 @@ const MessageList = forwardRef<MessageListRef, MessageListProps>(
                 ))}
               </DateGroup>
 
-              {/* 마지막 그룹이 아닐 때만 구분선 표시 */}
               {groupIndex < sortedDates.length - 1 && <Separator />}
             </div>
           ))}

--- a/src/hooks/useCreateFeed.ts
+++ b/src/hooks/useCreateFeed.ts
@@ -16,9 +16,7 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
     try {
       setLoading(true);
 
-      // ===== 클라이언트 선검증 (선택값일 때만 검사) =====
       if (body.tagList) {
-        // 최대 5개
         if (body.tagList.length > 5) {
           openSnackbar({
             message: '태그는 최대 5개까지 입력할 수 있어요.',
@@ -27,7 +25,6 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
           });
           return { success: false as const };
         }
-        // 중복 제거 체크
         const trimmed = body.tagList.map(t => t.trim()).filter(Boolean);
         const uniq = new Set(trimmed);
         if (uniq.size !== trimmed.length) {
@@ -43,7 +40,6 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
       let uploadedImageUrls: string[] = [];
 
       if (images && images.length > 0) {
-        // 최대 3장
         if (images.length > 3) {
           openSnackbar({
             message: '이미지는 최대 3장까지 업로드할 수 있어요.',
@@ -52,7 +48,6 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
           });
           return { success: false as const };
         }
-        // 빈 파일 금지
         if (images.some(f => f.size === 0)) {
           openSnackbar({
             message: '빈 이미지 파일이 포함되어 있어요.',
@@ -61,7 +56,6 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
           });
           return { success: false as const };
         }
-        // 확장자 제한
         const extOk = (name: string) => /\.(jpe?g|png|gif)$/i.test(name);
         if (images.some(f => !extOk(f.name))) {
           openSnackbar({
@@ -72,7 +66,6 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
           return { success: false as const };
         }
 
-        // Presigned URL 발급 요청
         const presignedRequests: PresignedUrlRequest[] = images.map(file => ({
           extension: file.name.split('.').pop()?.toLowerCase() || 'jpg',
           size: file.size,
@@ -80,7 +73,7 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
 
         try {
           const presignedResponse = await getPresignedUrl(presignedRequests);
-          
+
           if (!presignedResponse.isSuccess || !presignedResponse.data) {
             openSnackbar({
               message: presignedResponse.message || 'Presigned URL 발급에 실패했습니다.',
@@ -90,17 +83,15 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
             return { success: false as const };
           }
 
-          // S3에 이미지 업로드
           const uploadPromises = presignedResponse.data.presignedUrls.map(
             async (urlData, index) => {
               const success = await uploadFileToS3(urlData.presignedUrl, images[index]);
               return success ? urlData.fileUrl : null;
-            }
+            },
           );
 
           const uploadResults = await Promise.all(uploadPromises);
-          
-          // 업로드 실패한 파일이 있는지 확인
+
           if (uploadResults.some(result => result === null)) {
             openSnackbar({
               message: '이미지 업로드 중 오류가 발생했습니다.',
@@ -121,9 +112,7 @@ export const useCreateFeed = (options?: UseCreateFeedProps) => {
           return { success: false as const };
         }
       }
-      // ===== 선검증 끝 =====
 
-      // 피드 생성 요청에 업로드된 이미지 URL 포함
       const feedBody: CreateFeedBody = {
         ...body,
         ...(uploadedImageUrls.length > 0 && { imageUrls: uploadedImageUrls }),

--- a/src/hooks/useUpdateFeed.ts
+++ b/src/hooks/useUpdateFeed.ts
@@ -14,9 +14,7 @@ export const useUpdateFeed = (options?: UseUpdateFeedProps) => {
     try {
       setLoading(true);
 
-      // ===== 클라이언트 선검증 =====
       if (body.tagList) {
-        // 최대 5개
         if (body.tagList.length > 5) {
           openSnackbar({
             message: '태그는 최대 5개까지 입력할 수 있어요.',
@@ -25,7 +23,6 @@ export const useUpdateFeed = (options?: UseUpdateFeedProps) => {
           });
           return { success: false as const };
         }
-        // 중복 제거 체크
         const trimmed = body.tagList.map(t => t.trim()).filter(Boolean);
         const uniq = new Set(trimmed);
         if (uniq.size !== trimmed.length) {
@@ -37,7 +34,6 @@ export const useUpdateFeed = (options?: UseUpdateFeedProps) => {
           return { success: false as const };
         }
       }
-      // ===== 선검증 끝 =====
 
       const res: UpdateFeedResponse = await updateFeed(feedId, body);
 

--- a/src/mocks/members.mock.ts
+++ b/src/mocks/members.mock.ts
@@ -12,7 +12,7 @@ export const mockMembers: Member[] = [
     id: '1',
     nickname: 'Thiper',
     role: '칭호칭호',
-    profileImage: '', // 빈 문자열로 기본 이미지 처리
+    profileImage: '',
     points: 0,
     followersCount: 0,
   },

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -7,13 +7,12 @@ import GenreSelectionSection from '../../components/creategroup/GenreSelectionSe
 import RoomInfoSection from '../../components/creategroup/RoomInfoSection';
 import ActivityPeriodSection from '../../components/creategroup/ActivityPeriodSection/ActivityPeriodSection';
 import MemberLimitSection from '../../components/creategroup/MemberLimitSection';
-import PrivacySettingSection from '../../components/creategroup//PrivacySettingSection/PrivacySettingSection';
+import PrivacySettingSection from '../../components/creategroup/PrivacySettingSection/PrivacySettingSection';
 import leftarrow from '../../assets/common/leftArrow.svg';
 import { Container } from './CreateGroup.styled';
 import { createRoom } from '../../api/rooms/createRoom';
 import type { CreateRoomRequest } from '@/types/room';
 
-// Book 타입 정의
 interface Book {
   id?: number;
   title: string;
@@ -81,21 +80,19 @@ const CreateGroup = () => {
   };
 
   const handleCompleteClick = async () => {
-    if (isSubmitting) return; // 중복 실행 방지
+    if (isSubmitting) return;
 
     setIsSubmitting(true);
 
     try {
-      // 날짜 형식 변환 (YYYY.MM.DD)
       const formatDate = (date: { year: number; month: number; day: number }) => {
         const month = date.month.toString().padStart(2, '0');
         const day = date.day.toString().padStart(2, '0');
         return `${date.year}.${month}.${day}`;
       };
 
-      // 방 생성 요청 데이터 구성
       const roomData: CreateRoomRequest = {
-        isbn: selectedBook?.isbn || '9788936434632', // 선택된 책의 ISBN 또는 기본값
+        isbn: selectedBook?.isbn || '9788936434632',
         category: selectedGenre,
         roomName: roomTitle.trim(),
         description: roomDescription.trim(),
@@ -103,18 +100,14 @@ const CreateGroup = () => {
         progressEndDate: formatDate(endDate),
         recruitCount: memberLimit,
         password: isPrivate ? password.trim() : null,
-        isPublic: !isPrivate, // isPrivate의 반대값
+        isPublic: !isPrivate,
       };
 
-
-      // 방 생성 API 호출
       const response = await createRoom(roomData);
 
-      // 두 가지 응답 형식 모두 확인
       const isSuccessful = response.isSuccess || response.isSuccess;
 
       if (isSuccessful) {
-        // 성공 시 모집 중인 방 상세 페이지로 이동
         navigate(`/group/detail/${response.data.roomId}`, {
           replace: true,
         });
@@ -122,7 +115,6 @@ const CreateGroup = () => {
         alert(`방 생성에 실패했습니다: ${response.message} (코드: ${response.code})`);
       }
     } catch (error) {
-      // 자세한 오류 정보 로깅
       if (error && typeof error === 'object' && 'response' in error) {
         const axiosError = error as {
           response?: {
@@ -174,7 +166,6 @@ const CreateGroup = () => {
 
   const handlePrivacyToggle = () => {
     setIsPrivate(!isPrivate);
-    // 비공개 설정을 끄면 비밀번호도 초기화
     if (isPrivate) {
       setPassword('');
     }
@@ -188,14 +179,13 @@ const CreateGroup = () => {
     setPassword('');
   };
 
-  // 폼 유효성 검사 - 4자리 숫자 비밀번호 검증 포함
   const isFormValid =
     selectedBook !== null &&
     selectedGenre !== '' &&
     roomTitle.trim() !== '' &&
     roomDescription.trim() !== '' &&
-    isDateValid && // 날짜 유효성 검사 추가
-    (!isPrivate || (password.trim() !== '' && /^\d{4}$/.test(password.trim()))) && // 비공개방인 경우 4자리 숫자 필수
+    isDateValid &&
+    (!isPrivate || (password.trim() !== '' && /^\d{4}$/.test(password.trim()))) &&
     !isSubmitting;
 
   return (

--- a/src/pages/groupDetail/ParticipatedGroupDetail.tsx
+++ b/src/pages/groupDetail/ParticipatedGroupDetail.tsx
@@ -107,7 +107,6 @@ const ParticipatedGroupDetail = () => {
       title: '모임방을 삭제하시겠어요?',
       disc: '방을 삭제하게 되면\n독서메이트들과의 추억이 사라집니다.',
       onConfirm: () => {
-        console.log('방 삭제 확정');
         openSnackbar({
           message: '삭제 기능은 현재 개발 중입니다.',
           variant: 'top',

--- a/src/pages/groupDetail/ParticipatedGroupDetail.tsx
+++ b/src/pages/groupDetail/ParticipatedGroupDetail.tsx
@@ -50,15 +50,12 @@ const ParticipatedGroupDetail = () => {
   const navigate = useNavigate();
   const { roomId } = useParams<{ roomId: string }>();
 
-  // API 상태 관리
   const [roomData, setRoomData] = useState<RoomPlayingResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // UI 상태 관리
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
-  // API 호출
   useEffect(() => {
     const fetchRoomDetail = async () => {
       if (!roomId) {
@@ -78,13 +75,12 @@ const ParticipatedGroupDetail = () => {
         }
       } catch (err: unknown) {
         console.error('방 상세 정보 조회 오류:', err);
-        
-        // 방 접근 권한이 없는 경우 - 모임 홈으로 리다이렉트
+
         if (err instanceof Error && err.message === '방 접근 권한이 없습니다.') {
           navigate('/group', { replace: true });
           return;
         }
-        
+
         setError('방 정보를 불러오는 중 오류가 발생했습니다.');
       } finally {
         setLoading(false);
@@ -131,7 +127,7 @@ const ParticipatedGroupDetail = () => {
 
         try {
           const response = await leaveRoom(parseInt(roomId));
-          
+
           if (response.isSuccess) {
             openSnackbar({
               message: '모임 나가기를 완료했어요.',
@@ -139,10 +135,8 @@ const ParticipatedGroupDetail = () => {
               isError: false,
               onClose: () => {},
             });
-            // 모임 홈으로 이동
             navigate('/group', { replace: true });
           } else {
-            // API에서 반환한 에러 메시지 사용
             openSnackbar({
               message: response.message,
               variant: 'top',
@@ -152,17 +146,16 @@ const ParticipatedGroupDetail = () => {
           }
         } catch (error: unknown) {
           console.error('방 나가기 오류:', error);
-          
-          // 서버 응답이 있는 경우 메시지 사용, 없으면 기본 메시지
+
           let errorMessage = '방 나가기 중 오류가 발생했습니다.';
-          
+
           if (error && typeof error === 'object' && 'response' in error) {
             const axiosError = error as { response?: { data?: { message?: string } } };
             if (axiosError.response?.data?.message) {
               errorMessage = axiosError.response.data.message;
             }
           }
-          
+
           openSnackbar({
             message: errorMessage,
             variant: 'top',
@@ -204,7 +197,6 @@ const ParticipatedGroupDetail = () => {
     navigate(`/group/${roomId}/members`);
   };
 
-  // 로딩 상태
   if (loading) {
     return (
       <ParticipatedWrapper>
@@ -213,7 +205,6 @@ const ParticipatedGroupDetail = () => {
     );
   }
 
-  // 에러 상태
   if (error || !roomData) {
     return (
       <ParticipatedWrapper>
@@ -224,27 +215,21 @@ const ParticipatedGroupDetail = () => {
 
   const { data } = roomData;
 
-  // API 데이터를 컴포넌트에 맞게 변환
   const polls: Poll[] = convertVotesToPolls(data.currentVotes);
   const hasPolls = polls.length > 0;
 
-  // 날짜 포맷팅 (YYYY-MM-DD -> YYYY.MM.DD)
   const formatDate = (dateString: string) => {
     return dateString.replace(/-/g, '.');
   };
 
-  // 장르에 따른 배경색 결정 (카테고리 컬러 사용)
   const getGenreForBackground = () => {
-    // categoryColor를 사용하거나 기본값으로 장르명 사용
     return data.category;
   };
 
-  // 댓글 섹션 메시지
   const commentData = {
     message: '모임방 멤버들과 간단한 인사를 나눠보세요!',
   };
 
-  // 모임방 완료 여부 확인
   const isCompleted = roomData ? isRoomCompleted(roomData.data.progressEndDate) : false;
 
   return (

--- a/src/pages/groupMembers/GroupMembers.tsx
+++ b/src/pages/groupMembers/GroupMembers.tsx
@@ -15,15 +15,12 @@ const GroupMembers = () => {
   const navigate = useNavigate();
   const { roomId } = useParams<{ roomId: string }>();
 
-  // API 상태 관리
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // API 호출
   useEffect(() => {
     const fetchMembers = async () => {
-      // roomId 우선 순위: URL 파라미터 > localStorage > 기본값 1
       const currentRoomId = roomId || localStorage.getItem('currentRoomId') || '1';
 
       if (!currentRoomId) {
@@ -44,13 +41,12 @@ const GroupMembers = () => {
         }
       } catch (err: unknown) {
         console.error('독서메이트 조회 오류:', err);
-        
-        // 방 접근 권한이 없는 경우 - 모임 홈으로 리다이렉트
+
         if (err instanceof Error && err.message === '방 접근 권한이 없습니다.') {
           navigate('/group', { replace: true });
           return;
         }
-        
+
         setError('독서메이트 목록을 불러오는 중 오류가 발생했습니다.');
       } finally {
         setLoading(false);
@@ -65,8 +61,6 @@ const GroupMembers = () => {
   };
 
   const handleMemberClick = (memberId: string) => {
-    // MemberList 컴포넌트에서 isMyself에 따른 네비게이션 처리를 담당하므로
-    // 여기서는 기본 동작을 유지
     const member = members.find(m => m.id === memberId);
     if (member?.isMyself) {
       navigate(`/myfeed/${memberId}`);
@@ -75,7 +69,6 @@ const GroupMembers = () => {
     }
   };
 
-  // 로딩 상태
   if (loading) {
     return (
       <>
@@ -91,7 +84,6 @@ const GroupMembers = () => {
     );
   }
 
-  // 에러 상태
   if (error) {
     return (
       <>

--- a/src/pages/memory/Memory.styled.ts
+++ b/src/pages/memory/Memory.styled.ts
@@ -24,9 +24,8 @@ export const ScrollableContent = styled.div`
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding-bottom: 100px; /* AddButton 공간 확보 */
+  padding-bottom: 100px;
 
-  /* 스크롤바 스타일링 */
   &::-webkit-scrollbar {
     width: 4px;
   }

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -70,7 +70,6 @@ const Memory = () => {
     if (pageParam && filterParam === 'poll') {
       const page = parseInt(pageParam);
       if (!isNaN(page)) {
-        console.log('✅ 페이지 필터 적용:', { page });
         setSelectedPageRange({ start: page, end: page });
         setActiveFilter('page');
         setActiveTab('group');
@@ -81,7 +80,6 @@ const Memory = () => {
   }, [location.search]);
 
   const [error, setError] = useState<string | null>(null);
-  const [isOverviewEnabled, setIsOverviewEnabled] = useState(false);
 
   const [showUploadProgress, setShowUploadProgress] = useState(false);
 
@@ -94,7 +92,6 @@ const Memory = () => {
 
   const loadMemoryPosts = useCallback(async () => {
     if (!roomId) {
-      console.log('❌ roomId가 없습니다:', roomId);
       return;
     }
     setError(null);
@@ -126,8 +123,6 @@ const Memory = () => {
         } else {
           setMyRecords(convertedRecords);
         }
-
-        setIsOverviewEnabled(response.data.isOverviewEnabled);
 
         if (response.data.totalPages !== undefined) {
           setTotalPages(response.data.totalPages);
@@ -282,9 +277,6 @@ const Memory = () => {
   }, []);
 
   const readingProgress = totalPages > 0 ? Math.round((currentUserPage / totalPages) * 100) : 0;
-
-  const overviewStatus = isOverviewEnabled ? '총평 활성화' : '총평 비활성화';
-  console.log('📊 현재 상태:', overviewStatus, `진행률: ${readingProgress}%`);
 
   if (error) {
     return (

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -16,7 +16,6 @@ import type { GetMemoryPostsParams, Post, Record } from '../../types/memory';
 export type RecordType = 'group' | 'my';
 export type FilterType = 'page' | 'overall';
 
-// API 포스트를 기존 Record 타입으로 변환하는 함수
 const convertPostToRecord = (post: Post): Record => {
   return {
     id: post.postId.toString(),
@@ -55,7 +54,6 @@ const Memory = () => {
   const { roomId } = useParams<{ roomId: string }>();
   const { openCommentBottomSheet } = useCommentBottomSheetStore();
 
-  // 상태 관리
   const [activeTab, setActiveTab] = useState<RecordType>('group');
   const [activeFilter, setActiveFilter] = useState<FilterType | null>(null);
   const [selectedSort, setSelectedSort] = useState<SortType>('latest');
@@ -82,24 +80,18 @@ const Memory = () => {
     }
   }, [location.search]);
 
-  // API 관련 상태
   const [error, setError] = useState<string | null>(null);
   const [isOverviewEnabled, setIsOverviewEnabled] = useState(false);
 
-  // 업로드 프로그레스 상태
   const [showUploadProgress, setShowUploadProgress] = useState(false);
 
-  // 모임방 완료 상태
   const [roomCompleted, setRoomCompleted] = useState(false);
 
-  // 기록 데이터
   const [myRecords, setMyRecords] = useState<Record[]>([]);
   const [groupRecords, setGroupRecords] = useState<Record[]>([]);
-  // API에서 받은 페이지 정보
   const [totalPages, setTotalPages] = useState<number>(0);
   const [currentUserPage, setCurrentUserPage] = useState<number>(0);
 
-  // API 데이터 로드 함수
   const loadMemoryPosts = useCallback(async () => {
     if (!roomId) {
       console.log('❌ roomId가 없습니다:', roomId);
@@ -108,18 +100,15 @@ const Memory = () => {
     setError(null);
 
     try {
-      // API 파라미터 구성
       const params: GetMemoryPostsParams = {
         roomId: parseInt(roomId),
         type: activeTab === 'group' ? 'group' : 'mine',
       };
 
-      // group 탭인 경우에만 sort 파라미터 추가
       if (activeTab === 'group') {
         params.sort = selectedSort;
       }
 
-      // 필터 적용
       if (activeFilter === 'overall') {
         params.isOverview = true;
       } else if (selectedPageRange) {
@@ -150,13 +139,12 @@ const Memory = () => {
         setError(response.message);
       }
     } catch (error) {
-      // Axios 에러인 경우 상세 정보 출력
       if (error && typeof error === 'object' && 'response' in error) {
         const axiosError = error as { response?: { data?: { code?: number } } };
         if (axiosError.response?.data?.code === 40002) {
           setError('독서 진행률이 80% 이상이어야 총평을 볼 수 있습니다.');
-          setActiveFilter(null); // 총평 필터를 자동으로 해제
-          return; // 다른 에러 메시지 설정하지 않음
+          setActiveFilter(null);
+          return;
         }
       }
 
@@ -164,7 +152,6 @@ const Memory = () => {
     }
   }, [roomId, activeTab, selectedSort, activeFilter, selectedPageRange]);
 
-  // 모임방 상태 확인
   useEffect(() => {
     const checkRoomStatus = async () => {
       if (!roomId) return;
@@ -183,12 +170,10 @@ const Memory = () => {
     checkRoomStatus();
   }, [roomId]);
 
-  // 컴포넌트 마운트 시 데이터 로드
   useEffect(() => {
     loadMemoryPosts();
   }, [loadMemoryPosts]);
 
-  // Notice에서 넘어온 state(page, focusPostId 등)로 초기 필터 적용
   useEffect(() => {
     type MemoryLocationState = {
       page?: number;
@@ -203,16 +188,13 @@ const Memory = () => {
       setActiveFilter('page');
     }
 
-    // 댓글 모달 자동 오픈 처리
     if (state?.openComments && state.focusPostId && state.postType) {
       openCommentBottomSheet(state.focusPostId, state.postType);
-      // 동일 경로 재진입 시 중복 오픈 방지를 위해 state 제거
       navigate(location.pathname, { replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.state, roomId]);
 
-  // 새로운 기록이 추가되었을 때 처리 (작성 완료 후 돌아왔을 때)
   useEffect(() => {
     if (location.state?.newRecord) {
       const newRecord = location.state.newRecord as Record;
@@ -224,22 +206,18 @@ const Memory = () => {
         setMyRecords(prev => [newRecord, ...prev]);
       }
 
-      // 상태 정리
       navigate(location.pathname, { replace: true });
     }
   }, [location.state, activeTab, navigate, location.pathname]);
 
-  // 현재 탭에 따른 기록 목록 결정
   const currentRecords = useMemo(() => {
     return activeTab === 'group' ? groupRecords : myRecords;
   }, [activeTab, groupRecords, myRecords]);
 
-  // 정렬된 기록 목록
   const sortedRecords = useMemo(() => {
     return currentRecords;
   }, [currentRecords]);
 
-  // 필터링된 기록 목록
   const filteredRecords = useMemo(() => {
     const filtered = sortedRecords;
 
@@ -258,7 +236,6 @@ const Memory = () => {
     return filtered;
   }, [sortedRecords, activeFilter, selectedPageRange]);
 
-  // 이벤트 핸들러들
   const handleBackClick = useCallback(() => {
     if (roomId) {
       navigate(`/group/detail/joined/${roomId}`);
@@ -304,14 +281,11 @@ const Memory = () => {
     setShowUploadProgress(false);
   }, []);
 
-  // 독서 진행률 계산 (전체 페이지 대비 현재 페이지 퍼센트)
   const readingProgress = totalPages > 0 ? Math.round((currentUserPage / totalPages) * 100) : 0;
 
-  // 총평 활성화 상태를 읽기 진행률에 따라 표시용으로 활용
   const overviewStatus = isOverviewEnabled ? '총평 활성화' : '총평 비활성화';
   console.log('📊 현재 상태:', overviewStatus, `진행률: ${readingProgress}%`);
 
-  // 에러 상태 렌더링
   if (error) {
     return (
       <Container>
@@ -328,7 +302,6 @@ const Memory = () => {
     );
   }
 
-  // 메인 렌더링
   return (
     <Container>
       <FixedHeader>

--- a/src/pages/pollwrite/PollWrite.tsx
+++ b/src/pages/pollwrite/PollWrite.tsx
@@ -15,8 +15,7 @@ const PollWrite = () => {
   const navigate = useNavigate();
   const { roomId, voteId } = useParams<{ roomId: string; voteId: string }>();
   const [searchParams] = useSearchParams();
-  
-  // 수정 모드인지 판단
+
   const isEditMode = Boolean(voteId);
   const { openSnackbar } = usePopupActions();
 
@@ -26,13 +25,11 @@ const PollWrite = () => {
   const [isOverallEnabled, setIsOverallEnabled] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // API에서 받아올 데이터
   const [totalPages, setTotalPages] = useState(0);
   const [lastRecordedPage, setLastRecordedPage] = useState(0);
   const [isOverviewPossible, setIsOverviewPossible] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  // 컴포넌트 마운트 시 책 페이지 정보 조회 (생성 모드) 또는 투표 내용 로드 (수정 모드)
   useEffect(() => {
     const initializeData = async () => {
       if (!roomId) {
@@ -47,26 +44,25 @@ const PollWrite = () => {
 
       try {
         setIsLoading(true);
-        
+
         if (isEditMode) {
-          // 수정 모드: 쿼리 파라미터에서 기존 내용과 페이지 정보, 투표 옵션 로드
           const existingContent = searchParams.get('content');
           const existingPageRange = searchParams.get('pageRange');
           const existingRecordType = searchParams.get('recordType');
           const existingOptions = searchParams.get('options');
-          
+
           if (existingContent) {
             setPollContent(decodeURIComponent(existingContent));
           }
-          
+
           if (existingPageRange) {
             setPageRange(existingPageRange);
           }
-          
+
           if (existingRecordType === 'overall') {
             setIsOverallEnabled(true);
           }
-          
+
           if (existingOptions) {
             try {
               const options = JSON.parse(decodeURIComponent(existingOptions));
@@ -75,18 +71,16 @@ const PollWrite = () => {
               console.error('투표 옵션 파싱 오류:', e);
             }
           }
-          
-          // 수정 모드에서도 전체 페이지 수는 필요하므로 책 정보 조회
+
           const response = await getBookPage(parseInt(roomId));
           if (response.isSuccess) {
             setTotalPages(response.data.totalBookPage);
           }
-          
+
           setIsLoading(false);
           return;
         }
-        
-        // 생성 모드: 책 페이지 정보 조회
+
         const response = await getBookPage(parseInt(roomId));
 
         if (response.isSuccess) {
@@ -139,7 +133,6 @@ const PollWrite = () => {
     initializeData();
   }, [roomId, isEditMode]);
 
-  // 총평 모드가 변경될 때 isOverviewPossible 체크
   useEffect(() => {
     if (isOverallEnabled && !isOverviewPossible) {
       setIsOverallEnabled(false);
@@ -162,7 +155,6 @@ const PollWrite = () => {
 
     try {
       if (isEditMode) {
-        // 수정 모드: 내용만 수정
         if (!voteId) {
           openSnackbar({
             message: '투표 정보를 찾을 수 없습니다.',
@@ -184,14 +176,13 @@ const PollWrite = () => {
 
         if (response.isSuccess) {
           console.log('투표 수정 성공:', response.data);
-          
+
           openSnackbar({
             message: '투표 수정을 완료했어요.',
             variant: 'top',
             onClose: () => {},
           });
 
-          // 성공 시 기록장으로 이동
           navigate(`/rooms/${roomId}/memory`, {
             replace: true,
           });
@@ -205,8 +196,6 @@ const PollWrite = () => {
           setIsSubmitting(false);
         }
       } else {
-        // 생성 모드: 기존 로직 유지
-        // 투표 옵션 필터링 (빈 옵션 제거)
         const validOptions = pollOptions.filter(option => option.trim() !== '');
 
         if (validOptions.length < 2) {
@@ -219,14 +208,11 @@ const PollWrite = () => {
           return;
         }
 
-        // 페이지 범위 결정
         let finalPage: number;
 
         if (isOverallEnabled) {
-          // 총평인 경우: 책의 마지막 페이지 또는 전체 페이지 수 사용
           finalPage = totalPages;
         } else {
-          // 일반 투표인 경우
           if (pageRange.trim() !== '') {
             finalPage = parseInt(pageRange.trim());
           } else {
@@ -234,7 +220,6 @@ const PollWrite = () => {
           }
         }
 
-        // 페이지 유효성 검사
         if (finalPage <= 0 || finalPage > totalPages) {
           openSnackbar({
             message: `유효하지 않은 페이지입니다. (1-${totalPages} 사이의 값을 입력해주세요)`,
@@ -245,43 +230,40 @@ const PollWrite = () => {
           return;
         }
 
-        // API 요청 데이터 생성
         const voteData: CreateVoteRequest = {
-        page: finalPage,
-        isOverview: isOverallEnabled,
-        content: pollContent.trim(),
-        voteItemList: validOptions.map(option => ({ itemName: option.trim() })),
-      };
+          page: finalPage,
+          isOverview: isOverallEnabled,
+          content: pollContent.trim(),
+          voteItemList: validOptions.map(option => ({ itemName: option.trim() })),
+        };
 
-      console.log('투표 생성 API 호출:', voteData);
-      console.log('roomId:', roomId);
+        console.log('투표 생성 API 호출:', voteData);
+        console.log('roomId:', roomId);
 
-      // API 호출
-      const response = await createVote(parseInt(roomId), voteData);
+        const response = await createVote(parseInt(roomId), voteData);
 
-      if (response.isSuccess) {
-        console.log('투표 생성 성공:', response.data);
+        if (response.isSuccess) {
+          console.log('투표 생성 성공:', response.data);
 
-        // 성공 시 기록장으로 이동
-        navigate(`/rooms/${roomId}/memory`, {
-          replace: true,
-        });
-      } else {
-        // API 에러 응답 처리
-        console.error('투표 생성 실패:', response.message);
-        openSnackbar({
-          message: response.message || '투표 생성에 실패했습니다.',
-          variant: 'top',
-          onClose: () => {},
-        });
-        setIsSubmitting(false);
-      }
+          navigate(`/rooms/${roomId}/memory`, {
+            replace: true,
+          });
+        } else {
+          console.error('투표 생성 실패:', response.message);
+          openSnackbar({
+            message: response.message || '투표 생성에 실패했습니다.',
+            variant: 'top',
+            onClose: () => {},
+          });
+          setIsSubmitting(false);
+        }
       }
     } catch (error) {
       console.error('투표 저장 실패:', error);
 
-      // 에러 타입에 따른 메시지 처리
-      let errorMessage = isEditMode ? '투표 수정 중 오류가 발생했습니다.' : '투표 저장 중 오류가 발생했습니다.';
+      let errorMessage = isEditMode
+        ? '투표 수정 중 오류가 발생했습니다.'
+        : '투표 저장 중 오류가 발생했습니다.';
 
       if (error && typeof error === 'object' && 'response' in error) {
         const axiosError = error as {
@@ -313,13 +295,12 @@ const PollWrite = () => {
     }
   };
 
-  // 로딩 중일 때 표시
   if (isLoading) {
     return (
       <>
         <TitleHeader
           leftIcon={<img src={leftArrow} alt="뒤로가기" />}
-          title={isEditMode ? "투표 수정" : "투표 작성"}
+          title={isEditMode ? '투표 수정' : '투표 작성'}
           onLeftClick={handleBackClick}
         />
         <Container>
@@ -343,7 +324,7 @@ const PollWrite = () => {
     <>
       <TitleHeader
         leftIcon={<img src={leftArrow} alt="뒤로가기" />}
-        title={isEditMode ? "투표 수정" : "투표 작성"}
+        title={isEditMode ? '투표 수정' : '투표 작성'}
         rightButton={<div className="complete">완료</div>}
         onLeftClick={handleBackClick}
         onRightClick={handleCompleteClick}
@@ -357,10 +338,10 @@ const PollWrite = () => {
           lastRecordedPage={lastRecordedPage}
           isOverallEnabled={isOverallEnabled}
           onOverallToggle={() => setIsOverallEnabled(prev => !prev)}
-          readingProgress={isOverviewPossible ? 80 : 70} // 총평 가능하면 80% 이상으로 표시
+          readingProgress={isOverviewPossible ? 80 : 70}
           isOverviewPossible={isOverviewPossible}
-          isDisabled={isEditMode} // 수정 모드일 때 비활성화
-          hideToggle={isEditMode} // 수정 모드일 때 총평 토글 숨김
+          isDisabled={isEditMode}
+          hideToggle={isEditMode}
         />
         <PollCreationSection
           content={pollContent}

--- a/src/pages/pollwrite/PollWrite.tsx
+++ b/src/pages/pollwrite/PollWrite.tsx
@@ -169,14 +169,9 @@ const PollWrite = () => {
           content: pollContent.trim(),
         };
 
-        console.log('투표 수정 API 호출:', updateData);
-        console.log('roomId:', roomId, 'voteId:', voteId);
-
         const response = await updateVote(parseInt(roomId), parseInt(voteId), updateData);
 
         if (response.isSuccess) {
-          console.log('투표 수정 성공:', response.data);
-
           openSnackbar({
             message: '투표 수정을 완료했어요.',
             variant: 'top',
@@ -237,14 +232,9 @@ const PollWrite = () => {
           voteItemList: validOptions.map(option => ({ itemName: option.trim() })),
         };
 
-        console.log('투표 생성 API 호출:', voteData);
-        console.log('roomId:', roomId);
-
         const response = await createVote(parseInt(roomId), voteData);
 
         if (response.isSuccess) {
-          console.log('투표 생성 성공:', response.data);
-
           navigate(`/rooms/${roomId}/memory`, {
             replace: true,
           });

--- a/src/pages/post/CreatePost.tsx
+++ b/src/pages/post/CreatePost.tsx
@@ -15,21 +15,16 @@ import { usePopupActions } from '@/hooks/usePopupActions';
 import type { CreateFeedBody } from '@/api/feeds/createFeed';
 import { ensureIsbn13 } from '@/utils/isbn';
 
-// 🔧 보조 유틸: 하이픈/공백 제거 + 대문자 X 유지
 const normalizeIsbn = (raw: string) => raw.replace(/[^0-9Xx]/g, '').toUpperCase();
 const isIsbn10 = (isbn: string) => /^[0-9]{9}[0-9X]$/.test(isbn);
 
-// ISBN 후보군 생성: 13자리(우선) → 원본정규화 → (가능하면) 10자리
 const makeIsbnCandidates = (raw: string) => {
   const candidates: string[] = [];
   const normalized = normalizeIsbn(raw);
-  const isbn13 = ensureIsbn13(raw); // 13으로 변환 성공 시
+  const isbn13 = ensureIsbn13(raw);
   if (isbn13) candidates.push(isbn13);
-  // 혹시 서버가 10자리로만 붙는 경우 대비(일부 API 환경에서 존재)
   if (isIsbn10(normalized)) candidates.push(normalized);
-  // 마지막으로 raw 정규화 값(13도 10도 아니면 그래도 시도)
   if (!candidates.includes(normalized)) candidates.push(normalized);
-  // 중복 제거
   return Array.from(new Set(candidates));
 };
 
@@ -45,7 +40,6 @@ const CreatePost = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // 핀 데이터가 있는지 확인
   const pinData = location.state?.pinData;
 
   function convertBookInfoToBook(bookInfo: Book): Book | null {
@@ -58,23 +52,23 @@ const CreatePost = () => {
     };
   }
 
-  // 핀 데이터가 있으면 초기값으로 설정
   const [selectedBook, setSelectedBook] = useState<Book | null>(
-    pinData ? {
-      title: pinData.bookTitle,
-      author: pinData.authorName,
-      cover: pinData.bookImageUrl,
-      isbn: pinData.isbn,
-    } : convertBookInfoToBook(location.state?.selectedBook),
+    pinData
+      ? {
+          title: pinData.bookTitle,
+          author: pinData.authorName,
+          cover: pinData.bookImageUrl,
+          isbn: pinData.isbn,
+        }
+      : convertBookInfoToBook(location.state?.selectedBook),
   );
-  
+
   const [postContent, setPostContent] = useState(pinData?.recordContent || '');
   const [selectedPhotos, setSelectedPhotos] = useState<File[]>([]);
   const [isPrivate, setIsPrivate] = useState(false);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [isBookSearchOpen, setIsBookSearchOpen] = useState(false);
 
-  // 핀 데이터가 있는 경우 책 선택 및 내용 입력 비활성화
   const isFromPin = !!pinData;
 
   const { openSnackbar, closePopup } = usePopupActions();
@@ -101,10 +95,8 @@ const CreatePost = () => {
 
     const candidates = makeIsbnCandidates(selectedBook!.isbn);
 
-    // images: 선택값 (없으면 undefined 전달)
     const filesOrUndefined = selectedPhotos.length ? selectedPhotos : undefined;
 
-    // 최대 2회까지(총 3회) 재시도: 13 → (10) → (정규화원본)
     for (let i = 0; i < Math.min(candidates.length, 3); i++) {
       const isbnToSend = candidates[i];
       const body: CreateFeedBody = {
@@ -117,22 +109,14 @@ const CreatePost = () => {
       try {
         const result = await createNewFeed(body, filesOrUndefined);
         if (result?.success) {
-          // onSuccess에서 이동 처리됨
           return;
-        } else {
-          // useCreateFeed에서 서버 메시지를 스낵바로 띄움
-          // 80009면 다음 후보로 자동 재시도, 그 외면 바로 중단
-          // (result.errorCode를 반환하도록 훅을 확장했다면 여기서 체크)
-          // 현재 훅은 errorCode를 안 주니, 다음 후보가 있으면 조용히 다음 루프 진행
         }
       } catch (error) {
         console.error(`[CreatePost] Try #${i + 1} failed:`, error);
-        // 네트워크/타임아웃 등은 바로 중단
         break;
       }
     }
 
-    // 여기까지 왔다면 모든 시도가 실패
     openSnackbar({
       message:
         'ISBN으로 책이 조회되지 않아요. ISBN-13(하이픈 없이)으로 다시 선택하시거나 다른 책으로 시도해 주세요.',
@@ -186,8 +170,8 @@ const CreatePost = () => {
 
         <Section showDivider />
 
-        <PostContentSection 
-          content={postContent} 
+        <PostContentSection
+          content={postContent}
           onContentChange={setPostContent}
           readOnly={false}
         />

--- a/src/pages/post/CreatePost.tsx
+++ b/src/pages/post/CreatePost.tsx
@@ -73,8 +73,7 @@ const CreatePost = () => {
 
   const { openSnackbar, closePopup } = usePopupActions();
   const { createNewFeed, loading } = useCreateFeed({
-    onSuccess: feedId => {
-      console.log('피드 작성 성공! 피드 ID:', feedId);
+    onSuccess: () => {
       navigate('/feed');
     },
   });

--- a/src/pages/post/UpdatePost.tsx
+++ b/src/pages/post/UpdatePost.tsx
@@ -36,7 +36,6 @@ const UpdatePost = () => {
   const { openSnackbar, closePopup } = usePopupActions();
   const { updateExistingFeed, loading: updateLoading } = useUpdateFeed({
     onSuccess: feedId => {
-      console.log('피드 수정 성공! 피드 ID:', feedId);
       navigate(`/feed/${feedId}`);
     },
   });

--- a/src/pages/post/UpdatePost.tsx
+++ b/src/pages/post/UpdatePost.tsx
@@ -41,7 +41,6 @@ const UpdatePost = () => {
     },
   });
 
-  // 피드 상세 정보 로드
   useEffect(() => {
     const loadFeedDetail = async () => {
       if (!feedId) {
@@ -59,7 +58,6 @@ const UpdatePost = () => {
         const response = await getFeedDetail(Number(feedId));
         const data = response.data;
 
-        // 기존 데이터로 폼 초기화
         setSelectedBook({
           id: 0,
           title: data.bookTitle,
@@ -108,7 +106,7 @@ const UpdatePost = () => {
       contentBody: postContent.trim(),
       isPublic: !isPrivate,
       ...(selectedTags.length ? { tagList: selectedTags } : {}),
-      remainImageUrls, // 이미지가 없어도 빈 배열로 전송하여 삭제 처리
+      remainImageUrls,
     };
 
     const result = await updateExistingFeed(Number(feedId), body);
@@ -138,7 +136,6 @@ const UpdatePost = () => {
 
   const isFormValid = postContent.trim() !== '';
 
-  // 로딩 중
   if (loading) {
     return (
       <div style={{ padding: '56px 0', textAlign: 'center', color: 'white' }}>

--- a/src/pages/recordwrite/RecordWrite.tsx
+++ b/src/pages/recordwrite/RecordWrite.tsx
@@ -16,7 +16,6 @@ const RecordWrite = () => {
   const { roomId, recordId } = useParams<{ roomId: string; recordId: string }>();
   const [searchParams] = useSearchParams();
 
-  // 수정 모드인지 판단
   const isEditMode = Boolean(recordId);
   const { openSnackbar } = usePopupActions();
 
@@ -25,13 +24,11 @@ const RecordWrite = () => {
   const [isOverallEnabled, setIsOverallEnabled] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // API에서 받아올 데이터
   const [totalPages, setTotalPages] = useState(0);
   const [lastRecordedPage, setLastRecordedPage] = useState(0);
   const [isOverviewPossible, setIsOverviewPossible] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  // 컴포넌트 마운트 시 책 페이지 정보 조회 (생성 모드) 또는 기록 내용 로드 (수정 모드)
   useEffect(() => {
     const initializeData = async () => {
       if (!roomId) {
@@ -48,7 +45,6 @@ const RecordWrite = () => {
         setIsLoading(true);
 
         if (isEditMode) {
-          // 수정 모드: 쿼리 파라미터에서 기존 내용과 페이지 정보 로드
           const existingContent = searchParams.get('content');
           const existingPageRange = searchParams.get('pageRange');
           const existingRecordType = searchParams.get('recordType');
@@ -65,7 +61,6 @@ const RecordWrite = () => {
             setIsOverallEnabled(true);
           }
 
-          // 수정 모드에서도 전체 페이지 수는 필요하므로 책 정보 조회
           const response = await getBookPage(parseInt(roomId));
           if (response.isSuccess) {
             setTotalPages(response.data.totalBookPage);
@@ -75,7 +70,6 @@ const RecordWrite = () => {
           return;
         }
 
-        // 생성 모드: 책 페이지 정보 조회
         const response = await getBookPage(parseInt(roomId));
 
         if (response.isSuccess) {
@@ -126,7 +120,6 @@ const RecordWrite = () => {
     initializeData();
   }, [roomId, isEditMode]);
 
-  // 총평 모드가 변경될 때 isOverviewPossible 체크
   useEffect(() => {
     if (isOverallEnabled && !isOverviewPossible) {
       setIsOverallEnabled(false);
@@ -149,7 +142,6 @@ const RecordWrite = () => {
 
     try {
       if (isEditMode) {
-        // 수정 모드: 내용만 수정
         if (!recordId) {
           openSnackbar({
             message: '기록 정보를 찾을 수 없습니다.',
@@ -173,7 +165,6 @@ const RecordWrite = () => {
             onClose: () => {},
           });
 
-          // 성공 시 기록장으로 이동
           navigate(`/rooms/${roomId}/memory`, {
             replace: true,
           });
@@ -186,15 +177,11 @@ const RecordWrite = () => {
           setIsSubmitting(false);
         }
       } else {
-        // 생성 모드: 기존 로직 유지
-        // 페이지 범위 결정
         let finalPage: number;
 
         if (isOverallEnabled) {
-          // 총평인 경우: 책의 마지막 페이지 또는 전체 페이지 수 사용
           finalPage = totalPages;
         } else {
-          // 일반 기록인 경우
           if (pageRange.trim() !== '') {
             finalPage = parseInt(pageRange.trim());
           } else {
@@ -202,7 +189,6 @@ const RecordWrite = () => {
           }
         }
 
-        // 페이지 유효성 검사
         if (finalPage <= 0 || finalPage > totalPages) {
           openSnackbar({
             message: `유효하지 않은 페이지입니다. (1-${totalPages} 사이의 값을 입력해주세요)`,
@@ -213,18 +199,15 @@ const RecordWrite = () => {
           return;
         }
 
-        // API 요청 데이터 생성
         const recordData: CreateRecordRequest = {
           page: finalPage,
           isOverview: isOverallEnabled,
           content: content.trim(),
         };
 
-        // API 호출
         const response = await createRecord(parseInt(roomId), recordData);
 
         if (response.isSuccess) {
-          // 성공 시 기록장으로 이동
           navigate(`/rooms/${roomId}/memory`, {
             replace: true,
           });
@@ -238,7 +221,6 @@ const RecordWrite = () => {
         }
       }
     } catch (error) {
-      // 에러 타입에 따른 메시지 처리
       let errorMessage = isEditMode
         ? '기록 수정 중 오류가 발생했습니다.'
         : '기록 저장 중 오류가 발생했습니다.';
@@ -273,7 +255,6 @@ const RecordWrite = () => {
     }
   };
 
-  // 로딩 중일 때 표시
   if (isLoading) {
     return (
       <>
@@ -317,10 +298,10 @@ const RecordWrite = () => {
           lastRecordedPage={lastRecordedPage}
           isOverallEnabled={isOverallEnabled}
           onOverallToggle={() => setIsOverallEnabled(prev => !prev)}
-          readingProgress={isOverviewPossible ? 80 : 70} // 총평 가능하면 80% 이상으로 표시
+          readingProgress={isOverviewPossible ? 80 : 70}
           isOverviewPossible={isOverviewPossible}
-          isDisabled={isEditMode} // 수정 모드일 때 비활성화
-          hideToggle={isEditMode} // 수정 모드일 때 총평 토글 숨김
+          isDisabled={isEditMode}
+          hideToggle={isEditMode}
         />
         <RecordContentSection
           content={content}

--- a/src/pages/today-words/TodayWords.tsx
+++ b/src/pages/today-words/TodayWords.tsx
@@ -30,49 +30,41 @@ const TodayWords = () => {
   const [roomCompleted, setRoomCompleted] = useState(false);
   const { openSnackbar } = usePopupActions();
 
-  // 하루 5개 제한 관련
   const DAILY_LIMIT = 5;
-  
-  // 오늘 날짜를 여러 포맷으로 생성하는 함수
+
   const getTodayDateStrings = useCallback(() => {
     const today = new Date();
     const year = today.getFullYear();
     const month = String(today.getMonth() + 1).padStart(2, '0');
     const day = String(today.getDate()).padStart(2, '0');
-    
+
     return [
-      `${year}.${month}.${day}`,        // 2024.01.15
-      `${year}년 ${month}월 ${day}일`,   // 2024년 01월 15일
-      `${year}-${month}-${day}`,        // 2024-01-15
-      `${month}/${day}/${year}`,        // 01/15/2024
+      `${year}.${month}.${day}`,
+      `${year}년 ${month}월 ${day}일`,
+      `${year}-${month}-${day}`,
+      `${month}/${day}/${year}`,
     ];
   }, []);
 
-  // 오늘 작성한 내 메시지 개수 계산
   const getTodayMyMessageCount = useCallback(() => {
     const todayFormats = getTodayDateStrings();
-    
+
     return messages.filter(message => {
       if (!message.isWriter) return false;
-      
-      // 여러 날짜 포맷과 비교
+
       return todayFormats.includes(message.timestamp);
     }).length;
   }, [messages, getTodayDateStrings]);
 
   const todayMyMessageCount = getTodayMyMessageCount();
 
-
   const handleBackClick = () => {
     navigate(-1);
   };
 
-  // API 데이터를 Message 타입으로 변환하는 함수
   const convertToMessage = (item: TodayCommentItem): Message => {
-    // 서버에서 받아오는 postDate를 그대로 사용 (이미 날짜 기반으로 계산된 값)
     const timeAgo = item.postDate || '방금 전';
-    
-    // createdAt은 현재 시간으로 설정 (정확한 시간이 필요하다면 다른 API 필드 사용)
+
     const createdAt = new Date();
 
     return {
@@ -87,91 +79,90 @@ const TodayWords = () => {
     };
   };
 
-  // 오늘의 한마디 목록 조회
-  const loadMessages = useCallback(async (cursor?: string, isRefresh = false) => {
-    if (!roomId) return;
+  const loadMessages = useCallback(
+    async (cursor?: string, isRefresh = false) => {
+      if (!roomId) return;
 
-    try {
-      if (isRefresh) {
-        setIsLoading(true);
-      } else {
-        setIsLoadingMore(true);
-      }
-
-      const response = await getDailyGreeting({
-        roomId: parseInt(roomId),
-        cursor: cursor || undefined,
-      });
-
-      if (response.isSuccess) {
-        const newMessages = response.data.todayCommentList.map(convertToMessage);
-        
+      try {
         if (isRefresh) {
-          setMessages(newMessages);
+          setIsLoading(true);
         } else {
-          setMessages(prev => [...prev, ...newMessages]);
+          setIsLoadingMore(true);
         }
-        
-        setNextCursor(response.data.nextCursor);
-        setIsLast(response.data.isLast);
-        setHasInitiallyLoaded(true);
-        
-        // 초기 로딩 시 스크롤을 맨 아래로 이동
-        if (isRefresh) {
-          setTimeout(() => {
-            window.scrollTo({ top: document.body.scrollHeight, behavior: 'auto' });
-          }, 100);
+
+        const response = await getDailyGreeting({
+          roomId: parseInt(roomId),
+          cursor: cursor || undefined,
+        });
+
+        if (response.isSuccess) {
+          const newMessages = response.data.todayCommentList.map(convertToMessage);
+
+          if (isRefresh) {
+            setMessages(newMessages);
+          } else {
+            setMessages(prev => [...prev, ...newMessages]);
+          }
+
+          setNextCursor(response.data.nextCursor);
+          setIsLast(response.data.isLast);
+          setHasInitiallyLoaded(true);
+
+          if (isRefresh) {
+            setTimeout(() => {
+              window.scrollTo({ top: document.body.scrollHeight, behavior: 'auto' });
+            }, 100);
+          }
+        } else {
+          openSnackbar({
+            message: response.message || '오늘의 한마디 목록을 불러오는데 실패했습니다.',
+            variant: 'top',
+            onClose: () => {},
+          });
         }
-      } else {
+      } catch (error) {
+        console.error('오늘의 한마디 목록 조회 오류:', error);
+
+        let errorMessage = '오늘의 한마디 목록을 불러오는 중 오류가 발생했습니다.';
+
+        if (error && typeof error === 'object' && 'response' in error) {
+          const axiosError = error as {
+            response?: {
+              data?: {
+                message?: string;
+                code?: number;
+              };
+            };
+          };
+
+          if (axiosError.response?.data?.message) {
+            errorMessage = axiosError.response.data.message;
+          } else if (axiosError.response?.data?.code === 403) {
+            errorMessage = '방 접근 권한이 없습니다.';
+          } else if (axiosError.response?.data?.code === 404) {
+            errorMessage = '존재하지 않는 방입니다.';
+          }
+        }
+
         openSnackbar({
-          message: response.message || '오늘의 한마디 목록을 불러오는데 실패했습니다.',
+          message: errorMessage,
           variant: 'top',
           onClose: () => {},
         });
+      } finally {
+        setIsLoading(false);
+        setIsLoadingMore(false);
       }
-    } catch (error) {
-      console.error('오늘의 한마디 목록 조회 오류:', error);
-      
-      let errorMessage = '오늘의 한마디 목록을 불러오는 중 오류가 발생했습니다.';
-      
-      if (error && typeof error === 'object' && 'response' in error) {
-        const axiosError = error as {
-          response?: {
-            data?: {
-              message?: string;
-              code?: number;
-            };
-          };
-        };
+    },
+    [roomId, convertToMessage, openSnackbar],
+  );
 
-        if (axiosError.response?.data?.message) {
-          errorMessage = axiosError.response.data.message;
-        } else if (axiosError.response?.data?.code === 403) {
-          errorMessage = '방 접근 권한이 없습니다.';
-        } else if (axiosError.response?.data?.code === 404) {
-          errorMessage = '존재하지 않는 방입니다.';
-        }
-      }
-
-      openSnackbar({
-        message: errorMessage,
-        variant: 'top',
-        onClose: () => {},
-      });
-    } finally {
-      setIsLoading(false);
-      setIsLoadingMore(false);
-    }
-  }, [roomId, convertToMessage, openSnackbar]);
-
-  // 더 많은 메시지 로드
   const loadMoreMessages = useCallback(() => {
     if (!isLoadingMore && !isLast && nextCursor && roomId) {
       loadMessages(nextCursor);
     }
   }, [isLoadingMore, isLast, nextCursor, roomId, loadMessages]);
 
-  // 모임방 상태 확인
   useEffect(() => {
     const checkRoomStatus = async () => {
       if (!roomId) return;
@@ -190,20 +181,22 @@ const TodayWords = () => {
     checkRoomStatus();
   }, [roomId]);
 
-  // 컴포넌트 마운트 시 초기 데이터 로드
   useEffect(() => {
     if (roomId && !hasInitiallyLoaded) {
       loadMessages(undefined, true);
     }
   }, [roomId, hasInitiallyLoaded, loadMessages]);
 
-  // 무한 스크롤 처리
   useEffect(() => {
     const handleScroll = () => {
       const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
-      
-      // 스크롤이 하단 근처에 도달했을 때 더 많은 데이터 로드
-      if (scrollTop + clientHeight >= scrollHeight - 100 && !isLoadingMore && !isLast && hasInitiallyLoaded) {
+
+      if (
+        scrollTop + clientHeight >= scrollHeight - 100 &&
+        !isLoadingMore &&
+        !isLast &&
+        hasInitiallyLoaded
+      ) {
         loadMoreMessages();
       }
     };
@@ -215,7 +208,6 @@ const TodayWords = () => {
   const handleSendMessage = useCallback(async () => {
     if (inputValue.trim() === '' || isSubmitting) return;
 
-    // roomId가 없으면 에러 처리
     if (!roomId) {
       openSnackbar({
         message: '방 정보를 찾을 수 없습니다.',
@@ -225,7 +217,6 @@ const TodayWords = () => {
       return;
     }
 
-    // 6개 작성 시도 시 토스트로 차단
     if (todayMyMessageCount >= DAILY_LIMIT) {
       openSnackbar({
         message: '오늘의 한마디는 하루에 다섯번까지 작성할 수 있어요',
@@ -239,20 +230,16 @@ const TodayWords = () => {
     setIsSubmitting(true);
 
     try {
-      // API 호출 - 오늘의 한마디 작성
       const response = await createDailyGreeting(parseInt(roomId), inputValue.trim());
 
       if (response.isSuccess) {
-        // 입력 필드 초기화
         setInputValue('');
 
-        // 최신 목록 다시 불러오기 위해 상태 초기화
         setMessages([]);
         setNextCursor(null);
         setIsLast(false);
         setHasInitiallyLoaded(false);
 
-        // 첫 번째 한마디 작성 시만 성공 메시지, 5개 도달 시 제한 메시지
         if (todayMyMessageCount + 1 >= DAILY_LIMIT) {
           openSnackbar({
             message: '오늘의 한마디는 하루에 다섯번까지 작성할 수 있어요',
@@ -261,7 +248,6 @@ const TodayWords = () => {
             onClose: () => {},
           });
         } else if (todayMyMessageCount === 0) {
-          // 첫 번째 한마디 작성 시만 토스트 메시지 표시
           openSnackbar({
             message: '오늘의 한마디가 작성되었습니다.',
             variant: 'top',
@@ -269,12 +255,10 @@ const TodayWords = () => {
           });
         }
 
-        // 자동으로 스크롤을 아래로 이동
         setTimeout(() => {
           window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
         }, 100);
       } else {
-        // API 에러 응답 처리
         openSnackbar({
           message: response.message || '오늘의 한마디 작성에 실패했습니다.',
           variant: 'top',
@@ -284,7 +268,6 @@ const TodayWords = () => {
     } catch (error) {
       console.error('오늘의 한마디 작성 오류:', error);
 
-      // 에러 타입에 따른 메시지 처리
       let errorMessage = '오늘의 한마디 작성 중 오류가 발생했습니다.';
 
       if (error && typeof error === 'object' && 'response' in error) {
@@ -318,9 +301,7 @@ const TodayWords = () => {
     }
   }, [inputValue, roomId, isSubmitting, openSnackbar, todayMyMessageCount, DAILY_LIMIT]);
 
-  // 메시지 삭제 핸들러
   const handleMessageDelete = useCallback((messageId: string) => {
-    // 삭제된 메시지를 로컬 상태에서 제거 (MessageList 컴포넌트에서 이미 처리하지만 동기화를 위해)
     setMessages(prev => prev.filter(msg => msg.id !== messageId));
   }, []);
 
@@ -334,7 +315,14 @@ const TodayWords = () => {
       <Container>
         <ContentArea>
           {isLoading && !hasInitiallyLoaded ? (
-            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: '200px',
+              }}
+            >
               <LoadingSpinner />
             </div>
           ) : messages.length === 0 ? (

--- a/src/stores/useCommentBottomSheetStore.ts
+++ b/src/stores/useCommentBottomSheetStore.ts
@@ -11,16 +11,15 @@ interface CommentBottomSheetActions {
   closeCommentBottomSheet: () => void;
 }
 
-export const useCommentBottomSheetStore = create<CommentBottomSheetState & CommentBottomSheetActions>((set) => ({
-  // 상태
+export const useCommentBottomSheetStore = create<
+  CommentBottomSheetState & CommentBottomSheetActions
+>(set => ({
   isOpen: false,
   postId: null,
   postType: null,
 
-  // 액션
   openCommentBottomSheet: (postId: number, postType: 'RECORD' | 'VOTE') =>
     set({ isOpen: true, postId, postType }),
-  
-  closeCommentBottomSheet: () =>
-    set({ isOpen: false, postId: null, postType: null }),
+
+  closeCommentBottomSheet: () => set({ isOpen: false, postId: null, postType: null }),
 }));

--- a/src/stores/usePopupStore.ts
+++ b/src/stores/usePopupStore.ts
@@ -1,4 +1,3 @@
-// usePopupStore.ts
 import { create } from 'zustand';
 
 export type PopupType =
@@ -45,7 +44,6 @@ export interface ReplyModalProps {
   onClose: () => void;
 }
 
-/* 추가 */
 export interface CountingBarProps {
   message: string;
   duration?: number;

--- a/src/styles/global/global.ts
+++ b/src/styles/global/global.ts
@@ -216,31 +216,3 @@ export const globalStyles = css`
 
   ${coreDesignTokens}
 `;
-
-// Usage example:
-/*
-// In your components, use like this:
-
-const StyledButton = styled.button`
-  // Use core colors from the system
-  background-color: ${semanticColors.button.fill.primary};
-  color: ${semanticColors.text.primary};
-  
-  // Use core typography
-  font-size: ${typography.fontSize.base};
-  font-weight: ${typography.fontWeight.medium};
-  
-  // Use custom spacing and other properties
-  padding: 12px 24px;
-  margin: 8px 0;
-  border-radius: 8px;
-  border: none;
-`;
-
-const StyledHeading = styled.h1`
-  color: ${semanticColors.text.primary};
-  font-size: ${typography.fontSize['2xl']};
-  font-weight: ${typography.fontWeight.bold};
-  margin-bottom: 16px; // Custom spacing
-`;
-*/

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -1,4 +1,3 @@
-// 투표 아이템 타입
 export interface VoteItem {
   voteItemId: number;
   itemName: string;
@@ -7,7 +6,6 @@ export interface VoteItem {
   isVoted: boolean;
 }
 
-// 기록/투표 포스트 타입
 export interface Post {
   postId: number;
   postDate: string;
@@ -22,23 +20,21 @@ export interface Post {
   isOverview: boolean;
   isLiked: boolean;
   isWriter: boolean;
-  isLocked: boolean; // 블러 처리 여부
+  isLocked: boolean;
   voteItems: VoteItem[];
 }
 
-// 기록장 조회 요청 파라미터 타입
 export interface GetMemoryPostsParams {
   roomId: number;
-  type?: 'group' | 'mine'; // default: group
-  sort?: 'latest' | 'like' | 'comment'; // default: latest (type이 group인 경우만)
-  pageStart?: number | null; // 페이지 필터 시작 (default: null)
-  pageEnd?: number | null; // 페이지 필터 끝 (default: null)
-  isOverview?: boolean; // 총평 보기 필터 (default: false)
-  isPageFilter?: boolean; // 페이지 보기 필터 (default: false)
-  cursor?: string | null; // 페이지네이션 커서
+  type?: 'group' | 'mine';
+  sort?: 'latest' | 'like' | 'comment';
+  pageStart?: number | null;
+  pageEnd?: number | null;
+  isOverview?: boolean;
+  isPageFilter?: boolean;
+  cursor?: string | null;
 }
 
-// 기록장 조회 응답 데이터 타입
 export interface MemoryPostsData {
   postList: Post[];
   roomId: number;
@@ -46,11 +42,10 @@ export interface MemoryPostsData {
   isbn: string;
   nextCursor: string | null;
   isLast: boolean;
-  totalPages?: number; // 전체 페이지 수
-  currentUserPage?: number; // 현재 사용자가 읽은 페이지
+  totalPages?: number;
+  currentUserPage?: number;
 }
 
-// API 응답 타입
 export interface GetMemoryPostsResponse {
   isSuccess: boolean;
   code: number;
@@ -58,12 +53,11 @@ export interface GetMemoryPostsResponse {
   data: MemoryPostsData;
 }
 
-// Memory 페이지에서 사용하는 Record 타입 (좋아요 상태 포함)
 export interface Record {
   id: string;
   user: string;
   userPoints: number;
-  profileImageUrl: string; // 프로필 이미지 URL 추가
+  profileImageUrl: string;
   content: string;
   likeCount: number;
   commentCount: number;
@@ -73,18 +67,17 @@ export interface Record {
   recordType: 'page' | 'overall';
   pageRange?: string;
   isWriter: boolean;
-  isLiked: boolean; // 좋아요 상태 추가
-  isLocked: boolean; // 블러 처리 여부 추가
+  isLiked: boolean;
+  isLocked: boolean;
   pollOptions?: PollOption[];
 }
 
-// 투표 옵션 타입
 export interface PollOption {
   id: string;
   text: string;
   percentage: number;
   count: number;
   isHighest: boolean;
-  voteItemId: number; // 투표 API에 필요한 ID
-  isVoted: boolean; // 현재 사용자가 투표했는지 여부
+  voteItemId: number;
+  isVoted: boolean;
 }

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -1,90 +1,73 @@
-// 기록 생성 요청 데이터 타입
 export interface CreateRecordRequest {
-  page: number; // 페이지 번호
-  isOverview: boolean; // 총평 여부
-  content: string; // 기록 내용
+  page: number;
+  isOverview: boolean;
+  content: string;
 }
-
-// 기록 생성 응답 데이터 타입
 export interface CreateRecordData {
-  recordId: number; // 생성된 기록 ID
-  roomId: number; // 방 ID
+  recordId: number;
+  roomId: number;
 }
 
-// 투표 아이템 타입
 export interface VoteItem {
-  itemName: string; // 투표 옵션 이름
+  itemName: string;
 }
 
-// 투표 생성 요청 데이터 타입
 export interface CreateVoteRequest {
-  page: number; // 페이지 번호
-  isOverview: boolean; // 총평 여부
-  content: string; // 투표 내용
-  voteItemList: VoteItem[]; // 투표 옵션 리스트
+  page: number;
+  isOverview: boolean;
+  content: string;
+  voteItemList: VoteItem[];
 }
 
-// 투표 생성 응답 데이터 타입
 export interface CreateVoteData {
-  voteId: number; // 생성된 투표 ID
-  roomId: number; // 방 ID
+  voteId: number;
+  roomId: number;
 }
 
-// 투표 아이템 응답 타입 (투표 결과 포함)
 export interface VoteItemResult {
-  voteItemId: number; // 투표 아이템 ID
-  itemName: string; // 투표 옵션 이름
-  percentage: number; // 득표율
-  count: number; // 득표수
-  isVoted: boolean; // 현재 사용자가 투표했는지 여부
+  voteItemId: number;
+  itemName: string;
+  percentage: number;
+  count: number;
+  isVoted: boolean;
 }
 
-// 투표하기 요청 데이터 타입
 export interface VoteRequest {
-  voteItemId: number; // 투표할 아이템 ID
-  type: boolean; // true: 투표하기, false: 투표취소
+  voteItemId: number;
+  type: boolean;
 }
 
-// 투표하기 응답 데이터 타입
 export interface VoteData {
-  postId: number; // 포스트 ID
-  roomId: number; // 방 ID
-  voteItems: VoteItemResult[]; // 투표 결과 리스트
+  postId: number;
+  roomId: number;
+  voteItems: VoteItemResult[];
 }
 
-// 기록 수정 요청 데이터 타입
 export interface UpdateRecordRequest {
-  content: string; // 수정할 기록 내용
+  content: string;
 }
 
-// 기록 수정 응답 데이터 타입
 export interface UpdateRecordData {
-  roomId: number; // 방 ID
+  roomId: number;
 }
 
-// 투표 수정 요청 데이터 타입
 export interface UpdateVoteRequest {
-  content: string; // 수정할 투표 내용
+  content: string;
 }
 
-// 투표 수정 응답 데이터 타입
 export interface UpdateVoteData {
-  roomId: number; // 방 ID
+  roomId: number;
 }
 
-// AI 독서감상문 생성 응답 데이터 타입
 export interface CreateAiReviewData {
-  content: string; // 생성된 독서감상문 내용
-  count: number; // 잔여 이용 횟수
+  content: string;
+  count: number;
 }
 
-// AI 이용 횟수 조회 응답 데이터 타입
 export interface AiUsageData {
-  recordReviewCount: number; // AI 독서감상문 작성 가능 횟수
-  recordCount: number; // 기록 작성 횟수
+  recordReviewCount: number;
+  recordCount: number;
 }
-
-// 공통 API 응답 타입
 export interface ApiResponse<T> {
   isSuccess: boolean;
   code: number;

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -1,4 +1,3 @@
-// Room 관련 공통 타입 정의
 export interface Room {
   roomId: number;
   roomName: string;
@@ -18,25 +17,22 @@ export interface Room {
   updatedAt: string;
 }
 
-// 방 생성 요청 데이터 타입
 export interface CreateRoomRequest {
   isbn: string;
   category: string;
   roomName: string;
   description: string;
-  progressStartDate: string; // YYYY.MM.DD 형식
-  progressEndDate: string; // YYYY.MM.DD 형식
+  progressStartDate: string;
+  progressEndDate: string;
   recruitCount: number;
-  password: string | null; // 비공개방: 4자리 숫자, 공개방: null
+  password: string | null;
   isPublic: boolean;
 }
 
-// 방 생성 응답 데이터 타입
 export interface CreateRoomData {
   roomId: number;
 }
 
-// 방 목록 조회 응답 타입
 export interface RoomListData {
   rooms: Room[];
   totalCount: number;
@@ -44,14 +40,12 @@ export interface RoomListData {
   totalPages: number;
 }
 
-// 방 상세 조회 응답 타입
 export interface RoomDetailData extends Room {
   members: RoomMember[];
   isOwner: boolean;
   isMember: boolean;
 }
 
-// 방 멤버 타입
 export interface RoomMember {
   userId: number;
   nickname: string;
@@ -60,7 +54,6 @@ export interface RoomMember {
   isOwner: boolean;
 }
 
-// 공통 API 응답 타입
 export interface ApiResponse<T> {
   isSuccess: boolean;
   code: number;

--- a/src/types/roomPostLike.ts
+++ b/src/types/roomPostLike.ts
@@ -1,16 +1,13 @@
-// 방 게시물 좋아요 요청 데이터 타입
 export interface RoomPostLikeRequest {
-  type: boolean; // true: 좋아요, false: 좋아요 취소
-  roomPostType: 'RECORD' | 'VOTE'; // 방 게시물 타입
+  type: boolean;
+  roomPostType: 'RECORD' | 'VOTE';
 }
 
-// 방 게시물 좋아요 응답 데이터 타입
 export interface RoomPostLikeData {
-  postId: number; // 게시물 ID
-  isLiked: boolean; // 좋아요 상태
+  postId: number;
+  isLiked: boolean;
 }
 
-// API 응답 타입
 export interface RoomPostLikeResponse {
   isSuccess: boolean;
   code: number;

--- a/src/types/today.ts
+++ b/src/types/today.ts
@@ -9,7 +9,6 @@ export interface Message {
   isWriter?: boolean;
 }
 
-// 오늘의 한마디 관련 타입들
 export interface TodayCommentItem {
   attendanceCheckId: number;
   creatorId: number;

--- a/src/utils/isbn.ts
+++ b/src/utils/isbn.ts
@@ -3,9 +3,8 @@ export const normalizeIsbn = (raw: string) => raw.replace(/[^0-9Xx]/g, '').toUpp
 export const isIsbn10 = (isbn: string) => /^[0-9]{9}[0-9X]$/.test(isbn);
 export const isIsbn13 = (isbn: string) => /^[0-9]{13}$/.test(isbn);
 
-/** ISBN-10 → ISBN-13 변환 (prefix 978 + 체크디지트 재계산) */
 export const isbn10to13 = (isbn10: string) => {
-  const core = '978' + isbn10.slice(0, 9); // 기존 체크디지트 제외
+  const core = '978' + isbn10.slice(0, 9);
   const sum = core
     .split('')
     .map(Number)
@@ -14,7 +13,6 @@ export const isbn10to13 = (isbn10: string) => {
   return core + String(check);
 };
 
-/** 하이픈/공백 제거 → 10이면 13으로 변환 → 최종 13자리 숫자 반환 */
 export const ensureIsbn13 = (raw: string): string | null => {
   const n = normalizeIsbn(raw);
   if (isIsbn13(n)) return n;

--- a/src/utils/roomStatus.ts
+++ b/src/utils/roomStatus.ts
@@ -1,22 +1,11 @@
-/**
- * 모임방 상태 관련 유틸리티 함수들
- */
-
-/**
- * 모임방이 완료되었는지 확인하는 함수
- * @param progressEndDate 활동 종료 날짜 (YYYY-MM-DD 또는 YYYY.MM.DD 형식)
- * @returns 활동 기간이 종료되었으면 true, 아니면 false
- */
 export const isRoomCompleted = (progressEndDate: string): boolean => {
   if (!progressEndDate) return false;
 
-  // 날짜 형식 정규화 (YYYY.MM.DD -> YYYY-MM-DD)
   const normalizedDate = progressEndDate.replace(/\./g, '-');
 
   const endDate = new Date(normalizedDate);
   const today = new Date();
 
-  // 시간 부분을 제거하고 날짜만 비교
   today.setHours(0, 0, 0, 0);
   endDate.setHours(23, 59, 59, 999);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[THIP-389](https://thip2025.atlassian.net/browse/THIP2025-389?atlOrigin=eyJpIjoiNWVhNDQxODA5ZmFkNDIzYzlkOWY1YjM2MjVkN2ZjNzgiLCJwIjoiaiJ9)

## 📝 작업 내용

### 작업 목적
코드베이스 전반에 걸쳐 불필요한 주석을 제거하여 코드 가독성과 유지보수성을 개선했습니다.

### 작업 배경
- TypeScript 타입 시스템이 충분한 문서화 역할을 수행하고 있음에도 불구하고, 중복되는 주석이 산재해 있었습니다.
- 사용 예시 코드 블록이 실제 코드와 동기화되지 않아 오히려 혼란을 야기할 가능성이 있었습니다.
- "타입이 곧 문서"라는 TypeScript의 철학에 맞게 코드를 간결하게 정리할 필요가 있었습니다.

### 작업 내용
**1️⃣ API 함수 주석 제거** (a26327e)
- API 파일에서 JSDoc 주석 제거
- 인터페이스/타입 설명 주석 제거
- 사용 예시 코드 블록 제거
- 영향 파일: `src/api/` 하위 feeds, record, rooms, images 등

**2️⃣ Components 주석 제거** (0be3cb7)
- React 컴포넌트의 props, 함수 설명 주석 제거
- 컴포넌트 동작 설명 주석 정리
- 영향 범위: `src/components/` 전체

**3️⃣ Hooks 주석 제거** (2bbe02b)
- 커스텀 훅의 파라미터, 반환값 설명 주석 제거
- 훅 사용법 예시 제거
- 영향 범위: `src/hooks/` 또는 `src/shared/hooks/`

**4️⃣ Pages 주석 제거** (6fd86e5)
- 페이지 컴포넌트의 설명 주석 제거
- 페이지 구조 설명 주석 정리
- 영향 범위: `src/pages/`

**5️⃣ Global 설정 주석 제거** (a1ce57e)
- 전역 스타일 사용 예시 주석 제거
- 영향 파일: `src/shared/config/global/`

**6️⃣ Types, Utils 주석 제거** (0c7f553)
- 타입 정의 설명 주석 제거
- 유틸 함수 설명 주석 제거
- 영향 범위: `src/types/`, `src/utils/` 또는 `src/shared/lib/`

### 개선 효과
- **가독성 향상**: 코드와 타입 정의만으로 의도를 파악할 수 있게 됨
- **유지보수성 개선**: 주석과 코드의 불일치 문제 해소
- **코드량 감소**: 불필요한 주석 제거로 파일 크기 축소
- **TypeScript 활용 극대화**: 타입 시스템을 통한 자연스러운 문서화

## 💬 리뷰 요구사항(선택)

- 혹시 제거하지 말았어야 할 중요한 주석이 있는지 확인해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * AI 글쓰기 기능에 사용량 검증 및 확인 모달 추가
  * 멤버 프로필 네비게이션 개선
  * 비밀번호 입력 필드에 4자리 숫자 제한 추가

* **버그 수정**
  * 글 업데이트 실패 시 대체 통신 방식으로 재시도
  * ISBN 정규화 로직 개선
  * API 오류 시 사용자 친화적 메시지 표시

* **개선사항**
  * 멤버 정보에 프로필 이미지 및 가입일 필드 추가
  * API 응답 타입 확장으로 메시지 및 데이터 필드 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->