### PR TITLE
fix: 무한스크롤 패턴 전역 도입

### DIFF
--- a/src/components/common/CommentBottomSheet/GlobalCommentBottomSheet.styled.ts
+++ b/src/components/common/CommentBottomSheet/GlobalCommentBottomSheet.styled.ts
@@ -50,6 +50,26 @@ export const Content = styled.div`
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+
+  scrollbar-width: thin;
+  scrollbar-color: ${colors.grey[100]} transparent;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${colors.grey[100]};
+    border-radius: 2px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: ${colors.white};
+  }
 `;
 
 export const LoadingState = styled.div`

--- a/src/components/common/CommentBottomSheet/GlobalCommentBottomSheet.tsx
+++ b/src/components/common/CommentBottomSheet/GlobalCommentBottomSheet.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import MessageInput from '@/components/today-words/MessageInput';
 import ReplyList from '@/components/common/Post/ReplyList';
-import { getComments, type CommentData } from '@/api/comments/getComments';
 import { postReply } from '@/api/comments/postReply';
 import { useReplyActions } from '@/hooks/useReplyActions';
 import { useReplyStore } from '@/stores/replyStore';
@@ -16,7 +15,6 @@ import {
   Header,
   Title,
   Content,
-  LoadingState,
   InputSection,
 } from './GlobalCommentBottomSheet.styled';
 
@@ -24,35 +22,15 @@ const GlobalCommentBottomSheet = () => {
   const { roomId } = useParams<{ roomId: string }>();
   const { isOpen, postId, postType, closeCommentBottomSheet } = useCommentBottomSheetStore();
 
-  const [commentList, setCommentList] = useState<CommentData[]>([]);
   const [inputValue, setInputValue] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
   const [isSending, setIsSending] = useState(false);
   const [roomCompleted, setRoomCompleted] = useState(false);
+  const [replyReloadKey, setReplyReloadKey] = useState(0);
+  const contentRef = useRef<HTMLDivElement | null>(null);
 
   const { nickname, isReplying, cancelReply } = useReplyActions();
   const { parentId } = useReplyStore();
   const { openSnackbar } = usePopupActions();
-
-  const loadComments = useCallback(async () => {
-    if (!isOpen || !postId || !postType) return;
-
-    setIsLoading(true);
-    try {
-      const response = await getComments(postId, {
-        postType,
-        size: 20,
-      });
-
-      if (response.data) {
-        setCommentList(response.data.commentList);
-      }
-    } catch (error) {
-      console.error('댓글 로드 실패:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isOpen, postId, postType]);
 
   const handleSendComment = async () => {
     if (!inputValue.trim() || isSending || !postId || !postType) return;
@@ -71,7 +49,7 @@ const GlobalCommentBottomSheet = () => {
       if (response.isSuccess) {
         setInputValue('');
         cancelReply();
-        await loadComments();
+        setReplyReloadKey(prev => prev + 1);
       } else {
         openSnackbar({
           message: response.message || '댓글 작성 중 오류가 발생했습니다.',
@@ -122,16 +100,10 @@ const GlobalCommentBottomSheet = () => {
   }, [isOpen, roomId]);
 
   useEffect(() => {
-    if (isOpen) {
-      loadComments();
-    }
-  }, [isOpen, postId, loadComments]);
-
-  useEffect(() => {
     if (!isOpen) {
       setInputValue('');
       cancelReply();
-      setCommentList([]);
+      setReplyReloadKey(0);
     }
   }, [isOpen, cancelReply]);
 
@@ -144,12 +116,15 @@ const GlobalCommentBottomSheet = () => {
           <Title>댓글</Title>
         </Header>
 
-        <Content>
-          {isLoading ? (
-            <LoadingState>댓글을 불러오는 중...</LoadingState>
-          ) : (
-            <ReplyList commentList={commentList} onReload={loadComments} />
-          )}
+        <Content ref={contentRef}>
+          {postId && postType ? (
+            <ReplyList
+              postId={postId}
+              postType={postType}
+              reloadKey={`${replyReloadKey}-${isOpen ? 'open' : 'closed'}`}
+              rootRef={contentRef}
+            />
+          ) : null}
         </Content>
 
         {!roomCompleted && (

--- a/src/components/common/CommentBottomSheet/GlobalCommentBottomSheet.tsx
+++ b/src/components/common/CommentBottomSheet/GlobalCommentBottomSheet.tsx
@@ -123,6 +123,7 @@ const GlobalCommentBottomSheet = () => {
               postType={postType}
               reloadKey={`${replyReloadKey}-${isOpen ? 'open' : 'closed'}`}
               rootRef={contentRef}
+              disableBottomMargin={true}
             />
           ) : null}
         </Content>

--- a/src/components/common/Post/PostBody.styled.ts
+++ b/src/components/common/Post/PostBody.styled.ts
@@ -22,8 +22,9 @@ export const PostContent = styled.div<{ hasImage: boolean }>`
     font-weight: var(--string-weight-regular, 400);
     line-height: var(--string-lineheight-feedcontent_height20, 20px);
     cursor: pointer;
-    white-space: pre-wrap; // 개행문자 유지
-    /* word-wrap: break-word; // 긴 텍스트 줄바꿈 */
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 
     display: -webkit-box;
     -webkit-box-orient: vertical;

--- a/src/components/common/Post/ReplyList.styled.ts
+++ b/src/components/common/Post/ReplyList.styled.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { typography, colors } from '@/styles/global/global';
 
-export const Container = styled.div`
+export const Container = styled.div<{ disableBottomMargin?: boolean }>`
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -9,7 +9,7 @@ export const Container = styled.div`
   max-width: 540px; */
   padding: 40px 20px;
   margin: 0 auto;
-  margin-bottom: 56px;
+  margin-bottom: ${({ disableBottomMargin }) => (disableBottomMargin ? '0' : '56px')};
   gap: 24px;
   flex: 1;
 
@@ -20,7 +20,7 @@ export const Container = styled.div`
   }
 `;
 
-export const EmptyState = styled.div`
+export const EmptyState = styled.div<{ disableBottomMargin?: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -30,7 +30,7 @@ export const EmptyState = styled.div`
   max-width: 540px;
   padding: 40px 20px;
   margin: 0 auto;
-  margin-bottom: 56px;
+  margin-bottom: ${({ disableBottomMargin }) => (disableBottomMargin ? '0' : '56px')};
   gap: 8px;
   flex: 1;
 

--- a/src/components/common/Post/ReplyList.tsx
+++ b/src/components/common/Post/ReplyList.tsx
@@ -1,27 +1,80 @@
+import { useCallback } from 'react';
+import type { RefObject } from 'react';
 import Reply from './Reply';
 import SubReply from './SubReply';
-import type { CommentData } from '@/api/comments/getComments';
+import { getComments, type CommentData } from '@/api/comments/getComments';
+import { useInifinieScroll } from '@/hooks/useInifinieScroll';
+import LoadingSpinner from '../LoadingSpinner';
 import { Container, EmptyState } from './ReplyList.styled';
 
 interface ReplyListProps {
-  commentList: CommentData[];
-  onReload: () => void;
+  commentList?: CommentData[];
+  onReload?: () => void;
+  postId?: number;
+  postType?: 'FEED' | 'RECORD' | 'VOTE';
+  reloadKey?: string;
+  rootRef?: RefObject<HTMLElement | null>;
 }
 
-const ReplyList = ({ commentList, onReload }: ReplyListProps) => {
-  const hasComments = commentList.length > 0;
+const ReplyList = ({
+  commentList = [],
+  onReload,
+  postId,
+  postType,
+  reloadKey = '',
+  rootRef,
+}: ReplyListProps) => {
+  const isInfiniteMode = Boolean(postId && postType);
+  const commentFeed = useInifinieScroll<CommentData>({
+    enabled: isInfiniteMode,
+    reloadKey: `${postId ?? ''}-${postType ?? ''}-${reloadKey}`,
+    fetchPage: async cursor => {
+      if (!postId || !postType) {
+        return { items: [], nextCursor: null, isLast: true };
+      }
+
+      const response = await getComments(postId, {
+        postType,
+        size: 20,
+        cursor,
+      });
+
+      return {
+        items: response.data.commentList,
+        nextCursor: response.data.nextCursor || null,
+        isLast: response.data.isLast,
+      };
+    },
+    rootRef,
+    rootMargin: '120px 0px',
+    threshold: 0.1,
+  });
+
+  const list = isInfiniteMode ? commentFeed.items : commentList;
+  const hasComments = list.length > 0;
+
+  const handleReload = useCallback(() => {
+    if (isInfiniteMode) {
+      void commentFeed.reload();
+      return;
+    }
+    onReload?.();
+  }, [commentFeed, isInfiniteMode, onReload]);
 
   return (
     <Container>
+      {isInfiniteMode && commentFeed.isLoading && list.length === 0 && (
+        <LoadingSpinner size="small" fullHeight={false} />
+      )}
       {hasComments ? (
-        commentList.map((comment, commentIndex) => (
+        list.map((comment, commentIndex) => (
           <div className="comment-group" key={comment.commentId || `comment-${commentIndex}`}>
-            <Reply {...comment} onDelete={onReload} />
+            <Reply {...comment} onDelete={handleReload} />
             {comment.replyList.map((sub, replyIndex) => (
               <SubReply
                 key={sub.commentId || `reply-${comment.commentId || commentIndex}-${replyIndex}`}
                 {...sub}
-                onDelete={onReload}
+                onDelete={handleReload}
               />
             ))}
           </div>
@@ -32,6 +85,9 @@ const ReplyList = ({ commentList, onReload }: ReplyListProps) => {
           <div className="sub-title">첫번째 댓글을 남겨보세요</div>
         </EmptyState>
       )}
+
+      {isInfiniteMode && !commentFeed.isLast && <div ref={commentFeed.sentinelRef} style={{ height: 20 }} />}
+      {isInfiniteMode && commentFeed.isLoadingMore && <LoadingSpinner size="small" fullHeight={false} />}
     </Container>
   );
 };

--- a/src/components/common/Post/ReplyList.tsx
+++ b/src/components/common/Post/ReplyList.tsx
@@ -14,6 +14,7 @@ interface ReplyListProps {
   postType?: 'FEED' | 'RECORD' | 'VOTE';
   reloadKey?: string;
   rootRef?: RefObject<HTMLElement | null>;
+  disableBottomMargin?: boolean;
 }
 
 const ReplyList = ({
@@ -23,6 +24,7 @@ const ReplyList = ({
   postType,
   reloadKey = '',
   rootRef,
+  disableBottomMargin = false,
 }: ReplyListProps) => {
   const isInfiniteMode = Boolean(postId && postType);
   const commentFeed = useInifinieScroll<CommentData>({
@@ -62,7 +64,7 @@ const ReplyList = ({
   }, [commentFeed, isInfiniteMode, onReload]);
 
   return (
-    <Container>
+    <Container disableBottomMargin={disableBottomMargin}>
       {isInfiniteMode && commentFeed.isLoading && list.length === 0 && (
         <LoadingSpinner size="small" fullHeight={false} />
       )}
@@ -80,7 +82,7 @@ const ReplyList = ({
           </div>
         ))
       ) : (
-        <EmptyState>
+        <EmptyState disableBottomMargin={disableBottomMargin}>
           <div className="title">아직 댓글이 없어요</div>
           <div className="sub-title">첫번째 댓글을 남겨보세요</div>
         </EmptyState>

--- a/src/components/group/MyGroupModal.tsx
+++ b/src/components/group/MyGroupModal.tsx
@@ -6,6 +6,8 @@ import { GroupCard } from './GroupCard';
 import { Modal, Overlay } from './Modal.styles';
 import { getMyRooms, type Room, type RoomType } from '@/api/rooms/getMyRooms';
 import { useNavigate } from 'react-router-dom';
+import LoadingSpinner from '../common/LoadingSpinner';
+import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 import {
   TabContainer,
   Tab,
@@ -30,12 +32,7 @@ export const MyGroupModal = ({ onClose }: MyGroupModalProps) => {
   }, []);
   const navigate = useNavigate();
   const [selected, setSelected] = useState<'진행중' | '모집중' | '완료' | ''>('');
-  const [rooms, setRooms] = useState<Room[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [isLast, setIsLast] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
 
   const convertRoomToGroup = (room: Room): Group => {
     return {
@@ -52,103 +49,33 @@ export const MyGroupModal = ({ onClose }: MyGroupModalProps) => {
     };
   };
 
-  useEffect(() => {
-    const fetchRooms = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-        setNextCursor(null);
-        setIsLast(false);
+  const roomType: RoomType =
+    selected === '진행중'
+      ? 'playing'
+      : selected === '모집중'
+        ? 'recruiting'
+        : selected === '완료'
+          ? 'expired'
+          : 'playingAndRecruiting';
 
-        const roomType: RoomType =
-          selected === '진행중'
-            ? 'playing'
-            : selected === '모집중'
-              ? 'recruiting'
-              : selected === '완료'
-                ? 'expired'
-                : 'playingAndRecruiting';
-
-        const response = await getMyRooms(roomType, null);
-
-        if (response.isSuccess) {
-          setRooms(response.data.roomList);
-          setNextCursor(response.data.nextCursor);
-          setIsLast(response.data.isLast);
-        } else {
-          setError(response.message);
-        }
-      } catch (error) {
-        console.error('방 목록 조회 실패:', error);
-        setError('방 목록을 불러오는데 실패했습니다.');
-      } finally {
-        setIsLoading(false);
+  const roomList = useInifinieScroll<Room>({
+    enabled: true,
+    reloadKey: roomType,
+    rootRef: contentRef,
+    fetchPage: async cursor => {
+      const response = await getMyRooms(roomType, cursor);
+      if (!response.isSuccess) {
+        throw new Error(response.message || '방 목록을 불러오는데 실패했습니다.');
       }
-    };
-
-    fetchRooms();
-  }, [selected]);
-
-  const isFetchingRef = useRef(false);
-
-  const loadMore = async () => {
-    if (isFetchingRef.current || isLast || !nextCursor) return;
-
-    isFetchingRef.current = true;
-    setIsLoading(true);
-    try {
-      const roomType: RoomType =
-        selected === '진행중'
-          ? 'playing'
-          : selected === '모집중'
-            ? 'recruiting'
-            : selected === '완료'
-              ? 'expired'
-              : 'playingAndRecruiting';
-
-      const res = await getMyRooms(roomType, nextCursor);
-      if (res.isSuccess) {
-        setRooms(prev => [...prev, ...res.data.roomList]);
-        setNextCursor(res.data.nextCursor);
-        setIsLast(res.data.isLast);
-      } else {
-        setError(res.message);
-      }
-    } catch (e) {
-      console.log(e);
-      setError('방 목록을 불러오는데 실패했습니다.');
-    } finally {
-      setIsLoading(false);
-      isFetchingRef.current = false;
-    }
-  };
-
-  const handleScroll = async (e: React.UIEvent<HTMLDivElement>) => {
-    const el = e.currentTarget;
-    const { scrollTop, scrollHeight, clientHeight } = el;
-    if (scrollHeight - scrollTop - clientHeight < 100) {
-      await loadMore();
-    }
-  };
-
-  useEffect(() => {
-    const tryFill = async () => {
-      if (!contentRef.current || isLast) return;
-      let guard = 2;
-      while (
-        guard-- > 0 &&
-        contentRef.current &&
-        contentRef.current.scrollHeight <= contentRef.current.clientHeight &&
-        !isLast &&
-        nextCursor
-      ) {
-        await loadMore();
-        await new Promise(requestAnimationFrame);
-      }
-    };
-    tryFill();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rooms, nextCursor, isLast]);
+      return {
+        items: response.data.roomList,
+        nextCursor: response.data.nextCursor,
+        isLast: response.data.isLast,
+      };
+    },
+    rootMargin: '100px 0px',
+    threshold: 0.1,
+  });
 
   useEffect(() => {
     if (contentRef.current) {
@@ -156,7 +83,7 @@ export const MyGroupModal = ({ onClose }: MyGroupModalProps) => {
     }
   }, [selected]);
 
-  const convertedGroups = rooms.map(convertRoomToGroup);
+  const convertedGroups = roomList.items.map(convertRoomToGroup);
 
   const handleGroupCardClick = (group: Group) => {
     if (selected === '완료') {
@@ -194,8 +121,8 @@ export const MyGroupModal = ({ onClose }: MyGroupModalProps) => {
           ))}
         </TabContainer>
 
-        <Content ref={contentRef} onScroll={handleScroll}>
-          {error && <ErrorMessage>{error}</ErrorMessage>}
+        <Content ref={contentRef}>
+          {roomList.error && <ErrorMessage>{roomList.error}</ErrorMessage>}
 
           {convertedGroups.map(group => (
             <GroupCard
@@ -208,9 +135,16 @@ export const MyGroupModal = ({ onClose }: MyGroupModalProps) => {
             />
           ))}
 
-          {isLoading && <BottomSpinner>불러오는 중…</BottomSpinner>}
+          {!roomList.isLast && (
+            <div ref={roomList.sentinelRef} style={{ gridColumn: '1 / -1', height: 20 }} />
+          )}
+          {roomList.isLoadingMore && (
+            <BottomSpinner>
+              <LoadingSpinner size="small" fullHeight={false} />
+            </BottomSpinner>
+          )}
 
-          {!isLoading && convertedGroups.length === 0 && (
+          {!roomList.isLoading && convertedGroups.length === 0 && !roomList.error && (
             <EmptyState>
               <EmptyTitle>
                 {selected === '진행중'

--- a/src/components/search/GroupSearchResult.styled.ts
+++ b/src/components/search/GroupSearchResult.styled.ts
@@ -71,7 +71,7 @@ export const EmptySubText = styled.p`
   text-align: center;
 `;
 
-export const LoadingText = styled.p`
+export const LoadingText = styled.div`
   color: ${colors.grey[100]};
   font-size: ${typography.fontSize.sm};
   text-align: center;

--- a/src/components/search/GroupSearchResult.tsx
+++ b/src/components/search/GroupSearchResult.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
+import type { RefObject } from 'react';
 import { GroupCard } from '../group/GroupCard';
 import { Filter } from '../common/Filter';
 import type { SearchRoomItem } from '@/api/rooms/getSearchRooms';
+import LoadingSpinner from '../common/LoadingSpinner';
 import {
   TabContainer,
   Tab,
@@ -26,7 +28,7 @@ interface Props {
   isLoading: boolean;
   isLoadingMore?: boolean;
   hasMore?: boolean;
-  lastRoomElementCallback?: (node: HTMLDivElement | null) => void;
+  sentinelRef?: RefObject<HTMLDivElement | null>;
   error: string | null;
   selectedFilter: string;
   setSelectedFilter: (v: string) => void;
@@ -53,7 +55,8 @@ const GroupSearchResult = ({
   rooms,
   isLoading,
   isLoadingMore = false,
-  lastRoomElementCallback,
+  hasMore = false,
+  sentinelRef,
   error,
   selectedFilter,
   setSelectedFilter,
@@ -113,12 +116,16 @@ const GroupSearchResult = ({
               isOngoing={false}
               isFirstCard={type === 'searching' && idx === 0}
               onClick={() => onClickRoom(Number(group.id))}
-              ref={idx === mapped.length - 1 ? lastRoomElementCallback : undefined}
             />
           ))
         )}
 
-        {isLoadingMore && mapped.length > 0 && <LoadingText>불러오는 중...</LoadingText>}
+        {hasMore && <div ref={sentinelRef} style={{ height: 20 }} />}
+        {isLoadingMore && mapped.length > 0 && (
+          <LoadingText>
+            <LoadingSpinner size="small" fullHeight={false} />
+          </LoadingText>
+        )}
       </Content>
     </>
   );

--- a/src/hooks/useInifinieScroll.ts
+++ b/src/hooks/useInifinieScroll.ts
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+interface PageResult<T> {
+  items: T[];
+  nextCursor: string | null;
+  isLast: boolean;
+}
+
+interface UseInifinieScrollOptions<T> {
+  enabled: boolean;
+  reloadKey: string;
+  fetchPage: (cursor: string | null) => Promise<PageResult<T>>;
+  mergeItems?: (prev: T[], next: T[]) => T[];
+  rootRef?: RefObject<HTMLElement | null>;
+  rootMargin?: string;
+  threshold?: number;
+}
+
+export const useInifinieScroll = <T>({
+  enabled,
+  reloadKey,
+  fetchPage,
+  mergeItems,
+  rootRef,
+  rootMargin = '200px 0px',
+  threshold = 0,
+}: UseInifinieScrollOptions<T>) => {
+  const [items, setItems] = useState<T[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLast, setIsLast] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const isFetchingRef = useRef(false);
+  const fetchPageRef = useRef(fetchPage);
+
+  useEffect(() => {
+    fetchPageRef.current = fetchPage;
+  }, [fetchPage]);
+
+  const merge = useMemo(
+    () =>
+      mergeItems ||
+      ((prev: T[], next: T[]) => {
+        return [...prev, ...next];
+      }),
+    [mergeItems],
+  );
+
+  const loadFirstPage = useCallback(async () => {
+    if (!enabled || isFetchingRef.current) return;
+    isFetchingRef.current = true;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetchPageRef.current(null);
+      setItems(res.items);
+      setNextCursor(res.nextCursor);
+      setIsLast(res.isLast);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : '목록을 불러오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+      isFetchingRef.current = false;
+    }
+  }, [enabled]);
+
+  const loadMore = useCallback(async () => {
+    if (!enabled || isFetchingRef.current || isLast || !nextCursor) return;
+    isFetchingRef.current = true;
+    setIsLoadingMore(true);
+
+    try {
+      const res = await fetchPageRef.current(nextCursor);
+      setItems(prev => merge(prev, res.items));
+      setNextCursor(res.nextCursor);
+      setIsLast(res.isLast);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : '추가 목록을 불러오지 못했습니다.');
+    } finally {
+      setIsLoadingMore(false);
+      isFetchingRef.current = false;
+    }
+  }, [enabled, isLast, nextCursor, merge]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    setItems([]);
+    setNextCursor(null);
+    setIsLast(false);
+    void loadFirstPage();
+  }, [enabled, reloadKey, loadFirstPage]);
+
+  useEffect(() => {
+    if (!enabled || !sentinelRef.current) return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting) {
+          void loadMore();
+        }
+      },
+      { root: rootRef?.current || null, rootMargin, threshold },
+    );
+
+    observer.observe(sentinelRef.current);
+
+    return () => observer.disconnect();
+  }, [enabled, loadMore, rootMargin, threshold, rootRef]);
+
+  return {
+    items,
+    setItems,
+    isLast,
+    isLoading,
+    isLoadingMore,
+    error,
+    sentinelRef,
+    reload: loadFirstPage,
+  };
+};

--- a/src/pages/feed/Feed.tsx
+++ b/src/pages/feed/Feed.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import NavBar from '../../components/common/NavBar';
 import TabBar from '../../components/feed/TabBar';
 import MyFeed from '../../components/feed/MyFeed';
@@ -10,6 +10,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { getTotalFeeds } from '@/api/feeds/getTotalFeed';
 import { getMyFeeds } from '@/api/feeds/getMyFeed';
 import { useSocialLoginToken } from '@/hooks/useSocialLoginToken';
+import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 import { Container } from './Feed.styled';
 import type { PostData } from '@/types/post';
 
@@ -30,20 +31,6 @@ const Feed = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const [totalFeedPosts, setTotalFeedPosts] = useState<PostData[]>([]);
-  const [totalLoading, setTotalLoading] = useState(false);
-  const [totalNextCursor, setTotalNextCursor] = useState<string>('');
-  const [totalIsLast, setTotalIsLast] = useState(false);
-
-  const [myFeedPosts, setMyFeedPosts] = useState<PostData[]>([]);
-  const [myLoading, setMyLoading] = useState(false);
-  const [myNextCursor, setMyNextCursor] = useState<string>('');
-  const [myIsLast, setMyIsLast] = useState(false);
-
-  const [tabLoading, setTabLoading] = useState(false);
-
-  const [initialLoading, setInitialLoading] = useState(true);
-
   const handleSearchButton = () => {
     navigate('/feed/search');
   };
@@ -52,110 +39,44 @@ const Feed = () => {
     navigate('/notice');
   };
 
-  const loadTotalFeeds = useCallback(async (_cursor?: string) => {
-    try {
-      setTotalLoading(true);
+  const totalFeed = useInifinieScroll<PostData>({
+    enabled: activeTab === '피드',
+    reloadKey: activeTab,
+    fetchPage: async cursor => {
+      await waitForToken();
+      const response = await getTotalFeeds(cursor ? { cursor } : undefined);
+      return {
+        items: response.data.feedList,
+        nextCursor: response.data.nextCursor || null,
+        isLast: response.data.isLast,
+      };
+    },
+    mergeItems: (prev, next) => {
+      const existingIds = new Set(prev.map(post => post.feedId));
+      const newPosts = next.filter(post => !existingIds.has(post.feedId));
+      return [...prev, ...newPosts];
+    },
+  });
 
-      const response = await getTotalFeeds(_cursor ? { cursor: _cursor } : undefined);
-
-      if (_cursor) {
-        setTotalFeedPosts(prev => {
-          const existingIds = new Set(prev.map(post => post.feedId));
-          const newPosts = response.data.feedList.filter(post => !existingIds.has(post.feedId));
-          return [...prev, ...newPosts];
-        });
-      } else {
-        setTotalFeedPosts(response.data.feedList);
-      }
-
-      setTotalNextCursor(response.data.nextCursor);
-      setTotalIsLast(response.data.isLast);
-    } catch (error) {
-      console.error('전체 피드 로드 실패:', error);
-    } finally {
-      setTotalLoading(false);
-    }
-  }, []);
-
-  const loadMyFeeds = useCallback(async (_cursor?: string) => {
-    try {
-      setMyLoading(true);
-      const response = await getMyFeeds(_cursor ? { cursor: _cursor } : undefined);
-
-      if (_cursor) {
-        setMyFeedPosts(prev => [...prev, ...response.data.feedList]);
-      } else {
-        setMyFeedPosts(response.data.feedList);
-      }
-
-      setMyNextCursor(response.data.nextCursor);
-      setMyIsLast(response.data.isLast);
-    } catch (error) {
-      console.error('내 피드 로드 실패:', error);
-    } finally {
-      setMyLoading(false);
-    }
-  }, []);
-
-  const loadMoreFeeds = useCallback(() => {
-    if (activeTab === '피드') {
-      if (!totalIsLast && !totalLoading && totalNextCursor) {
-        loadTotalFeeds(totalNextCursor);
-      }
-    } else {
-      if (!myIsLast && !myLoading && myNextCursor) {
-        loadMyFeeds(myNextCursor);
-      }
-    }
-  }, [activeTab, totalIsLast, totalLoading, totalNextCursor, myIsLast, myLoading, myNextCursor]);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      const isLoading = activeTab === '피드' ? totalLoading : myLoading;
-      const isLastPage = activeTab === '피드' ? totalIsLast : myIsLast;
-
-      if (isLoading || isLastPage) return;
-
-      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-      const windowHeight = window.innerHeight;
-      const documentHeight = document.documentElement.scrollHeight;
-
-      if (scrollTop + windowHeight >= documentHeight - 200) {
-        loadMoreFeeds();
-      }
-    };
-
-    window.addEventListener('scroll', handleScroll);
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, [activeTab, totalLoading, myLoading, totalIsLast, myIsLast, loadMoreFeeds]);
+  const myFeed = useInifinieScroll<PostData>({
+    enabled: activeTab === '내 피드',
+    reloadKey: activeTab,
+    fetchPage: async cursor => {
+      await waitForToken();
+      const response = await getMyFeeds(cursor ? { cursor } : undefined);
+      return {
+        items: response.data.feedList,
+        nextCursor: response.data.nextCursor || null,
+        isLast: response.data.isLast,
+      };
+    },
+  });
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [activeTab]);
 
-  useEffect(() => {
-    const loadFeedsWithToken = async () => {
-      await waitForToken();
-
-      setTabLoading(true);
-
-      try {
-        if (activeTab === '피드') {
-          await loadTotalFeeds();
-        } else if (activeTab === '내 피드') {
-          await loadMyFeeds();
-        }
-      } finally {
-        setTabLoading(false);
-        setInitialLoading(false);
-      }
-    };
-
-    loadFeedsWithToken();
-  }, [activeTab, waitForToken, loadTotalFeeds, loadMyFeeds]);
+  const currentFeed = activeTab === '피드' ? totalFeed : myFeed;
 
   return (
     <Container>
@@ -165,7 +86,7 @@ const Feed = () => {
         rightButtonClick={handleNoticeButton}
       />
       <TabBar tabs={tabs} activeTab={activeTab} onTabClick={setActiveTab} />
-      {initialLoading || tabLoading ? (
+      {currentFeed.isLoading && currentFeed.items.length === 0 ? (
         <LoadingSpinner size="large" fullHeight={true} />
       ) : (
         <>
@@ -173,16 +94,23 @@ const Feed = () => {
             <>
               <TotalFeed
                 showHeader={true}
-                posts={totalFeedPosts}
+                posts={totalFeed.items}
                 isMyFeed={false}
-                isLast={totalIsLast}
+                isLast={totalFeed.isLast}
               />
             </>
           ) : (
             <>
-              <MyFeed showHeader={false} posts={myFeedPosts} isMyFeed={true} isLast={myIsLast} />
+              <MyFeed
+                showHeader={false}
+                posts={myFeed.items}
+                isMyFeed={true}
+                isLast={myFeed.isLast}
+              />
             </>
           )}
+          {!currentFeed.isLast && <div ref={currentFeed.sentinelRef} style={{ height: 40 }} />}
+          {currentFeed.isLoadingMore && <LoadingSpinner size="small" fullHeight={false} />}
         </>
       )}
       <NavBar src={writefab} path="/post/create" />

--- a/src/pages/feed/FeedDetailPage.tsx
+++ b/src/pages/feed/FeedDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useParams } from 'react-router-dom';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import TitleHeader from '@/components/common/TitleHeader';
 import FeedDetailPost from '@/components/feed/FeedDetailPost';
 import leftArrow from '../../assets/common/leftArrow.svg';
@@ -9,7 +9,6 @@ import MessageInput from '@/components/today-words/MessageInput';
 import { usePopupActions } from '@/hooks/usePopupActions';
 import { useReplyActions } from '@/hooks/useReplyActions';
 import { getFeedDetail, type FeedDetailData } from '@/api/feeds/getFeedDetail';
-import { getComments, type CommentData } from '@/api/comments/getComments';
 import { deleteFeedPost } from '@/api/feeds/deleteFeedPost';
 import { Wrapper } from './FeedDetailPage.styled';
 import { useReplyStore } from '@/stores/replyStore';
@@ -18,7 +17,7 @@ const FeedDetailPage = () => {
   const navigate = useNavigate();
   const { feedId } = useParams<{ feedId: string }>();
   const [feedData, setFeedData] = useState<FeedDetailData | null>(null);
-  const [commentList, setCommentList] = useState<CommentData[]>([]);
+  const [replyReloadKey, setReplyReloadKey] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -26,27 +25,6 @@ const FeedDetailPage = () => {
   const { isReplying, replyContent, setReplyContent, submitComment, cancelReply } =
     useReplyActions();
   const { nickname } = useReplyStore();
-  const reloadComments = useCallback(async () => {
-    if (!feedId) return;
-
-    try {
-      const commentsResponse = await getComments(Number(feedId), { postType: 'FEED' });
-      setCommentList(commentsResponse.data.commentList);
-
-      if (feedData) {
-        setFeedData(prev =>
-          prev
-            ? {
-                ...prev,
-                commentCount: commentsResponse.data.commentList.length,
-              }
-            : null,
-        );
-      }
-    } catch (err) {
-      console.error('댓글 목록 다시 로드 실패:', err);
-    }
-  }, [feedId, feedData]);
 
   useEffect(() => {
     return () => {
@@ -55,7 +33,7 @@ const FeedDetailPage = () => {
   }, [cancelReply]);
 
   useEffect(() => {
-    const loadFeedDetailAndComments = async () => {
+    const loadFeedDetail = async () => {
       if (!feedId) {
         setError('피드 ID가 없습니다.');
         setLoading(false);
@@ -65,30 +43,26 @@ const FeedDetailPage = () => {
       try {
         setLoading(true);
 
-        const [feedResponse, commentsResponse] = await Promise.all([
-          getFeedDetail(Number(feedId)),
-          getComments(Number(feedId), { postType: 'FEED' }),
-        ]);
+        const feedResponse = await getFeedDetail(Number(feedId));
 
         setFeedData(feedResponse.data);
-        setCommentList(commentsResponse.data.commentList);
         setError(null);
       } catch (err) {
-        console.error('피드 상세 정보 또는 댓글 로드 실패:', err);
+        console.error('피드 상세 정보 로드 실패:', err);
         setError('피드 정보를 불러오는데 실패했습니다.');
       } finally {
         setLoading(false);
       }
     };
 
-    loadFeedDetailAndComments();
+    loadFeedDetail();
   }, [feedId]);
 
   const handleCommentSubmit = async () => {
     await submitComment({
       postId: Number(feedId),
       postType: 'FEED',
-      onSuccess: reloadComments,
+      onSuccess: () => setReplyReloadKey(prev => prev + 1),
     });
   };
 
@@ -190,7 +164,7 @@ const FeedDetailPage = () => {
         onRightClick={handleMoreClick}
       />
       <FeedDetailPost {...feedData} />
-      <ReplyList commentList={commentList} onReload={reloadComments} />
+      <ReplyList postId={Number(feedId)} postType="FEED" reloadKey={`${replyReloadKey}`} />
       <MessageInput
         placeholder="여러분의 생각을 남겨주세요."
         value={replyContent}

--- a/src/pages/feed/FollowerListPage.tsx
+++ b/src/pages/feed/FollowerListPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useParams } from 'react-router-dom';
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import TitleHeader from '@/components/common/TitleHeader';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import UserProfileItem from '@/components/feed/UserProfileItem';
@@ -7,6 +7,7 @@ import type { UserProfileType } from '@/types/user';
 import { getFollowerList } from '@/api/users/getFollowerList';
 import { getFollowingList } from '@/api/users/getFollowingList';
 import type { FollowData } from '@/types/follow';
+import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { TotalBar, UserProfileList, Wrapper } from './FollowerListPage.syled';
 
@@ -15,116 +16,56 @@ const FollowerListPage = () => {
   const { type, userId } = useParams<{ type: UserProfileType; userId?: string }>();
   const title = type === 'followerlist' ? '띱 목록' : '내 띱 목록';
 
-  const [userList, setUserList] = useState<FollowData[]>([]);
   const [totalCount, setTotalCount] = useState(0);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [retryCount, setRetryCount] = useState(0);
-  const [nextCursor, setNextCursor] = useState<string>('');
-  const [isLast, setIsLast] = useState(false);
 
   const handleBackClick = () => {
     navigate(-1);
   };
 
-  const loadUserList = useCallback(
-    async (cursor?: string) => {
-      if (loading) return;
-
-      try {
-        setLoading(true);
-        setError(null);
-        let response;
-
-        if (type === 'followerlist') {
-          if (!userId) {
-            setError('사용자 ID가 없습니다.');
-            return;
-          }
-          response = await getFollowerList(userId, { size: 10, cursor: cursor || null });
-        } else {
-          response = await getFollowingList({ size: 10, cursor: cursor || null });
+  const userList = useInifinieScroll<FollowData>({
+    enabled: true,
+    reloadKey: `${type}-${userId ?? ''}`,
+    fetchPage: async cursor => {
+      if (type === 'followerlist') {
+        if (!userId) {
+          throw new Error('사용자 ID가 없습니다.');
         }
-
-        let userData: FollowData[] = [];
-        if (type === 'followerlist') {
-          userData = (response.data as { followers: FollowData[] })?.followers || [];
-        } else {
-          userData = (response.data as { followings: FollowData[] })?.followings || [];
-        }
-
-        if (!response || !response.data) {
-          setError('API 응답이 없습니다.');
-          return;
-        }
-
-        if (cursor) {
-          setUserList(prev => [...prev, ...userData]);
-        } else {
-          setUserList(userData);
-        }
-
-        setNextCursor(response.data.nextCursor);
-        setIsLast(response.data.isLast);
-        if (type === 'followerlist') {
-          const total = (response.data as { totalFollowerCount?: number }).totalFollowerCount;
-          if (typeof total === 'number') setTotalCount(total);
-        } else {
-          const total = (response.data as { totalFollowingCount?: number }).totalFollowingCount;
-          if (typeof total === 'number') setTotalCount(total);
-        }
-        setRetryCount(0);
-      } catch (error) {
-        console.error('사용자 목록 로드 실패:', error);
-        setError('사용자 목록을 불러오는데 실패했습니다.');
-        setRetryCount(prev => prev + 1);
-      } finally {
-        setLoading(false);
+        const response = await getFollowerList(userId, { size: 10, cursor });
+        const total = response.data.totalFollowerCount;
+        if (typeof total === 'number') setTotalCount(total);
+        return {
+          items: response.data.followers || [],
+          nextCursor: response.data.nextCursor || null,
+          isLast: response.data.isLast,
+        };
       }
+
+      const response = await getFollowingList({ size: 10, cursor });
+      const total = response.data.totalFollowingCount;
+      if (typeof total === 'number') setTotalCount(total);
+      return {
+        items: response.data.followings || [],
+        nextCursor: response.data.nextCursor || null,
+        isLast: response.data.isLast,
+      };
     },
-    [type, userId],
-  );
+    rootMargin: '100px 0px',
+    threshold: 0.1,
+  });
 
   useEffect(() => {
-    const handleScroll = () => {
-      if (loading || isLast || error || retryCount >= 3 || !nextCursor) {
-        return;
-      }
-
-      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-      const windowHeight = window.innerHeight;
-      const documentHeight = document.documentElement.scrollHeight;
-
-      if (scrollTop + windowHeight >= documentHeight - 100) {
-        loadUserList(nextCursor);
-      }
-    };
-
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [isLast, error, retryCount, nextCursor, loadUserList]);
-
-  useEffect(() => {
-    loadUserList();
-  }, [loadUserList]);
-
-  useEffect(() => {
-    const doc = document.documentElement;
-    const needsMore = doc.scrollHeight <= window.innerHeight + 100;
-    if (!loading && !isLast && !!nextCursor && needsMore) {
-      loadUserList(nextCursor);
-    }
-  }, [userList, loading, isLast, nextCursor, loadUserList]);
+    window.scrollTo(0, 0);
+  }, [type, userId]);
 
   return (
     <Wrapper>
       <TitleHeader leftIcon={<img src={leftArrow} />} onLeftClick={handleBackClick} title={title} />
       <TotalBar>전체 {totalCount}</TotalBar>
-      {loading && userList.length === 0 ? (
+      {userList.isLoading && userList.items.length === 0 ? (
         <LoadingSpinner size="medium" fullHeight={true} />
       ) : (
         <UserProfileList>
-          {userList.map((user, index) => (
+          {userList.items.map((user, index) => (
             <UserProfileItem
               key={user.userId}
               profileImageUrl={user.profileImageUrl}
@@ -135,11 +76,12 @@ const FollowerListPage = () => {
               userId={user.userId}
               type={type as UserProfileType}
               isFollowing={user.isFollowing}
-              isLast={index === userList.length - 1}
+              isLast={index === userList.items.length - 1}
               isMyself={user.isMyself}
             />
           ))}
-          {loading && userList.length > 0 && (
+          {!userList.isLast && <div ref={userList.sentinelRef} style={{ height: 20 }} />}
+          {userList.isLoadingMore && (
             <div style={{ display: 'flex', justifyContent: 'center', padding: '16px 0' }}>
               <LoadingSpinner size="small" />
             </div>

--- a/src/pages/groupSearch/GroupSearch.tsx
+++ b/src/pages/groupSearch/GroupSearch.tsx
@@ -3,14 +3,16 @@ import { Modal, Overlay } from '@/components/group/Modal.styles';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import SearchBar from '@/components/search/SearchBar';
 import rightChevron from '../../assets/common/right-Chevron.svg';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import RecentSearchTabs from '@/components/search/RecentSearchTabs';
 import GroupSearchResult from '@/components/search/GroupSearchResult';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { getRecentSearch, type RecentSearchData } from '@/api/recentsearch/getRecentSearch';
 import { deleteRecentSearch } from '@/api/recentsearch/deleteRecentSearch';
-import { getSearchRooms, type SearchRoomItem } from '@/api/rooms/getSearchRooms';
+import { getSearchRooms } from '@/api/rooms/getSearchRooms';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { AllRoomsButton, LoadingMessage } from './GroupSearch.styled';
+import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 
 type SortKey = 'deadline' | 'memberCount';
 type SearchStatus = 'idle' | 'searching' | 'searched';
@@ -22,27 +24,18 @@ const GroupSearch = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchStatus, setSearchStatus] = useState<SearchStatus>('idle');
 
-  const [rooms, setRooms] = useState<SearchRoomItem[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [isLast, setIsLast] = useState(true);
-
-  const [isLoading, setIsLoading] = useState(false);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
   const [selectedFilter, setSelectedFilter] = useState<string>('마감임박순');
   const toSortKey = useCallback(
     (f: string): SortKey => (f === '인기순' ? 'memberCount' : 'deadline'),
     [],
   );
   const [category, setCategory] = useState<string>('');
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
 
   const [recentSearches, setRecentSearches] = useState<RecentSearchData[]>([]);
-  const [searchTimeoutId, setSearchTimeoutId] = useState<NodeJS.Timeout | null>(null);
+  const [searchTimeoutId, setSearchTimeoutId] = useState<ReturnType<typeof setTimeout> | null>(null);
 
   const [showTabs, setShowTabs] = useState(false);
-
-  const observerRef = useRef<IntersectionObserver | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -70,48 +63,6 @@ const GroupSearch = () => {
     }
   };
 
-  const searchFirstPage = useCallback(
-    async (
-      term: string,
-      sortKey: SortKey,
-      status: 'searching' | 'searched',
-      categoryParam: string,
-      isAllCategory: boolean = false,
-    ) => {
-      setIsLoading(true);
-      setError(null);
-      setRooms([]);
-      setNextCursor(null);
-      setIsLast(true);
-
-      try {
-        const isFinalized = status === 'searched';
-        const res = await getSearchRooms(
-          term.trim(),
-          sortKey,
-          undefined,
-          isFinalized,
-          categoryParam,
-          isAllCategory,
-        );
-        if (res.isSuccess) {
-          const { roomList, nextCursor: nc, isLast: last } = res.data;
-
-          setRooms(roomList);
-          setNextCursor(nc);
-          setIsLast(last);
-        } else {
-          setError(res.message || '검색 실패');
-        }
-      } catch {
-        setError('네트워크 오류가 발생했습니다.');
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [],
-  );
-
   useEffect(() => {
     if (location.state?.allRooms) {
       navigate(location.pathname, { replace: true });
@@ -130,10 +81,7 @@ const GroupSearch = () => {
     const trimmed = value.trim();
     if (!trimmed) {
       setSearchStatus('idle');
-      setRooms([]);
-      setError(null);
-      setNextCursor(null);
-      setIsLast(true);
+      setDebouncedSearchTerm('');
       setShowTabs(false);
       setSearchTimeoutId(null);
       return;
@@ -141,9 +89,7 @@ const GroupSearch = () => {
 
     setSearchStatus('searching');
     setShowTabs(false);
-    const id = setTimeout(() => {
-      searchFirstPage(trimmed, toSortKey(selectedFilter), 'searching', category);
-    }, 300);
+    const id = setTimeout(() => setDebouncedSearchTerm(trimmed), 300);
     setSearchTimeoutId(id);
   };
 
@@ -175,98 +121,51 @@ const GroupSearch = () => {
       setSearchTimeoutId(null);
     }
     setSearchTerm('');
+    setDebouncedSearchTerm('');
     setSearchStatus('searched');
     setShowTabs(true);
     setCategory('');
   };
 
-  const searchStatusRef = useRef(searchStatus);
-  const categoryRef = useRef(category);
-  const selectedFilterRef = useRef(selectedFilter);
-  const searchTermRef = useRef(searchTerm);
-
   useEffect(() => {
-    searchStatusRef.current = searchStatus;
-    categoryRef.current = category;
-    selectedFilterRef.current = selectedFilter;
-    searchTermRef.current = searchTerm;
-  });
-
-  useEffect(() => {
-    if (searchStatus !== 'searched') return;
-
-    const term = searchTerm.trim();
-    const isAllCategory = !term && category === '';
-
-    searchFirstPage(term, toSortKey(selectedFilter), 'searched', category, isAllCategory);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedFilter, category, searchStatus, searchTerm]);
-
-  useEffect(() => {
-    const term = searchTerm.trim();
-    if (!term || searchStatus !== 'searching') return;
-
-    if (searchTimeoutId) {
-      clearTimeout(searchTimeoutId);
-      setSearchTimeoutId(null);
+    if (searchStatus === 'searched') {
+      setDebouncedSearchTerm(searchTerm.trim());
     }
+  }, [searchStatus, searchTerm]);
 
-    const id = setTimeout(() => {
-      const currentCategory = categoryRef.current;
-      searchFirstPage(term, toSortKey(selectedFilter), 'searching', currentCategory);
-    }, 300);
-    setSearchTimeoutId(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchTerm, searchStatus, selectedFilter]);
-
-  const loadMore = useCallback(async () => {
-    const trimmedTerm = searchTerm.trim();
-    const isAllCategory = !trimmedTerm && category === '';
-    if ((!isAllCategory && !trimmedTerm) || !nextCursor || isLast || isLoadingMore) return;
-    try {
-      setIsLoadingMore(true);
+  const queryTerm = searchStatus === 'searching' ? debouncedSearchTerm : searchTerm.trim();
+  const searchResult = useInifinieScroll({
+    enabled: searchStatus !== 'idle' && (searchStatus === 'searched' || queryTerm.length > 0),
+    reloadKey: `${searchStatus}-${queryTerm}-${selectedFilter}-${category}`,
+    fetchPage: async cursor => {
       const isFinalized = searchStatus === 'searched';
+      const isAllCategory = !queryTerm && category === '';
+      if (searchStatus === 'searching' && !queryTerm) {
+        return { items: [], nextCursor: null, isLast: true };
+      }
+
       const res = await getSearchRooms(
-        trimmedTerm,
+        queryTerm,
         toSortKey(selectedFilter),
-        nextCursor,
+        cursor ?? undefined,
         isFinalized,
         category,
         isAllCategory,
       );
-      if (res.isSuccess) {
-        const { roomList, nextCursor: nc, isLast: last } = res.data;
 
-        setRooms(prev => [...prev, ...roomList]);
-        setNextCursor(nc);
-        setIsLast(last);
-      } else {
-        setIsLast(true);
+      if (!res.isSuccess) {
+        throw new Error(res.message || '검색 실패');
       }
-    } catch {
-      setIsLast(true);
-    } finally {
-      setIsLoadingMore(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchTerm, nextCursor, isLast, isLoadingMore, selectedFilter, searchStatus, category]);
 
-  const lastRoomElementCallback = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (isLoadingMore || isLast) return;
-
-      if (observerRef.current) observerRef.current.disconnect();
-
-      observerRef.current = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting && !isLoadingMore && !isLast) {
-          loadMore();
-        }
-      });
-
-      if (node) observerRef.current.observe(node);
+      return {
+        items: res.data.roomList,
+        nextCursor: res.data.nextCursor,
+        isLast: res.data.isLast,
+      };
     },
-    [isLoadingMore, isLast, loadMore],
-  );
+    rootMargin: '100px 0px',
+    threshold: 0.1,
+  });
 
   const handleBackButton = () => {
     if (searchTimeoutId) {
@@ -278,11 +177,8 @@ const GroupSearch = () => {
 
     if (!isIdleView) {
       setSearchTerm('');
+      setDebouncedSearchTerm('');
       setSearchStatus('idle');
-      setRooms([]);
-      setNextCursor(null);
-      setIsLast(true);
-      setError(null);
       setShowTabs(false);
       return;
     }
@@ -297,7 +193,6 @@ const GroupSearch = () => {
   useEffect(() => {
     return () => {
       if (searchTimeoutId) clearTimeout(searchTimeoutId);
-      if (observerRef.current) observerRef.current.disconnect();
     };
   }, [searchTimeoutId]);
 
@@ -320,18 +215,20 @@ const GroupSearch = () => {
 
         {searchStatus !== 'idle' ? (
           <>
-            {isLoading && rooms.length === 0 ? (
-              <LoadingMessage>검색 중...</LoadingMessage>
+            {searchResult.isLoading && searchResult.items.length === 0 ? (
+              <LoadingMessage>
+                <LoadingSpinner size="small" fullHeight={false} />
+              </LoadingMessage>
             ) : (
               <GroupSearchResult
                 type={searchStatus}
                 showTabs={showTabs}
-                rooms={rooms}
-                isLoading={isLoading}
-                isLoadingMore={isLoadingMore}
-                hasMore={!isLast}
-                lastRoomElementCallback={lastRoomElementCallback}
-                error={error}
+                rooms={searchResult.items}
+                isLoading={searchResult.isLoading}
+                isLoadingMore={searchResult.isLoadingMore}
+                hasMore={!searchResult.isLast}
+                sentinelRef={searchResult.sentinelRef}
+                error={searchResult.error}
                 selectedFilter={selectedFilter}
                 setSelectedFilter={setSelectedFilter}
                 onChangeCategory={setCategory}

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import type { SortType } from '../../components/memory/SortDropdown';
 import MemoryHeader from '../../components/memory/MemoryHeader/MemoryHeader';
@@ -6,7 +6,9 @@ import MemoryContent from '../../components/memory/MemoryContent/MemoryContent';
 import MemoryAddButton from '../../components/memory/MemoryAddButton/MemoryAddButton';
 import Snackbar from '../../components/common/Modal/Snackbar';
 import GlobalCommentBottomSheet from '../../components/common/CommentBottomSheet/GlobalCommentBottomSheet';
+import LoadingSpinner from '../../components/common/LoadingSpinner';
 import { useCommentBottomSheetStore } from '@/stores/commentBottomSheetStore';
+import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 import { Container, FixedHeader, ScrollableContent, FloatingElements } from './Memory.styled';
 import { getMemoryPosts } from '../../api/memory/getMemoryPosts';
 import { getRoomPlaying } from '../../api/rooms/getRoomPlaying';
@@ -79,27 +81,27 @@ const Memory = () => {
     }
   }, [location.search]);
 
-  const [error, setError] = useState<string | null>(null);
-
   const [showUploadProgress, setShowUploadProgress] = useState(false);
 
   const [roomCompleted, setRoomCompleted] = useState(false);
 
-  const [myRecords, setMyRecords] = useState<Record[]>([]);
-  const [groupRecords, setGroupRecords] = useState<Record[]>([]);
   const [totalPages, setTotalPages] = useState<number>(0);
   const [currentUserPage, setCurrentUserPage] = useState<number>(0);
+  const scrollRootRef = useRef<HTMLDivElement | null>(null);
 
-  const loadMemoryPosts = useCallback(async () => {
-    if (!roomId) {
-      return;
-    }
-    setError(null);
+  const recordsList = useInifinieScroll<Record>({
+    enabled: !!roomId,
+    reloadKey: `${roomId}-${activeTab}-${selectedSort}-${activeFilter}-${selectedPageRange?.start ?? ''}-${selectedPageRange?.end ?? ''}`,
+    rootRef: scrollRootRef,
+    fetchPage: async cursor => {
+      if (!roomId) {
+        return { items: [], nextCursor: null, isLast: true };
+      }
 
-    try {
       const params: GetMemoryPostsParams = {
-        roomId: parseInt(roomId),
+        roomId: parseInt(roomId, 10),
         type: activeTab === 'group' ? 'group' : 'mine',
+        cursor,
       };
 
       if (activeTab === 'group') {
@@ -114,14 +116,11 @@ const Memory = () => {
         params.isPageFilter = true;
       }
 
-      const response = await getMemoryPosts(params);
-      if (response.isSuccess) {
-        const convertedRecords = response.data.postList.map(convertPostToRecord);
+      try {
+        const response = await getMemoryPosts(params);
 
-        if (activeTab === 'group') {
-          setGroupRecords(convertedRecords);
-        } else {
-          setMyRecords(convertedRecords);
+        if (!response.isSuccess) {
+          throw new Error(response.message || '기록을 불러오는 중 오류가 발생했습니다.');
         }
 
         if (response.data.totalPages !== undefined) {
@@ -130,22 +129,27 @@ const Memory = () => {
         if (response.data.currentUserPage !== undefined) {
           setCurrentUserPage(response.data.currentUserPage);
         }
-      } else {
-        setError(response.message);
-      }
-    } catch (error) {
-      if (error && typeof error === 'object' && 'response' in error) {
-        const axiosError = error as { response?: { data?: { code?: number } } };
-        if (axiosError.response?.data?.code === 40002) {
-          setError('독서 진행률이 80% 이상이어야 총평을 볼 수 있습니다.');
-          setActiveFilter(null);
-          return;
-        }
-      }
 
-      setError('기록을 불러오는 중 오류가 발생했습니다.');
-    }
-  }, [roomId, activeTab, selectedSort, activeFilter, selectedPageRange]);
+        return {
+          items: response.data.postList.map(convertPostToRecord),
+          nextCursor: response.data.nextCursor,
+          isLast: response.data.isLast,
+        };
+      } catch (error) {
+        if (error && typeof error === 'object' && 'response' in error) {
+          const axiosError = error as { response?: { data?: { code?: number } } };
+          if (axiosError.response?.data?.code === 40002) {
+            setActiveFilter(null);
+            throw new Error('독서 진행률이 80% 이상이어야 총평을 볼 수 있습니다.');
+          }
+        }
+        throw new Error('기록을 불러오는 중 오류가 발생했습니다.');
+      }
+    },
+    rootMargin: '100px 0px',
+    threshold: 0.1,
+  });
+  const { setItems: setRecordItems } = recordsList;
 
   useEffect(() => {
     const checkRoomStatus = async () => {
@@ -164,10 +168,6 @@ const Memory = () => {
 
     checkRoomStatus();
   }, [roomId]);
-
-  useEffect(() => {
-    loadMemoryPosts();
-  }, [loadMemoryPosts]);
 
   useEffect(() => {
     type MemoryLocationState = {
@@ -194,20 +194,13 @@ const Memory = () => {
     if (location.state?.newRecord) {
       const newRecord = location.state.newRecord as Record;
       setShowUploadProgress(true);
-
-      if (activeTab === 'group') {
-        setGroupRecords(prev => [newRecord, ...prev]);
-      } else {
-        setMyRecords(prev => [newRecord, ...prev]);
-      }
+      setRecordItems(prev => [newRecord, ...prev]);
 
       navigate(location.pathname, { replace: true });
     }
-  }, [location.state, activeTab, navigate, location.pathname]);
+  }, [location.state, navigate, location.pathname, setRecordItems]);
 
-  const currentRecords = useMemo(() => {
-    return activeTab === 'group' ? groupRecords : myRecords;
-  }, [activeTab, groupRecords, myRecords]);
+  const currentRecords = useMemo(() => recordsList.items, [recordsList.items]);
 
   const sortedRecords = useMemo(() => {
     return currentRecords;
@@ -278,15 +271,15 @@ const Memory = () => {
 
   const readingProgress = totalPages > 0 ? Math.round((currentUserPage / totalPages) * 100) : 0;
 
-  if (error) {
+  if (recordsList.error) {
     return (
       <Container>
         <FixedHeader>
           <MemoryHeader onBackClick={handleBackClick} />
         </FixedHeader>
         <div style={{ padding: '20px', textAlign: 'center', color: 'red' }}>
-          오류가 발생했습니다: {error}
-          <button onClick={loadMemoryPosts} style={{ marginLeft: '10px' }}>
+          오류가 발생했습니다: {recordsList.error}
+          <button onClick={() => recordsList.reload()} style={{ marginLeft: '10px' }}>
             다시 시도
           </button>
         </div>
@@ -300,7 +293,7 @@ const Memory = () => {
         <MemoryHeader onBackClick={handleBackClick} />
       </FixedHeader>
 
-      <ScrollableContent>
+      <ScrollableContent ref={scrollRootRef}>
         <MemoryContent
           activeTab={activeTab}
           activeFilter={activeFilter}
@@ -316,6 +309,8 @@ const Memory = () => {
           onPageRangeSet={handlePageRangeSet}
           onUploadComplete={handleUploadComplete}
         />
+        {!recordsList.isLast && <div ref={recordsList.sentinelRef} style={{ height: 20 }} />}
+        {recordsList.isLoadingMore && <LoadingSpinner size="small" fullHeight={false} />}
       </ScrollableContent>
 
       {!roomCompleted && (

--- a/src/pages/mypage/SavePage.tsx
+++ b/src/pages/mypage/SavePage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import TitleHeader from '../../components/common/TitleHeader';
 import TabBar from '@/components/feed/TabBar';
 import FeedPost from '@/components/feed/FeedPost';
@@ -9,6 +9,7 @@ import activeSave from '../../assets/feed/activeSave.svg';
 import { getSavedBooksInMy, type SavedBookInMy } from '@/api/books/getSavedBooksInMy';
 import { getSavedFeedsInMy, type SavedFeedInMy } from '@/api/feeds/getSavedFeedsInMy';
 import { postSaveBook } from '@/api/books/postSaveBook';
+import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import {
   Wrapper,
@@ -30,171 +31,77 @@ const SavePage = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState(tabs[0]);
 
-  const [savedFeeds, setSavedFeeds] = useState<SavedFeedInMy[]>([]);
-  const [feedNextCursor, setFeedNextCursor] = useState<string | null>(null);
-  const [feedIsLast, setFeedIsLast] = useState(false);
-  const [feedLoading, setFeedLoading] = useState(false);
+  const savedFeeds = useInifinieScroll<SavedFeedInMy>({
+    enabled: activeTab === '피드',
+    reloadKey: activeTab,
+    fetchPage: async cursor => {
+      const response = await getSavedFeedsInMy(cursor);
+      return {
+        items: response.data.feedList,
+        nextCursor: response.data.nextCursor || null,
+        isLast: response.data.isLast,
+      };
+    },
+    rootMargin: '100px 0px',
+    threshold: 0.1,
+  });
 
-  const [savedBooks, setSavedBooks] = useState<SavedBookInMy[]>([]);
-  const [bookNextCursor, setBookNextCursor] = useState<string | null>(null);
-  const [bookIsLast, setBookIsLast] = useState(false);
-  const [bookLoading, setBookLoading] = useState(false);
-
-  const [initialLoading, setInitialLoading] = useState(true);
-
-  const feedObserverRef = useRef<HTMLDivElement>(null);
-  const bookObserverRef = useRef<HTMLDivElement>(null);
+  const savedBooks = useInifinieScroll<SavedBookInMy>({
+    enabled: activeTab === '책',
+    reloadKey: activeTab,
+    fetchPage: async cursor => {
+      const response = await getSavedBooksInMy(cursor);
+      return {
+        items: response.data.bookList,
+        nextCursor: response.data.nextCursor || null,
+        isLast: response.data.isLast,
+      };
+    },
+    rootMargin: '100px 0px',
+    threshold: 0.1,
+  });
 
   const handleBack = () => {
     navigate('/mypage');
   };
-
-  const loadSavedBooks = useCallback(async (cursor: string | null = null) => {
-    try {
-      setBookLoading(true);
-      const response = await getSavedBooksInMy(cursor);
-
-      if (cursor === null) {
-        setSavedBooks(response.data.bookList);
-      } else {
-        setSavedBooks(prev => [...prev, ...response.data.bookList]);
-      }
-
-      setBookNextCursor(response.data.nextCursor);
-      setBookIsLast(response.data.isLast);
-    } catch (error) {
-      console.error('저장된 책 목록 로드 실패:', error);
-    } finally {
-      setBookLoading(false);
-    }
-  }, []);
-
-  const loadSavedFeeds = useCallback(async (cursor: string | null = null) => {
-    try {
-      setFeedLoading(true);
-      const response = await getSavedFeedsInMy(cursor);
-
-      if (cursor === null) {
-        setSavedFeeds(response.data.feedList);
-      } else {
-        setSavedFeeds(prev => [...prev, ...response.data.feedList]);
-      }
-
-      setFeedNextCursor(response.data.nextCursor);
-      setFeedIsLast(response.data.isLast);
-    } catch (error) {
-      console.error('저장된 피드 로드 실패:', error);
-    } finally {
-      setFeedLoading(false);
-    }
-  }, []);
-
-  const loadMoreBooks = useCallback(async () => {
-    if (!bookNextCursor || bookIsLast || bookLoading) return;
-
-    try {
-      await loadSavedBooks(bookNextCursor);
-    } catch (error) {
-      console.error('책 추가 로드 실패:', error);
-    }
-  }, [bookNextCursor, bookIsLast, bookLoading, loadSavedBooks]);
-
-  const lastBookElementCallback = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (bookLoading || bookIsLast) return;
-
-      if (node) {
-        const observer = new IntersectionObserver(entries => {
-          if (entries[0].isIntersecting && !bookLoading && !bookIsLast) {
-            loadMoreBooks();
-          }
-        });
-
-        observer.observe(node);
-      }
-    },
-    [bookLoading, bookIsLast, loadMoreBooks],
-  );
-
-  useEffect(() => {
-    const loadAllData = async () => {
-      try {
-        setInitialLoading(true);
-
-        const [feedsResponse, booksResponse] = await Promise.all([
-          getSavedFeedsInMy(null),
-          getSavedBooksInMy(),
-        ]);
-
-        setSavedFeeds(feedsResponse.data.feedList);
-        setFeedNextCursor(feedsResponse.data.nextCursor);
-        setFeedIsLast(feedsResponse.data.isLast);
-
-        setSavedBooks(booksResponse.data.bookList);
-        setBookNextCursor(booksResponse.data.nextCursor);
-        setBookIsLast(booksResponse.data.isLast);
-      } catch (error) {
-        console.error('초기 데이터 로드 실패:', error);
-      } finally {
-        setInitialLoading(false);
-      }
-    };
-
-    loadAllData();
-  }, []);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      entries => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting && !feedIsLast && !feedLoading && feedNextCursor) {
-            loadSavedFeeds(feedNextCursor);
-          }
-        });
-      },
-      { threshold: 0.1 },
-    );
-
-    if (feedObserverRef.current) {
-      observer.observe(feedObserverRef.current);
-    }
-
-    return () => observer.disconnect();
-  }, [feedIsLast, feedLoading, feedNextCursor, loadSavedFeeds]);
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [activeTab]);
 
   const handleSaveToggle = async (isbn: string) => {
+    const currentBook = savedBooks.items.find(book => book.isbn === isbn);
+    if (!currentBook) return;
+
+    const nextSaved = !currentBook.isSaved;
+    const previousBooks = savedBooks.items;
+
+    if (!nextSaved) {
+      savedBooks.setItems(prev => prev.filter(book => book.isbn !== isbn));
+    } else {
+      savedBooks.setItems(prev =>
+        prev.map(book => (book.isbn === isbn ? { ...book, isSaved: nextSaved } : book)),
+      );
+    }
+
     try {
-      const currentBook = savedBooks.find(book => book.isbn === isbn);
-      if (!currentBook) return;
-
-      const newSaveState = !currentBook.isSaved;
-      await postSaveBook(isbn, newSaveState);
-
-      if (!newSaveState) {
-        await loadSavedBooks();
-      } else {
-        setSavedBooks(prev =>
-          prev.map(book => (book.isbn === isbn ? { ...book, isSaved: newSaveState } : book)),
-        );
+      const response = await postSaveBook(isbn, nextSaved);
+      if (!response.isSuccess) {
+        savedBooks.setItems(previousBooks);
       }
-    } catch (error) {
-      console.error('저장 토글 실패:', error);
+    } catch {
+      savedBooks.setItems(previousBooks);
     }
   };
 
-  const handleFeedSaveToggle = async (feedId: number, newSaveState: boolean) => {
-    try {
-      if (!newSaveState) {
-        setSavedFeeds(prev => prev.filter(feed => feed.feedId !== feedId));
-      }
-    } catch (error) {
-      console.error('피드 저장 상태 변경 실패:', error);
+  const handleFeedSaveToggle = (feedId: number, newSaveState: boolean) => {
+    if (!newSaveState) {
+      savedFeeds.setItems(prev => prev.filter(feed => feed.feedId !== feedId));
     }
   };
+
+  const currentList = activeTab === '피드' ? savedFeeds : savedBooks;
+  const showInitialLoading = currentList.isLoading && currentList.items.length === 0;
 
   return (
     <Wrapper>
@@ -204,28 +111,24 @@ const SavePage = () => {
         title="저장"
       />
       <TabBar tabs={tabs} activeTab={activeTab} onTabClick={setActiveTab} />
-      {initialLoading ? (
+      {showInitialLoading ? (
         <LoadingSpinner fullHeight={true} size="large" />
       ) : activeTab === '피드' ? (
         <>
-          {savedFeeds.length > 0 ? (
+          {savedFeeds.items.length > 0 ? (
             <FeedContainer>
-              {savedFeeds.map((feed, index) => (
+              {savedFeeds.items.map((feed, index) => (
                 <FeedPost
                   key={feed.feedId}
                   showHeader={true}
                   isMyFeed={false}
-                  isLast={index === savedFeeds.length - 1}
+                  isLast={index === savedFeeds.items.length - 1}
                   onSaveToggle={handleFeedSaveToggle}
                   {...feed}
                 />
               ))}
-              {/* 무한스크롤을 위한 observer 요소 */}
-              {!feedIsLast && (
-                <div ref={feedObserverRef} style={{ height: '20px' }}>
-                  {feedLoading && <LoadingSpinner fullHeight={false} size="small" />}
-                </div>
-              )}
+              {!savedFeeds.isLast && <div ref={savedFeeds.sentinelRef} style={{ height: 20 }} />}
+              {savedFeeds.isLoadingMore && <LoadingSpinner fullHeight={false} size="small" />}
             </FeedContainer>
           ) : (
             <EmptyState>
@@ -234,39 +137,27 @@ const SavePage = () => {
             </EmptyState>
           )}
         </>
-      ) : savedBooks.length > 0 ? (
-        <>
-          <BookList>
-            {savedBooks.map((book, index) => (
-              <BookItem
-                key={book.bookId}
-                ref={index === savedBooks.length - 1 ? lastBookElementCallback : null}
-              >
-                <LeftSection>
-                  <Cover src={book.bookImageUrl} alt={`${book.bookTitle} 커버`} />
-                  <BookInfo>
-                    <Title>{book.bookTitle}</Title>
-                    <Subtitle>
-                      {book.authorName} 저 · {book.publisher}
-                    </Subtitle>
-                  </BookInfo>
-                </LeftSection>
-                <SaveIcon onClick={() => handleSaveToggle(book.isbn)}>
-                  <img
-                    src={book.isSaved ? activeSave : save}
-                    alt={book.isSaved ? '저장됨' : '저장'}
-                  />
-                </SaveIcon>
-              </BookItem>
-            ))}
-            {/* 무한스크롤을 위한 observer 요소 */}
-            {!bookIsLast && (
-              <div ref={bookObserverRef} style={{ height: '20px' }}>
-                {bookLoading && <LoadingSpinner fullHeight={false} size="small" />}
-              </div>
-            )}
-          </BookList>
-        </>
+      ) : savedBooks.items.length > 0 ? (
+        <BookList>
+          {savedBooks.items.map(book => (
+            <BookItem key={book.bookId}>
+              <LeftSection>
+                <Cover src={book.bookImageUrl} alt={`${book.bookTitle} 커버`} />
+                <BookInfo>
+                  <Title>{book.bookTitle}</Title>
+                  <Subtitle>
+                    {book.authorName} 저 · {book.publisher}
+                  </Subtitle>
+                </BookInfo>
+              </LeftSection>
+              <SaveIcon onClick={() => handleSaveToggle(book.isbn)}>
+                <img src={book.isSaved ? activeSave : save} alt={book.isSaved ? '저장됨' : '저장'} />
+              </SaveIcon>
+            </BookItem>
+          ))}
+          {!savedBooks.isLast && <div ref={savedBooks.sentinelRef} style={{ height: 20 }} />}
+          {savedBooks.isLoadingMore && <LoadingSpinner fullHeight={false} size="small" />}
+        </BookList>
       ) : (
         <EmptyState>
           <div className="title">아직 저장한 책이 없어요</div>

--- a/src/pages/notice/Notice.tsx
+++ b/src/pages/notice/Notice.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import TitleHeader from '@/components/common/TitleHeader';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import { getNotifications, type NotificationItem } from '@/api/notifications/getNotifications';
 import { postNotificationsCheck } from '@/api/notifications/postNotificationsCheck';
+import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 import {
   Wrapper,
   TabContainer,
@@ -22,12 +23,6 @@ import {
 
 const Notice = () => {
   const [selected, setSelected] = useState<string>('');
-  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [isLast, setIsLast] = useState<boolean>(true);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const isLoadingRef = useRef<boolean>(false);
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
 
   const handleBackButton = () => {
@@ -38,60 +33,23 @@ const Notice = () => {
     setSelected(prev => (prev === tab ? '' : tab));
   };
 
-  const loadNotifications = useCallback(
-    async (cursor?: string | null) => {
-      try {
-        if (isLoadingRef.current) return;
-        isLoadingRef.current = true;
-        setIsLoading(true);
-        const params: { cursor?: string | null; type?: 'feed' | 'room' } = { cursor };
-        if (selected === '피드') params.type = 'feed';
-        if (selected === '모임') params.type = 'room';
-
-        const res = await getNotifications(params);
-        if (res.isSuccess) {
-          setNotifications(prev =>
-            cursor ? [...prev, ...res.data.notifications] : res.data.notifications,
-          );
-          setNextCursor(res.data.nextCursor || null);
-          setIsLast(res.data.isLast);
-        }
-      } finally {
-        setIsLoading(false);
-        isLoadingRef.current = false;
-      }
+  const notificationList = useInifinieScroll<NotificationItem>({
+    enabled: true,
+    reloadKey: selected,
+    fetchPage: async cursor => {
+      const params: { cursor?: string | null; type?: 'feed' | 'room' } = { cursor };
+      if (selected === '피드') params.type = 'feed';
+      if (selected === '모임') params.type = 'room';
+      const res = await getNotifications(params);
+      return {
+        items: res.data.notifications,
+        nextCursor: res.data.nextCursor || null,
+        isLast: res.data.isLast,
+      };
     },
-    [selected],
-  );
-
-  useEffect(() => {
-    setNotifications([]);
-    setNextCursor(null);
-    setIsLast(false);
-    void loadNotifications(null);
-  }, [selected, loadNotifications]);
-
-  useEffect(() => {
-    if (!sentinelRef.current) return;
-    const el = sentinelRef.current;
-    const observer = new IntersectionObserver(
-      entries => {
-        const entry = entries[0];
-        if (entry.isIntersecting && !isLoading && !isLast && nextCursor !== null) {
-          void loadNotifications(nextCursor);
-        }
-      },
-      { root: null, rootMargin: '0px', threshold: 0.1 },
-    );
-
-    observer.observe(el);
-    return () => {
-      observer.unobserve(el);
-      observer.disconnect();
-    };
-  }, [isLoading, isLast, nextCursor, loadNotifications]);
-
-  const filteredNotifications = notifications;
+    rootMargin: '100px 0px',
+    threshold: 0.1,
+  });
 
   const tabs = ['피드', '모임'];
 
@@ -178,10 +136,10 @@ const Notice = () => {
       </TabContainer>
 
       <NotificationList>
-        {filteredNotifications.length === 0 ? (
+        {notificationList.items.length === 0 && !notificationList.isLoading ? (
           <EmptyState>새로운 알림이 없어요</EmptyState>
         ) : (
-          filteredNotifications.map((notif, idx) => (
+          notificationList.items.map((notif, idx) => (
             <NotificationCard
               key={notif.notificationId ?? idx}
               read={notif.isChecked}
@@ -199,7 +157,7 @@ const Notice = () => {
         )}
       </NotificationList>
 
-      <Sentinel ref={sentinelRef} />
+      {!notificationList.isLast && <Sentinel ref={notificationList.sentinelRef} />}
     </Wrapper>
   );
 };

--- a/src/pages/searchBook/SearchBook.tsx
+++ b/src/pages/searchBook/SearchBook.tsx
@@ -30,7 +30,7 @@ import saveIcon from '../../assets/common/SaveIcon.svg';
 import filledSaveIcon from '../../assets/common/filledSaveIcon.svg';
 import rightChevron from '../../assets/common/right-Chevron.svg';
 import plusIcon from '../../assets/common/plus.svg';
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { IntroModal } from '@/components/search/IntroModal';
 import { getBookDetail, type BookDetail } from '@/api/books/getBookDetail';
 import { getRecruitingRooms, type RecruitingRoomsData } from '@/api/books/getRecruitingRooms';
@@ -41,6 +41,7 @@ import { getFeedsByIsbn, type FeedItem, type FeedSort } from '@/api/feeds/getFee
 import { usePopupStore } from '@/stores/popupStore';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { usePreventDoubleClick } from '@/hooks/usePreventDoubleClick';
+import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 
 const FILTER = ['최신순', '인기순'] as const;
 const toFeedSort = (f: (typeof FILTER)[number]): FeedSort => (f === '최신순' ? 'latest' : 'like');
@@ -61,13 +62,6 @@ const SearchBook = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [feeds, setFeeds] = useState<FeedItem[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [isLast, setIsLast] = useState(true);
-  const [isLoadingFeeds, setIsLoadingFeeds] = useState(false);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-
-  const observerRef = useRef<IntersectionObserver | null>(null);
   const openPopup = usePopupStore(state => state.openPopup);
 
   useEffect(() => {
@@ -108,63 +102,20 @@ const SearchBook = () => {
     fetchBookDetail();
   }, [isbn]);
 
-  const loadFirstFeeds = useCallback(async () => {
-    if (!isbn) return;
-    try {
-      setIsLoadingFeeds(true);
-      setFeeds([]);
-      setNextCursor(null);
-      setIsLast(true);
-
-      const res = await getFeedsByIsbn(isbn, toFeedSort(selectedFilter), null);
-      if (res.isSuccess) {
-        setFeeds(res.data.feeds);
-        setNextCursor(res.data.nextCursor);
-        setIsLast(res.data.isLast);
-      }
-    } catch {
-      // no-op
-    } finally {
-      setIsLoadingFeeds(false);
-    }
-  }, [isbn, selectedFilter]);
-
-  useEffect(() => {
-    loadFirstFeeds();
-  }, [loadFirstFeeds]);
-
-  const loadMore = useCallback(async () => {
-    if (!isbn || !nextCursor || isLast || isLoadingMore) return;
-    try {
-      setIsLoadingMore(true);
-      const res = await getFeedsByIsbn(isbn, toFeedSort(selectedFilter), nextCursor);
-      if (res.isSuccess) {
-        setFeeds(prev => [...prev, ...res.data.feeds]);
-        setNextCursor(res.data.nextCursor);
-        setIsLast(res.data.isLast);
-      }
-    } catch {
-      // no-op
-    } finally {
-      setIsLoadingMore(false);
-    }
-  }, [isbn, nextCursor, isLast, isLoadingMore, selectedFilter]);
-
-  const lastFeedElementCallback = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (isLoadingMore || isLast) return;
-
-      if (observerRef.current) observerRef.current.disconnect();
-
-      observerRef.current = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting && !isLoadingMore && !isLast) {
-          loadMore();
-        }
-      });
-      if (node) observerRef.current.observe(node);
+  const feeds = useInifinieScroll<FeedItem>({
+    enabled: !!isbn,
+    reloadKey: `${isbn ?? ''}-${selectedFilter}`,
+    fetchPage: async cursor => {
+      const res = await getFeedsByIsbn(isbn!, toFeedSort(selectedFilter), cursor);
+      return {
+        items: res.data.feeds,
+        nextCursor: res.data.nextCursor || null,
+        isLast: res.data.isLast,
+      };
     },
-    [isLoadingMore, isLast, loadMore],
-  );
+    rootMargin: '100px 0px',
+    threshold: 0.1,
+  });
 
   const handleBackButton = () => navigate(-1);
   const handleIntroClick = () => setShowIntroModal(true);
@@ -303,15 +254,12 @@ const SearchBook = () => {
             setSelectedFilter={filter => setSelectedFilter(filter as (typeof FILTER)[number])}
           />
         </FilterContainer>
-        {isLoadingFeeds && feeds.length === 0 ? (
+        {feeds.isLoading && feeds.items.length === 0 ? (
           <LoadingBox>불러오는 중...</LoadingBox>
-        ) : feeds.length > 0 ? (
+        ) : feeds.items.length > 0 ? (
           <FeedPostContainer>
-            {feeds.map((post, idx) => (
-              <div
-                key={post.feedId}
-                ref={idx === feeds.length - 1 ? el => lastFeedElementCallback(el) : undefined}
-              >
+            {feeds.items.map(post => (
+              <div key={post.feedId}>
                 <FeedPost
                   showHeader={true}
                   isMyFeed={false}
@@ -332,6 +280,8 @@ const SearchBook = () => {
                 />
               </div>
             ))}
+            {!feeds.isLast && <div ref={feeds.sentinelRef} style={{ height: 20 }} />}
+            {feeds.isLoadingMore && <LoadingBox>불러오는 중...</LoadingBox>}
           </FeedPostContainer>
         ) : (
           <EmptyState>


### PR DESCRIPTION
## **📝작업 내용**

- 무한스크롤 로직을 useInifinieScroll 공통 훅 기반으로 통일했습니다.
- 기존 페이지별 수동 구현(스크롤 이벤트, 개별 observer, nextCursor/isLast 상태 관리)을 제거하고, fetchPage + reloadKey + sentinelRef 패턴으로 정리했습니다.
- 내부 스크롤 컨테이너에서도 감지되도록 훅에 rootRef 옵션을 추가했습니다.
- 하단 로딩 UI를 텍스트 대신 공통 LoadingSpinner로 통일했습니다.
- 댓글 영역(FeedDetailPage)은 ReplyList 내부에서 직접 커서 기반 무한스크롤을 수행하도록 구조를 변경했습니다.
- 리팩토링 과정에서 발견된 CSS 이슈를 보완했습니다.
  - 긴 영문 연속 텍스트가 한 줄로만 보이던 문제 해결
  - 데스크탑에서도 모바일 화면에서의 댓글 모달의 스크롤바 스타일을 적용
  - 댓글 모달의 불필요한 하단 여백 삭제

## **적용 파일**

- src/hooks/useInifinieScroll.ts
- src/pages/feed/Feed.tsx
- src/pages/feed/FollowerListPage.tsx
- src/pages/searchBook/SearchBook.tsx
- src/pages/notice/Notice.tsx
- src/pages/mypage/SavePage.tsx
- src/pages/memory/Memory.tsx
- src/components/group/MyGroupModal.tsx
- src/pages/groupSearch/GroupSearch.tsx
- src/components/search/GroupSearchResult.tsx
- src/components/search/GroupSearchResult.styled.ts
- src/pages/feed/FeedDetailPage.tsx
- src/components/common/Post/ReplyList.tsx
- src/components/common/Post/ReplyList.tsx

### 위키
[위키](https://github.com/THIP-TextHip/THIP-Web/wiki/%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%EB%AC%B4%ED%95%9C%EC%8A%A4%ED%81%AC%EB%A1%A4-%EA%B3%B5%ED%86%B5-%ED%9B%85-%EB%8F%84%EC%9E%85-%EB%B0%8F-%EC%95%88%EC%A0%95%EC%84%B1-%EA%B0%9C%EC%84%A0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 무한 스크롤 기능 추가: 피드, 그룹, 알림 목록 등에서 자동으로 더 많은 콘텐츠 로드
  * 댓글 및 답글의 동적 로딩: 필요할 때만 데이터를 불러오는 방식으로 개선

* **개선 사항**
  * 스크롤 시 로딩 상태 표시 개선
  * 텍스트 줄바꿈 처리 향상
  * 스크롤바 스타일 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->