### PR TITLE
refactor-record: 기록 삭제 후 페이지 새로고침 제거 및 페이지별 보기 입력창 버그 수정

### DIFF
--- a/src/components/memory/MemoryContent/MemoryContent.tsx
+++ b/src/components/memory/MemoryContent/MemoryContent.tsx
@@ -23,6 +23,7 @@ interface MemoryContentProps {
   onPageRangeClear: () => void;
   onPageRangeSet: (range: { start: number; end: number }) => void;
   onUploadComplete: () => void;
+  onDelete?: (id: string) => void;
 }
 
 const MemoryContent = ({
@@ -39,6 +40,7 @@ const MemoryContent = ({
   onPageRangeClear,
   onPageRangeSet,
   onUploadComplete,
+  onDelete,
 }: MemoryContentProps) => {
   return (
     <Content>
@@ -66,7 +68,7 @@ const MemoryContent = ({
 
         {records.length === 0 && <EmptyRecord type={activeTab} />}
 
-        {records.length > 0 && <RecordList records={records} />}
+        {records.length > 0 && <RecordList records={records} onDelete={onDelete} />}
       </ScrollableSection>
     </Content>
   );

--- a/src/components/memory/MemoryContent/RecordList.tsx
+++ b/src/components/memory/MemoryContent/RecordList.tsx
@@ -4,13 +4,14 @@ import { RecordListContainer } from './RecordList.styled';
 
 interface RecordListProps {
   records: Record[];
+  onDelete?: (id: string) => void;
 }
 
-const RecordList = ({ records }: RecordListProps) => {
+const RecordList = ({ records, onDelete }: RecordListProps) => {
   return (
     <RecordListContainer>
       {records.map(record => (
-        <RecordItem key={record.id} record={record} shouldBlur={record.isLocked} />
+        <RecordItem key={record.id} record={record} shouldBlur={record.isLocked} onDelete={onDelete} />
       ))}
     </RecordListContainer>
   );

--- a/src/components/memory/RecordItem/RecordItem.tsx
+++ b/src/components/memory/RecordItem/RecordItem.tsx
@@ -29,6 +29,7 @@ import { pinRecordToFeed } from '@/api/record/pinRecordToFeed';
 interface RecordItemProps {
   record: Record;
   shouldBlur?: boolean;
+  onDelete?: (id: string) => void;
 }
 
 const isSamePollOptions = (a: PollOption[], b: PollOption[]) => {
@@ -50,7 +51,7 @@ const isSamePollOptions = (a: PollOption[], b: PollOption[]) => {
   });
 };
 
-const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
+const RecordItem = ({ record, shouldBlur = false, onDelete }: RecordItemProps) => {
   const navigate = useNavigate();
   const { roomId } = useParams<{ roomId: string }>();
   const { openMoreMenu, openConfirm, openSnackbar, closePopup } = usePopupActions();
@@ -167,7 +168,7 @@ const RecordItem = ({ record, shouldBlur = false }: RecordItemProps) => {
           variant: 'top',
           onClose: () => {},
         });
-        window.location.reload();
+        onDelete?.(record.id);
       } else {
         openSnackbar({
           message: '삭제에 실패했습니다. 다시 시도해주세요.',

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -290,6 +290,14 @@ const Memory = () => {
     setShowUploadProgress(false);
   }, []);
 
+  const handleRecordDelete = useCallback((id: string) => {
+    if (activeTab === 'group') {
+      setGroupRecords(prev => prev.filter(r => r.id !== id));
+    } else {
+      setMyRecords(prev => prev.filter(r => r.id !== id));
+    }
+  }, [activeTab]);
+
   const readingProgress = totalPages > 0 ? Math.round((currentUserPage / totalPages) * 100) : 0;
 
   if (error) {
@@ -355,6 +363,7 @@ const Memory = () => {
             onPageRangeClear={handlePageRangeClear}
             onPageRangeSet={handlePageRangeSet}
             onUploadComplete={handleUploadComplete}
+            onDelete={handleRecordDelete}
           />
         )}
       </ScrollableContent>

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -103,6 +103,11 @@ const Memory = () => {
     if (!roomId) {
       return;
     }
+
+    if (activeFilter === 'page' && !selectedPageRange) {
+      return;
+    }
+
     setError(null);
     setLoading(true);
 
@@ -290,13 +295,16 @@ const Memory = () => {
     setShowUploadProgress(false);
   }, []);
 
-  const handleRecordDelete = useCallback((id: string) => {
-    if (activeTab === 'group') {
-      setGroupRecords(prev => prev.filter(r => r.id !== id));
-    } else {
-      setMyRecords(prev => prev.filter(r => r.id !== id));
-    }
-  }, [activeTab]);
+  const handleRecordDelete = useCallback(
+    (id: string) => {
+      if (activeTab === 'group') {
+        setGroupRecords(prev => prev.filter(r => r.id !== id));
+      } else {
+        setMyRecords(prev => prev.filter(r => r.id !== id));
+      }
+    },
+    [activeTab],
+  );
 
   const readingProgress = totalPages > 0 ? Math.round((currentUserPage / totalPages) * 100) : 0;
 


### PR DESCRIPTION
## 📝 작업 내용

### 1. 기록/투표 삭제 시 전체 페이지 새로고침 제거
기록이나 투표 삭제 성공 후 `window.location.reload()`를 호출하고 있었습니다. 이로 인해 스크롤 위치가 맨 위로 초기화되고, 사용자가 설정한 필터(페이지 범위, 총평)와 정렬 옵션이 모두 리셋되며, 전체 리소스를 다시 로드하는 네트워크 비용이 발생하고 있었습니다.

이를 `onDelete` 콜백 prop을 통해 해결했습니다. 삭제 성공 시 페이지를 새로고침하는 대신, 콜백을 통해 `Memory.tsx`의 로컬 상태(`groupRecords` / `myRecords`)에서 해당 항목만 제거합니다. 컴포넌트가 언마운트되지 않으므로 스크롤 위치, 필터, 정렬 상태가 모두 유지됩니다.

**변경 파일:**

- `RecordItem.tsx`: `onDelete` prop 추가, `window.location.reload()` → `onDelete?.(record.id)` 교체
- `RecordList.tsx`: `onDelete` prop을 `RecordItem`에 전달
- `MemoryContent.tsx`: `onDelete` prop을 `RecordList`에 전달
- `Memory.tsx`: `handleRecordDelete` 구현 — `activeTab` 기준으로 해당 id를 로컬 상태에서 필터링

### 2. 페이지별 보기 클릭 시 입력창 미표시 버그 수정
"페이지별 보기" 버튼을 클릭하면 페이지 범위 입력창이 나타나야 하는데, 버튼만 활성화(보라색 + X)되고 입력창이 표시되지 않는 버그가 있었습니다.

원인은 다음과 같습니다. `RecordFilters`의 로컬 상태 `showInputMode`가 `true`로 설정되는 동시에, 부모(`Memory.tsx`)의 `activeFilter` 상태가 `'page'`로 변경됩니다. `activeFilter`는 `loadMemoryPosts`의 의존성 배열에 포함되어 있어 즉시 API 재호출이 트리거되고, `setLoading(true)`로 인해 Memory가 로딩 스켈레톤으로 전환됩니다. 이 과정에서 `MemoryContent` 내부의 `RecordFilters`가 언마운트되어 `showInputMode`가 `false`로 리셋됩니다. 로딩이 완료되면 `activeFilter === 'page'`이지만 `showInputMode === false`인 상태가 되어 입력창 대신 X 버튼만 표시됩니다.

`activeFilter === 'page'`이면서 `selectedPageRange`가 null인 경우에는 API 파라미터에 실제로 필터가 적용되지 않으므로 fetch가 불필요합니다. `loadMemoryPosts` 상단에 이 조건에서 조기 반환하는 처리를 추가하여 불필요한 로딩 전환을 차단했습니다.

**변경 파일:**

- `Memory.tsx`: `loadMemoryPosts` 내 `activeFilter === 'page' && !selectedPageRange` 조기 반환 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 기록 삭제 시 페이지 전체를 새로고침하지 않고 즉시 사용자 인터페이스에 반영되도록 개선했습니다. 더 빠르고 부드러운 삭제 경험을 제공합니다.
* 현재 활성화된 탭(모든 기록 또는 내 기록)에 따라 올바른 기록 목록이 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->