### PR TITLE
fix: 초기 로딩 스켈레톤/무한스크롤 로딩 분리

### DIFF
--- a/src/pages/feed/Feed.tsx
+++ b/src/pages/feed/Feed.tsx
@@ -11,6 +11,7 @@ import { getTotalFeeds } from '@/api/feeds/getTotalFeed';
 import { getMyFeeds } from '@/api/feeds/getMyFeed';
 import { useSocialLoginToken } from '@/hooks/useSocialLoginToken';
 import { useInifinieScroll } from '@/hooks/useInifinieScroll';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { Container, SkeletonWrapper } from './Feed.styled';
 import type { PostData } from '@/types/post';
 
@@ -77,29 +78,7 @@ const Feed = () => {
   }, [activeTab]);
 
   const currentFeed = activeTab === '피드' ? totalFeed : myFeed;
-
-  useEffect(() => {
-    const loadFeedsWithToken = async () => {
-      await waitForToken();
-
-      setTabLoading(true);
-
-      try {
-        const minLoadingTime = new Promise(resolve => setTimeout(resolve, 500));
-
-        if (activeTab === '피드') {
-          await Promise.all([loadTotalFeeds(), minLoadingTime]);
-        } else if (activeTab === '내 피드') {
-          await Promise.all([loadMyFeeds(), minLoadingTime]);
-        }
-      } finally {
-        setTabLoading(false);
-        setInitialLoading(false);
-      }
-    };
-
-    loadFeedsWithToken();
-  }, [activeTab, waitForToken, loadTotalFeeds, loadMyFeeds]);
+  const showInitialLoading = currentFeed.isLoading && currentFeed.items.length === 0;
 
   return (
     <Container>
@@ -109,7 +88,7 @@ const Feed = () => {
         rightButtonClick={handleNoticeButton}
       />
       <TabBar tabs={tabs} activeTab={activeTab} onTabClick={setActiveTab} />
-      {initialLoading || tabLoading ? (
+      {showInitialLoading ? (
         activeTab === '내 피드' ? (
           <OtherFeedSkeleton showFollowButton={false} paddingTop={136} />
         ) : (
@@ -126,7 +105,7 @@ const Feed = () => {
               <TotalFeed
                 showHeader={true}
                 posts={totalFeed.items}
-                isMyFeed={false}
+                isTotalFeed={true}
                 isLast={totalFeed.isLast}
               />
             </>

--- a/src/pages/feed/Feed.tsx
+++ b/src/pages/feed/Feed.tsx
@@ -5,7 +5,6 @@ import MyFeed from '../../components/feed/MyFeed';
 import TotalFeed from '../../components/feed/TotalFeed';
 import MainHeader from '@/components/common/MainHeader';
 import { FeedPostSkeleton, OtherFeedSkeleton } from '@/shared/ui/Skeleton';
-import LoadingSpinner from '../../components/common/LoadingSpinner';
 import writefab from '../../assets/common/writefab.svg';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { getTotalFeeds } from '@/api/feeds/getTotalFeed';

--- a/src/pages/feed/FeedDetailPage.tsx
+++ b/src/pages/feed/FeedDetailPage.tsx
@@ -43,14 +43,8 @@ const FeedDetailPage = () => {
 
       try {
         setLoading(true);
-
-        const feedResponse = await getFeedDetail(Number(feedId));
         const minLoadingTime = new Promise(resolve => setTimeout(resolve, 500));
-        const [feedResponse, commentsResponse] = await Promise.all([
-          getFeedDetail(Number(feedId)),
-          getComments(Number(feedId), { postType: 'FEED' }),
-        ]);
-        await minLoadingTime;
+        const [feedResponse] = await Promise.all([getFeedDetail(Number(feedId)), minLoadingTime]);
 
         setFeedData(feedResponse.data);
         setError(null);

--- a/src/pages/feed/FollowerListPage.tsx
+++ b/src/pages/feed/FollowerListPage.tsx
@@ -19,52 +19,23 @@ const FollowerListPage = () => {
 
   const [totalCount, setTotalCount] = useState(0);
 
-  const handleBackClick = () => {
-    navigate(-1);
-  };
+  const userList = useInifinieScroll<FollowData>({
+    enabled: !!type,
+    reloadKey: `${type}-${userId ?? ''}`,
+    fetchPage: async cursor => {
+      const minLoadingTime = cursor ? null : new Promise(resolve => setTimeout(resolve, 500));
 
-  const loadUserList = useCallback(
-    async (cursor?: string) => {
-      if (loading) return;
-
-      try {
-        setLoading(true);
-        setError(null);
-        let response;
-
-        const minLoadingTime = !cursor ? new Promise(resolve => setTimeout(resolve, 500)) : null;
-
-        if (type === 'followerlist') {
-          if (!userId) {
-            setError('사용자 ID가 없습니다.');
-            return;
-          }
-          const [data] = await Promise.all([
-            getFollowerList(userId, { size: 10, cursor: cursor || null }),
-          ]);
-          response = data;
-        } else {
-          const [data] = await Promise.all([
-            getFollowingList({ size: 10, cursor: cursor || null }),
-          ]);
-          response = data;
-        }
-        await minLoadingTime;
-
-        let userData: FollowData[] = [];
-        if (type === 'followerlist') {
-          userData = (response.data as { followers: FollowData[] })?.followers || [];
-        } else {
-          userData = (response.data as { followings: FollowData[] })?.followings || [];
+      if (type === 'followerlist') {
+        if (!userId) {
+          throw new Error('사용자 ID가 없습니다.');
         }
 
-        if (!response || !response.data) {
-          setError('API 응답이 없습니다.');
-          return;
-        }
         const response = await getFollowerList(userId, { size: 10, cursor });
+        if (minLoadingTime) await minLoadingTime;
+
         const total = response.data.totalFollowerCount;
         if (typeof total === 'number') setTotalCount(total);
+
         return {
           items: response.data.followers || [],
           nextCursor: response.data.nextCursor || null,
@@ -73,8 +44,11 @@ const FollowerListPage = () => {
       }
 
       const response = await getFollowingList({ size: 10, cursor });
+      if (minLoadingTime) await minLoadingTime;
+
       const total = response.data.totalFollowingCount;
       if (typeof total === 'number') setTotalCount(total);
+
       return {
         items: response.data.followings || [],
         nextCursor: response.data.nextCursor || null,
@@ -89,11 +63,18 @@ const FollowerListPage = () => {
     window.scrollTo(0, 0);
   }, [type, userId]);
 
+  const showInitialSkeleton = userList.isLoading && userList.items.length === 0;
+
   return (
     <Wrapper>
-      <TitleHeader leftIcon={<img src={leftArrow} alt="뒤로가기" />} onLeftClick={handleBackClick} title={title} />
+      <TitleHeader
+        leftIcon={<img src={leftArrow} alt="뒤로가기" />}
+        onLeftClick={() => navigate(-1)}
+        title={title}
+      />
       <TotalBar>전체 {totalCount}</TotalBar>
-      {loading && userList.length === 0 ? (
+
+      {showInitialSkeleton ? (
         <UserProfileList>
           {Array.from({ length: 5 }).map((_, i) => (
             <UserProfileItemSkeleton key={i} type={type as UserProfileType} />
@@ -116,6 +97,7 @@ const FollowerListPage = () => {
               isMyself={user.isMyself}
             />
           ))}
+
           {!userList.isLast && <div ref={userList.sentinelRef} style={{ height: 20 }} />}
           {userList.isLoadingMore && (
             <div style={{ display: 'flex', justifyContent: 'center', padding: '16px 0' }}>

--- a/src/pages/groupSearch/GroupSearch.tsx
+++ b/src/pages/groupSearch/GroupSearch.tsx
@@ -6,12 +6,11 @@ import rightChevron from '../../assets/common/right-Chevron.svg';
 import { useState, useEffect, useCallback } from 'react';
 import RecentSearchTabs from '@/components/search/RecentSearchTabs';
 import GroupSearchResult from '@/components/search/GroupSearchResult';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { getRecentSearch, type RecentSearchData } from '@/api/recentsearch/getRecentSearch';
 import { deleteRecentSearch } from '@/api/recentsearch/deleteRecentSearch';
 import { getSearchRooms } from '@/api/rooms/getSearchRooms';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { AllRoomsButton, LoadingMessage } from './GroupSearch.styled';
+import { AllRoomsButton } from './GroupSearch.styled';
 import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 import { GroupCardSkeleton, RecentSearchTabsSkeleton } from '@/shared/ui/Skeleton';
 import { Content } from '@/components/search/GroupSearchResult.styled';
@@ -25,7 +24,6 @@ const GroupSearch = () => {
 
   const [searchTerm, setSearchTerm] = useState('');
   const [searchStatus, setSearchStatus] = useState<SearchStatus>('idle');
-
   const [selectedFilter, setSelectedFilter] = useState<string>('마감임박순');
   const toSortKey = useCallback(
     (f: string): SortKey => (f === '인기순' ? 'memberCount' : 'deadline'),
@@ -33,12 +31,9 @@ const GroupSearch = () => {
   );
   const [category, setCategory] = useState<string>('');
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
-
   const [recentSearches, setRecentSearches] = useState<RecentSearchData[]>([]);
-
   const [isLoadingRecentSearches, setIsLoadingRecentSearches] = useState(true);
   const [searchTimeoutId, setSearchTimeoutId] = useState<NodeJS.Timeout | null>(null);
-
   const [showTabs, setShowTabs] = useState(false);
 
   useEffect(() => {
@@ -52,7 +47,7 @@ const GroupSearch = () => {
     }
   }, [searchStatus]);
 
-  const fetchRecentSearches = async () => {
+  const fetchRecentSearches = useCallback(async () => {
     try {
       setIsLoadingRecentSearches(true);
       const minLoadingTime = new Promise(resolve => setTimeout(resolve, 500));
@@ -63,62 +58,14 @@ const GroupSearch = () => {
     } finally {
       setIsLoadingRecentSearches(false);
     }
-  };
-
-  const searchFirstPage = useCallback(
-    async (
-      term: string,
-      sortKey: SortKey,
-      status: 'searching' | 'searched',
-      categoryParam: string,
-      isAllCategory: boolean = false,
-      keepPrevious: boolean = false,
-    ) => {
-      setIsLoading(true);
-      setError(null);
-      if (!keepPrevious) {
-        setRooms([]);
-        setNextCursor(null);
-        setIsLast(true);
-      }
-
-      try {
-        const isFinalized = status === 'searched';
-        const minLoadingTime = new Promise(resolve => setTimeout(resolve, 500));
-        const [res] = await Promise.all([
-          getSearchRooms(
-            term.trim(),
-            sortKey,
-            undefined,
-            isFinalized,
-            categoryParam,
-            isAllCategory,
-          ),
-        ]);
-        await minLoadingTime;
-        if (res.isSuccess) {
-          const { roomList, nextCursor: nc, isLast: last } = res.data;
-
-          setRooms(roomList);
-          setNextCursor(nc);
-          setIsLast(last);
-        } else {
-          setError(res.message || '검색 실패');
-        }
-      } catch {
-        setError('네트워크 오류가 발생했습니다.');
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [],
-  );
+  }, []);
 
   useEffect(() => {
     if (location.state?.allRooms) {
       navigate(location.pathname, { replace: true });
 
       setSearchTerm('');
+      setDebouncedSearchTerm('');
       setSearchStatus('searched');
       setShowTabs(true);
       setCategory('');
@@ -141,7 +88,7 @@ const GroupSearch = () => {
     setSearchStatus('searching');
     setShowTabs(false);
     const id = setTimeout(() => {
-      searchFirstPage(trimmed, toSortKey(selectedFilter), 'searching', category, false, true);
+      setDebouncedSearchTerm(trimmed);
     }, 300);
     setSearchTimeoutId(id);
   };
@@ -180,80 +127,34 @@ const GroupSearch = () => {
     setCategory('');
   };
 
-  const searchStatusRef = useRef(searchStatus);
-  const categoryRef = useRef(category);
-  const selectedFilterRef = useRef(selectedFilter);
-  const searchTermRef = useRef(searchTerm);
-
-  useEffect(() => {
-    searchStatusRef.current = searchStatus;
-    categoryRef.current = category;
-    selectedFilterRef.current = selectedFilter;
-    searchTermRef.current = searchTerm;
-  });
-
-  useEffect(() => {
-    if (searchStatus !== 'searched') return;
-
-    const term = searchTermRef.current.trim();
-    const currentCategory = categoryRef.current;
-    const isAllCategory = !term && currentCategory === '';
-
-    searchFirstPage(
-      term,
-      toSortKey(selectedFilterRef.current),
-      'searched',
-      currentCategory,
-      isAllCategory,
-      true,
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchStatus, searchTerm]);
-
-  useEffect(() => {
-    if (searchStatusRef.current !== 'searched') return;
-
-    const term = searchTermRef.current.trim();
-    const isAllCategory = !term && category === '';
-
-    searchFirstPage(term, toSortKey(selectedFilter), 'searched', category, isAllCategory, true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedFilter, category]);
-
   useEffect(() => {
     if (searchStatus === 'searched') {
       setDebouncedSearchTerm(searchTerm.trim());
     }
   }, [searchStatus, searchTerm]);
 
-    const id = setTimeout(() => {
-      const currentCategory = categoryRef.current;
-      searchFirstPage(term, toSortKey(selectedFilter), 'searching', currentCategory, false, true);
-    }, 300);
-    setSearchTimeoutId(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchTerm, searchStatus, selectedFilter]);
+  const queryTerm = searchStatus === 'searched' ? searchTerm.trim() : debouncedSearchTerm.trim();
+  const isAllCategory = !queryTerm && category === '';
 
-  const loadMore = useCallback(async () => {
-    const trimmedTerm = searchTerm.trim();
-    const isAllCategory = !trimmedTerm && category === '';
-    if ((!isAllCategory && !trimmedTerm) || !nextCursor || isLast || isLoadingMore) return;
-    try {
-      setIsLoadingMore(true);
-      const isFinalized = searchStatus === 'searched';
-      const isAllCategory = !queryTerm && category === '';
+  const searchResult = useInifinieScroll({
+    enabled: searchStatus !== 'idle' && (searchStatus === 'searched' || !!queryTerm),
+    reloadKey: `${searchStatus}-${queryTerm}-${selectedFilter}-${category}`,
+    fetchPage: async cursor => {
       if (searchStatus === 'searching' && !queryTerm) {
         return { items: [], nextCursor: null, isLast: true };
       }
 
+      const minLoadingTime = cursor ? null : new Promise(resolve => setTimeout(resolve, 500));
       const res = await getSearchRooms(
         queryTerm,
         toSortKey(selectedFilter),
         cursor ?? undefined,
-        isFinalized,
+        searchStatus === 'searched',
         category,
         isAllCategory,
       );
+
+      if (minLoadingTime) await minLoadingTime;
 
       if (!res.isSuccess) {
         throw new Error(res.message || '검색 실패');
@@ -317,7 +218,7 @@ const GroupSearch = () => {
 
         {searchStatus !== 'idle' ? (
           <>
-            {isLoading && rooms.length === 0 ? (
+            {searchResult.isLoading && searchResult.items.length === 0 ? (
               <Content>
                 {Array.from({ length: 5 }).map((_, i) => (
                   <GroupCardSkeleton key={i} type="search" />

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -6,7 +6,6 @@ import MemoryContent from '../../components/memory/MemoryContent/MemoryContent';
 import MemoryAddButton from '../../components/memory/MemoryAddButton/MemoryAddButton';
 import Snackbar from '../../components/common/Modal/Snackbar';
 import GlobalCommentBottomSheet from '../../components/common/CommentBottomSheet/GlobalCommentBottomSheet';
-import LoadingSpinner from '../../components/common/LoadingSpinner';
 import { useCommentBottomSheetStore } from '@/stores/commentBottomSheetStore';
 import { useInifinieScroll } from '@/hooks/useInifinieScroll';
 import { Container, FixedHeader, ScrollableContent, FloatingElements } from './Memory.styled';
@@ -71,6 +70,11 @@ const Memory = () => {
   const [selectedPageRange, setSelectedPageRange] = useState<{ start: number; end: number } | null>(
     null,
   );
+  const [showUploadProgress, setShowUploadProgress] = useState(false);
+  const [roomCompleted, setRoomCompleted] = useState(false);
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [currentUserPage, setCurrentUserPage] = useState<number>(0);
+  const scrollRootRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
@@ -78,27 +82,15 @@ const Memory = () => {
     const filterParam = searchParams.get('filter');
 
     if (pageParam && filterParam === 'poll') {
-      const page = parseInt(pageParam);
+      const page = parseInt(pageParam, 10);
       if (!isNaN(page)) {
         setSelectedPageRange({ start: page, end: page });
         setActiveFilter('page');
         setActiveTab('group');
-
         navigate(location.pathname, { replace: true });
       }
     }
-  }, [location.search]);
-
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  const [showUploadProgress, setShowUploadProgress] = useState(false);
-
-  const [roomCompleted, setRoomCompleted] = useState(false);
-
-  const [totalPages, setTotalPages] = useState<number>(0);
-  const [currentUserPage, setCurrentUserPage] = useState<number>(0);
-  const scrollRootRef = useRef<HTMLDivElement | null>(null);
+  }, [location.search, location.pathname, navigate]);
 
   const recordsList = useInifinieScroll<Record>({
     enabled: !!roomId,
@@ -109,14 +101,6 @@ const Memory = () => {
         return { items: [], nextCursor: null, isLast: true };
       }
 
-  const loadMemoryPosts = useCallback(async () => {
-    if (!roomId) {
-      return;
-    }
-    setError(null);
-    setLoading(true);
-
-    try {
       const params: GetMemoryPostsParams = {
         roomId: parseInt(roomId, 10),
         type: activeTab === 'group' ? 'group' : 'mine',
@@ -135,11 +119,10 @@ const Memory = () => {
         params.isPageFilter = true;
       }
 
-      const minLoadingTime = new Promise(resolve => setTimeout(resolve, 500));
-      const [response] = await Promise.all([getMemoryPosts(params), minLoadingTime]);
-
-      if (response.isSuccess) {
-        const convertedRecords = response.data.postList.map(convertPostToRecord);
+      try {
+        const minLoadingTime = cursor ? null : new Promise(resolve => setTimeout(resolve, 500));
+        const response = await getMemoryPosts(params);
+        if (minLoadingTime) await minLoadingTime;
 
         if (!response.isSuccess) {
           throw new Error(response.message || '기록을 불러오는 중 오류가 발생했습니다.');
@@ -167,22 +150,20 @@ const Memory = () => {
         }
         throw new Error('기록을 불러오는 중 오류가 발생했습니다.');
       }
-
-      setError('기록을 불러오는 중 오류가 발생했습니다.');
-    } finally {
-      setLoading(false);
-    }
-  }, [roomId, activeTab, selectedSort, activeFilter, selectedPageRange]);
+    },
+    rootMargin: '100px 0px',
+    threshold: 0.1,
+  });
+  const { setItems: setRecordItems } = recordsList;
 
   useEffect(() => {
     const checkRoomStatus = async () => {
       if (!roomId) return;
 
       try {
-        const response = await getRoomPlaying(parseInt(roomId));
+        const response = await getRoomPlaying(parseInt(roomId, 10));
         if (response.isSuccess) {
-          const completed = isRoomCompleted(response.data.progressEndDate);
-          setRoomCompleted(completed);
+          setRoomCompleted(isRoomCompleted(response.data.progressEndDate));
         }
       } catch (error) {
         console.error('모임방 상태 확인 오류:', error);
@@ -199,6 +180,7 @@ const Memory = () => {
       postType?: 'RECORD' | 'VOTE';
       openComments?: boolean;
     } | null;
+
     const state = (location.state as MemoryLocationState) || null;
     const initialPage = state?.page;
     if (initialPage && !selectedPageRange) {
@@ -218,34 +200,25 @@ const Memory = () => {
       const newRecord = location.state.newRecord as Record;
       setShowUploadProgress(true);
       setRecordItems(prev => [newRecord, ...prev]);
-
       navigate(location.pathname, { replace: true });
     }
   }, [location.state, navigate, location.pathname, setRecordItems]);
 
-  const currentRecords = useMemo(() => recordsList.items, [recordsList.items]);
-
-  const sortedRecords = useMemo(() => {
-    return currentRecords;
-  }, [currentRecords]);
-
   const filteredRecords = useMemo(() => {
-    const filtered = sortedRecords;
-
     if (activeFilter === 'overall') {
-      const overallRecords = filtered.filter(record => record.recordType === 'overall');
-      return overallRecords;
-    } else if (activeFilter === 'page' && selectedPageRange) {
-      const pageRecords = filtered.filter(record => {
-        if (record.recordType === 'overall') return false;
-        const page = parseInt(record.pageRange || '0');
-        return page >= selectedPageRange.start && page <= selectedPageRange.end;
-      });
-      return pageRecords;
+      return recordsList.items.filter(record => record.recordType === 'overall');
     }
 
-    return filtered;
-  }, [sortedRecords, activeFilter, selectedPageRange]);
+    if (activeFilter === 'page' && selectedPageRange) {
+      return recordsList.items.filter(record => {
+        if (record.recordType === 'overall') return false;
+        const page = parseInt(record.pageRange || '0', 10);
+        return page >= selectedPageRange.start && page <= selectedPageRange.end;
+      });
+    }
+
+    return recordsList.items;
+  }, [recordsList.items, activeFilter, selectedPageRange]);
 
   const handleBackClick = useCallback(() => {
     if (roomId) {
@@ -293,6 +266,7 @@ const Memory = () => {
   }, []);
 
   const readingProgress = totalPages > 0 ? Math.round((currentUserPage / totalPages) * 100) : 0;
+  const showInitialSkeleton = recordsList.isLoading && recordsList.items.length === 0;
 
   if (recordsList.error) {
     return (
@@ -315,10 +289,11 @@ const Memory = () => {
       <FixedHeader>
         <MemoryHeader onBackClick={handleBackClick} />
       </FixedHeader>
-      <ScrollableContent>
-        {loading ? (
+
+      <ScrollableContent ref={scrollRootRef}>
+        {showInitialSkeleton ? (
           <Content>
-            <FixedSection inert>
+            <FixedSection>
               <RecordTabs activeTab={activeTab} onTabChange={handleTabChange} />
               {activeTab === 'group' && (
                 <RecordFilters
@@ -342,21 +317,24 @@ const Memory = () => {
             </ScrollableSection>
           </Content>
         ) : (
-          <MemoryContent
-            activeTab={activeTab}
-            activeFilter={activeFilter}
-            readingProgress={readingProgress}
-            selectedSort={selectedSort}
-            records={filteredRecords}
-            selectedPageRange={selectedPageRange}
-            showUploadProgress={showUploadProgress}
-            onTabChange={handleTabChange}
-            onFilterChange={handleFilterChange}
-            onSortChange={handleSortChange}
-            onPageRangeClear={handlePageRangeClear}
-            onPageRangeSet={handlePageRangeSet}
-            onUploadComplete={handleUploadComplete}
-          />
+          <>
+            <MemoryContent
+              activeTab={activeTab}
+              activeFilter={activeFilter}
+              readingProgress={readingProgress}
+              selectedSort={selectedSort}
+              records={filteredRecords}
+              selectedPageRange={selectedPageRange}
+              showUploadProgress={showUploadProgress}
+              onTabChange={handleTabChange}
+              onFilterChange={handleFilterChange}
+              onSortChange={handleSortChange}
+              onPageRangeClear={handlePageRangeClear}
+              onPageRangeSet={handlePageRangeSet}
+              onUploadComplete={handleUploadComplete}
+            />
+            {!recordsList.isLast && <div ref={recordsList.sentinelRef} style={{ height: 20 }} />}
+          </>
         )}
       </ScrollableContent>
 

--- a/src/pages/mypage/SavePage.tsx
+++ b/src/pages/mypage/SavePage.tsx
@@ -69,121 +69,6 @@ const SavePage = () => {
     navigate('/mypage');
   };
 
-  const loadSavedBooks = useCallback(async (cursor: string | null = null) => {
-    try {
-      setBookLoading(true);
-      const response = await getSavedBooksInMy(cursor);
-
-      if (cursor === null) {
-        setSavedBooks(response.data.bookList);
-      } else {
-        setSavedBooks(prev => [...prev, ...response.data.bookList]);
-      }
-
-      setBookNextCursor(response.data.nextCursor);
-      setBookIsLast(response.data.isLast);
-    } catch (error) {
-      console.error('저장된 책 목록 로드 실패:', error);
-    } finally {
-      setBookLoading(false);
-    }
-  }, []);
-
-  const loadSavedFeeds = useCallback(async (cursor: string | null = null) => {
-    try {
-      setFeedLoading(true);
-      const response = await getSavedFeedsInMy(cursor);
-
-      if (cursor === null) {
-        setSavedFeeds(response.data.feedList);
-      } else {
-        setSavedFeeds(prev => [...prev, ...response.data.feedList]);
-      }
-
-      setFeedNextCursor(response.data.nextCursor);
-      setFeedIsLast(response.data.isLast);
-    } catch (error) {
-      console.error('저장된 피드 로드 실패:', error);
-    } finally {
-      setFeedLoading(false);
-    }
-  }, []);
-
-  const loadMoreBooks = useCallback(async () => {
-    if (!bookNextCursor || bookIsLast || bookLoading) return;
-
-    try {
-      await loadSavedBooks(bookNextCursor);
-    } catch (error) {
-      console.error('책 추가 로드 실패:', error);
-    }
-  }, [bookNextCursor, bookIsLast, bookLoading, loadSavedBooks]);
-
-  const lastBookElementCallback = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (bookLoading || bookIsLast) return;
-
-      if (node) {
-        const observer = new IntersectionObserver(entries => {
-          if (entries[0].isIntersecting && !bookLoading && !bookIsLast) {
-            loadMoreBooks();
-          }
-        });
-
-        observer.observe(node);
-      }
-    },
-    [bookLoading, bookIsLast, loadMoreBooks],
-  );
-
-  useEffect(() => {
-    const loadAllData = async () => {
-      try {
-        setInitialLoading(true);
-
-        const minLoadingTime = new Promise(resolve => setTimeout(resolve, 500));
-        const [feedsResponse, booksResponse] = await Promise.all([
-          getSavedFeedsInMy(null),
-          getSavedBooksInMy(),
-        ]);
-        await minLoadingTime;
-
-        setSavedFeeds(feedsResponse.data.feedList);
-        setFeedNextCursor(feedsResponse.data.nextCursor);
-        setFeedIsLast(feedsResponse.data.isLast);
-
-        setSavedBooks(booksResponse.data.bookList);
-        setBookNextCursor(booksResponse.data.nextCursor);
-        setBookIsLast(booksResponse.data.isLast);
-      } catch (error) {
-        console.error('초기 데이터 로드 실패:', error);
-      } finally {
-        setInitialLoading(false);
-      }
-    };
-
-    loadAllData();
-  }, []);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      entries => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting && !feedIsLast && !feedLoading && feedNextCursor) {
-            loadSavedFeeds(feedNextCursor);
-          }
-        });
-      },
-      { threshold: 0.1 },
-    );
-
-    if (feedObserverRef.current) {
-      observer.observe(feedObserverRef.current);
-    }
-
-    return () => observer.disconnect();
-  }, [feedIsLast, feedLoading, feedNextCursor, loadSavedFeeds]);
-
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [activeTab]);
@@ -230,7 +115,7 @@ const SavePage = () => {
         title="저장"
       />
       <TabBar tabs={tabs} activeTab={activeTab} onTabClick={setActiveTab} />
-      {initialLoading ? (
+      {showInitialLoading ? (
         activeTab === '피드' ? (
           <SkeletonWrapper>
             {Array.from({ length: 3 }).map((_, index) => (

--- a/src/pages/searchBook/SearchBook.tsx
+++ b/src/pages/searchBook/SearchBook.tsx
@@ -21,6 +21,7 @@ import {
   EmptyTitle,
   EmptySubText,
   FeedPostContainer,
+  LoadingBox,
 } from './SearchBook.styled';
 import { useNavigate, useParams } from 'react-router-dom';
 import leftArrow from '../../assets/common/leftArrow.svg';
@@ -103,64 +104,23 @@ const SearchBook = () => {
     fetchBookDetail();
   }, [isbn]);
 
-  const loadFirstFeeds = useCallback(async () => {
-    if (!isbn) return;
-    try {
-      setIsLoadingFeeds(true);
-      setFeeds([]);
-      setNextCursor(null);
-      setIsLast(true);
-
-      const minLoadingTime = new Promise(resolve => setTimeout(resolve, 500));
-      const [res] = await Promise.all([
-        getFeedsByIsbn(isbn, toFeedSort(selectedFilter), null),
-      ]);
-      await minLoadingTime;
-      if (res.isSuccess) {
-        setFeeds(res.data.feeds);
-        setNextCursor(res.data.nextCursor);
-        setIsLast(res.data.isLast);
+  const feeds = useInifinieScroll<FeedItem>({
+    enabled: !!isbn,
+    reloadKey: `${isbn ?? ''}-${selectedFilter}`,
+    fetchPage: async cursor => {
+      if (!isbn) {
+        return { items: [], nextCursor: null, isLast: true };
       }
-    } catch {
-      // no-op
-    } finally {
-      setIsLoadingFeeds(false);
-    }
-  }, [isbn, selectedFilter]);
 
-  useEffect(() => {
-    loadFirstFeeds();
-  }, [loadFirstFeeds]);
+      const minLoadingTime = cursor ? null : new Promise(resolve => setTimeout(resolve, 500));
+      const res = await getFeedsByIsbn(isbn, toFeedSort(selectedFilter), cursor);
+      if (minLoadingTime) await minLoadingTime;
 
-  const loadMore = useCallback(async () => {
-    if (!isbn || !nextCursor || isLast || isLoadingMore) return;
-    try {
-      setIsLoadingMore(true);
-      const res = await getFeedsByIsbn(isbn, toFeedSort(selectedFilter), nextCursor);
-      if (res.isSuccess) {
-        setFeeds(prev => [...prev, ...res.data.feeds]);
-        setNextCursor(res.data.nextCursor);
-        setIsLast(res.data.isLast);
-      }
-    } catch {
-      // no-op
-    } finally {
-      setIsLoadingMore(false);
-    }
-  }, [isbn, nextCursor, isLast, isLoadingMore, selectedFilter]);
-
-  const lastFeedElementCallback = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (isLoadingMore || isLast) return;
-
-      if (observerRef.current) observerRef.current.disconnect();
-
-      observerRef.current = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting && !isLoadingMore && !isLast) {
-          loadMore();
-        }
-      });
-      if (node) observerRef.current.observe(node);
+      return {
+        items: res.data.feeds,
+        nextCursor: res.data.nextCursor || null,
+        isLast: res.data.isLast,
+      };
     },
     rootMargin: '100px 0px',
     threshold: 0.1,
@@ -302,13 +262,13 @@ const SearchBook = () => {
             setSelectedFilter={filter => setSelectedFilter(filter as (typeof FILTER)[number])}
           />
         </FilterContainer>
-        {isLoadingFeeds && feeds.length === 0 ? (
+        {feeds.isLoading && feeds.items.length === 0 ? (
           <FeedPostContainer>
             {Array.from({ length: 3 }).map((_, i) => (
               <FeedPostSkeleton key={i} />
             ))}
           </FeedPostContainer>
-        ) : feeds.length > 0 ? (
+        ) : feeds.items.length > 0 ? (
           <FeedPostContainer>
             {feeds.items.map(post => (
               <div key={post.feedId}>


### PR DESCRIPTION
## 📝작업 내용
Memory, SearchBook, SavePage, GroupSearch, FollowerListPage, Feed, FeedDetailPage에서 훅 기반 무한스크롤, 기존 수동 페이징, 스켈레톤 로직이 혼재되어 있어 아래 원칙에 따라 코드를 정리했습니다.

- useInifinieScroll만 남기고 수동 loadMore/observer 제거
- 스켈레톤은 isLoading && items.length === 0에서만 표시
- 무한스크롤 추가 로딩(isLoadingMore)에서는 스켈레톤 미사용 (필요시 스피너만 유지)
- 충돌로 생긴 중복 요청, 미정의 변수, 잘못된 import 정리

### 수정 파일
- src/pages/feed/Feed.tsx
  - 섞여 있던 setTabLoading/loadTotalFeeds/loadMyFeeds 경로 제거
  - currentFeed.isLoading && currentFeed.items.length === 0일 때만 초기 스켈레톤
  - 무한스크롤은 useInifinieScroll 결과만 사용
- src/pages/feed/FeedDetailPage.tsx
  - 중복 호출/깨진 로딩 코드 정리
  - 상세 데이터 초기 로딩만 스켈레톤 유지
- src/pages/feed/FollowerListPage.tsx
  - 수동 페이징 코드 제거하고 useInifinieScroll로 단일화
  - 초기 진입만 UserProfileItemSkeleton 표시
- src/pages/groupSearch/GroupSearch.tsx
  - 깨진 검색/페이징 병합 코드 정리
  - 검색 결과도 훅 기반으로 통일
  - 초기 검색 로딩에만 카드 스켈레톤
- src/pages/memory/Memory.tsx
  - 충돌 상태였던 파일을 전체 정리
  - 초기 진입 시만 RecordItemSkeleton
  - 무한스크롤 시 스켈레톤 재표시 없이 리스트 유지
- src/pages/mypage/SavePage.tsx
  - 기존 수동 IntersectionObserver/중복 상태 제거
  - 탭별 훅 결과 기준으로 초기 스켈레톤만 표시
- src/pages/searchBook/SearchBook.tsx
  - 수동 loadFirst/loadMore 제거, 훅 기반으로 통일
  - 초기 피드 로딩에서만 FeedPostSkeleton
  - LoadingBox import 누락 포함 정리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **성능 개선**
  * 초기 로딩 스켈레톤과 최소 로딩 시간 도입으로 로드 경험 일관화
  * 피드·팔로워·검색·메모리의 무한 스크롤 및 로딩 흐름 최적화

* **버그 수정**
  * 그룹 검색 및 팔로워 목록 에러 처리 강화
  * 메모리 페이지 필터·페이지 범위 및 내비게이션 관련 안정성 개선

* **리팩토링**
  * 페칭 및 로딩 제어 재구성으로 렌더링 분기와 상태 관리 정리
  * 피드 상세 로드 병렬화로 응답 지연 최소화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->