### PR TITLE
fix: 피드 이미지 로딩 최적화 및 FollowerList에 의한 CLS 완화

### DIFF
--- a/src/components/common/Post/PostBody.tsx
+++ b/src/components/common/Post/PostBody.tsx
@@ -12,7 +12,8 @@ const PostBody = ({
   feedId,
   contentUrls = [],
 }: PostBodyProps) => {
-  const hasImage = contentUrls.length > 0;
+  const previewImages = contentUrls.slice(0, 3);
+  const hasImage = previewImages.length > 0;
   const contentRef = useRef<HTMLDivElement>(null);
   const [isTruncated, setIsTruncated] = useState(false);
 
@@ -43,8 +44,17 @@ const PostBody = ({
       <ImageContainer>
         {hasImage && (
           <>
-            {contentUrls.map((src: string, i: number) => (
-              <img key={i} src={src} />
+            {previewImages.map((src: string, i: number) => (
+              <img
+                key={`${feedId}-${i}`}
+                src={src}
+                alt={`피드 이미지 ${i + 1}`}
+                loading="lazy"
+                decoding="async"
+                fetchPriority="low"
+                width={100}
+                height={100}
+              />
             ))}
           </>
         )}

--- a/src/components/feed/FollowList.styled.ts
+++ b/src/components/feed/FollowList.styled.ts
@@ -14,10 +14,30 @@ export const Container = styled.div`
   .title {
     display: flex;
     flex-direction: row;
+    align-items: center;
+    gap: 4px;
     color: var(--color-white);
     font-size: ${typography.fontSize['2xs']};
     font-weight: var(--font-weight-medium);
     line-height: 20px;
+
+    img {
+      width: 14px;
+      height: 14px;
+      flex-shrink: 0;
+    }
+  }
+
+  .titleSkeletonIcon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+  }
+
+  .titleSkeletonText {
+    display: flex;
+    align-items: center;
+    height: 20px;
   }
 `;
 
@@ -26,6 +46,7 @@ export const FollowContainer = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  min-height: 58px;
 
   img {
     cursor: pointer;
@@ -73,6 +94,37 @@ export const FollowContainer = styled.div`
         border: 0.5px solid #888;
       }
     }
+
+    .skeletonItem {
+      cursor: default;
+    }
+  }
+
+  .arrowSkeleton {
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+`;
+
+export const FollowListLoading = styled.div`
+  display: flex;
+  align-items: center;
+  min-height: 58px;
+
+  .placeholderList {
+    display: flex;
+    gap: 12px;
+  }
+
+  .placeholderItem {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background-color: var(--color-darkgrey-dark);
   }
 `;
 

--- a/src/components/feed/FollowList.tsx
+++ b/src/components/feed/FollowList.tsx
@@ -4,9 +4,14 @@ import rightArrow from '../../assets/feed/rightArrow.svg';
 import people from '../../assets/feed/people.svg';
 import character from '../../assets/feed/character.svg';
 import { getRecentFollowing, type RecentWriterData } from '@/api/users/getRecentFollowing';
+import Skeleton from '@/shared/ui/Skeleton';
 import { Container, FollowContainer, EmptyFollowerContainer } from './FollowList.styled';
 
-const FollowList = () => {
+interface FollowListProps {
+  onLoadingChange?: (loading: boolean) => void;
+}
+
+const FollowList = ({ onLoadingChange }: FollowListProps) => {
   const navigate = useNavigate();
   const [myFollowings, setMyFollowings] = useState<RecentWriterData[]>([]);
   const [loading, setLoading] = useState(true);
@@ -14,7 +19,8 @@ const FollowList = () => {
   const fetchRecentFollowing = async () => {
     try {
       setLoading(true);
-      const response = await getRecentFollowing();
+      const minLoadingTime = new Promise(resolve => setTimeout(resolve, 500));
+      const [response] = await Promise.all([getRecentFollowing(), minLoadingTime]);
 
       if (response.isSuccess) {
         setMyFollowings(response.data.myFollowingUsers);
@@ -33,6 +39,10 @@ const FollowList = () => {
     fetchRecentFollowing();
   }, []);
 
+  useEffect(() => {
+    onLoadingChange?.(loading);
+  }, [loading, onLoadingChange]);
+
   const hasFollowers = myFollowings.length > 0;
   const visible = hasFollowers ? myFollowings.slice(0, 10) : [];
 
@@ -50,12 +60,37 @@ const FollowList = () => {
 
   return (
     <Container>
-      <div className="title">
-        <img src={people} />
-        <div>내 띱</div>
-      </div>
       {loading ? (
-        <></>
+        <div className="title">
+          <div className="titleSkeletonIcon">
+            <Skeleton.Box width={14} height={14} />
+          </div>
+          <div className="titleSkeletonText">
+            <Skeleton.Text width={24} height={12} />
+          </div>
+        </div>
+      ) : (
+        <div className="title">
+          <img src={people} alt="내 띱" />
+          <div>내 띱</div>
+        </div>
+      )}
+      {loading ? (
+        <FollowContainer>
+          <div className="followerList">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div className="followers skeletonItem" key={i}>
+                <Skeleton.Circle width={36} />
+                <div className="username skeletonUsername">
+                  <Skeleton.Text width={30} height={10} />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="arrowSkeleton">
+            <Skeleton.Box width={16} height={16} />
+          </div>
+        </FollowContainer>
       ) : hasFollowers ? (
         <FollowContainer>
           <div className="followerList">

--- a/src/components/feed/MyFeed.styled.ts
+++ b/src/components/feed/MyFeed.styled.ts
@@ -3,7 +3,6 @@ import { colors, typography } from '@/styles/global/global';
 
 export const Container = styled.div`
   min-height: 100vh;
-  padding-top: 136px;
   padding-bottom: 125px; //이전 76px
   background-color: var(--color-black-main);
 `;

--- a/src/components/feed/TotalFeed.styled.ts
+++ b/src/components/feed/TotalFeed.styled.ts
@@ -3,7 +3,7 @@ import { colors, typography } from '@/styles/global/global';
 
 export const Container = styled.div`
   min-height: 100vh;
-  padding-top: 136px;
+  /* padding-top: 136px; */
   padding-bottom: 125px; //이전 76px
   background-color: var(--color-black-main);
 `;

--- a/src/components/feed/TotalFeed.tsx
+++ b/src/components/feed/TotalFeed.tsx
@@ -1,4 +1,3 @@
-import FollowList from './FollowList';
 import FeedPost from './FeedPost';
 import type { FeedListProps } from '../../types/post';
 import { Container, EmptyState } from './TotalFeed.styled';
@@ -8,7 +7,6 @@ const TotalFeed = ({ showHeader, posts = [], isTotalFeed, isLast = false }: Feed
 
   return (
     <Container>
-      <FollowList />
       {hasPosts ? (
         posts.map((post, index) => (
           <FeedPost

--- a/src/pages/feed/Feed.styled.ts
+++ b/src/pages/feed/Feed.styled.ts
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 export const Container = styled.div`
   min-width: 320px;
   max-width: 767px;
+  padding-top: 136px;
   height: 100vh;
   background-color: var(--color-black-main);
   margin: 0 auto;
@@ -10,7 +11,6 @@ export const Container = styled.div`
 
 export const SkeletonWrapper = styled.div`
   min-height: 100vh;
-  padding-top: 136px;
   padding-bottom: 125px;
   background-color: var(--color-black-main);
 `;

--- a/src/pages/feed/Feed.tsx
+++ b/src/pages/feed/Feed.tsx
@@ -3,6 +3,7 @@ import NavBar from '../../components/common/NavBar';
 import TabBar from '../../components/feed/TabBar';
 import MyFeed from '../../components/feed/MyFeed';
 import TotalFeed from '../../components/feed/TotalFeed';
+import FollowList from '../../components/feed/FollowList';
 import MainHeader from '@/components/common/MainHeader';
 import { FeedPostSkeleton, OtherFeedSkeleton } from '@/shared/ui/Skeleton';
 import writefab from '../../assets/common/writefab.svg';
@@ -22,6 +23,7 @@ const Feed = () => {
   const location = useLocation();
   const initialTabFromState = (location.state as { initialTab?: string } | null)?.initialTab;
   const [activeTab, setActiveTab] = useState<string>(initialTabFromState ?? tabs[0]);
+  const [isFollowListLoading, setIsFollowListLoading] = useState(activeTab === '피드');
 
   const { waitForToken } = useSocialLoginToken();
 
@@ -77,8 +79,17 @@ const Feed = () => {
     window.scrollTo(0, 0);
   }, [activeTab]);
 
+  useEffect(() => {
+    if (activeTab === '피드') {
+      setIsFollowListLoading(true);
+    }
+  }, [activeTab]);
+
   const currentFeed = activeTab === '피드' ? totalFeed : myFeed;
-  const showInitialLoading = currentFeed.isLoading && currentFeed.items.length === 0;
+  const showFeedInitialLoading = totalFeed.isLoading && totalFeed.items.length === 0;
+  const showMyFeedInitialLoading = myFeed.isLoading && myFeed.items.length === 0;
+  const showInitialLoading =
+    activeTab === '피드' ? showFeedInitialLoading || isFollowListLoading : showMyFeedInitialLoading;
 
   return (
     <Container>
@@ -88,6 +99,7 @@ const Feed = () => {
         rightButtonClick={handleNoticeButton}
       />
       <TabBar tabs={tabs} activeTab={activeTab} onTabClick={setActiveTab} />
+      {activeTab === '피드' && <FollowList onLoadingChange={setIsFollowListLoading} />}
       {showInitialLoading ? (
         activeTab === '내 피드' ? (
           <OtherFeedSkeleton showFollowButton={false} paddingTop={136} />

--- a/src/shared/ui/Skeleton/feed/OtherFeedSkeleton.styled.ts
+++ b/src/shared/ui/Skeleton/feed/OtherFeedSkeleton.styled.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const SkeletonContainer = styled.div<{ paddingTop?: number }>`
-  padding-top: ${({ paddingTop }) => (paddingTop !== undefined ? `${paddingTop}px` : '56px')};
+  /* padding-top: ${({ paddingTop }) => (paddingTop !== undefined ? `${paddingTop}px` : '56px')}; */
   background-color: var(--color-black-main);
   min-height: 100vh;
 `;


### PR DESCRIPTION
## 📝작업 내용

피드 탭 초기 진입 시 FollowList 렌더 타이밍과 피드 미리보기 이미지 로딩 방식으로 인해 로딩 지연 체감과 레이아웃 시프트(CLS)가 발생했습니다.

**변경 사항**

- FollowList를 TotalFeed 내부에서 분리하고 Feed에서 직접 렌더하도록 구조 변경
- Feed 초기 로딩 조건에 FollowList 로딩 상태를 포함해 동기화
- FollowList 로딩 UI를 스켈레톤으로 구성하고 실제 레이아웃과 간격/정렬 일치하도록 조정
- 피드 미리보기 이미지를 최대 3개만 렌더하도록 제한
- 피드 미리보기 이미지에 loading="lazy", decoding="async", fetchPriority="low" 적용
- 상단 고정 헤더 기준으로 피드/스켈레톤 패딩 위치 정리


**적용 파일**

- src/pages/feed/Feed.tsx
- src/pages/feed/Feed.styled.ts
- src/components/feed/TotalFeed.tsx
- src/components/feed/TotalFeed.styled.ts
- src/components/feed/FollowList.tsx
- src/components/feed/FollowList.styled.ts
- src/components/common/Post/PostBody.tsx
- src/components/feed/MyFeed.styled.ts
- src/shared/ui/Skeleton/feed/OtherFeedSkeleton.styled.ts

**기대 효과**

- 피드 탭 첫 진입 시 FollowList 컴포넌트의 늦은 랜더링으로 인한 밀림 현상 완화
- 피드 페이지의 스켈레톤 표시 타이밍 일관성 향상
- 피드 카드 이미지 초기 로딩 부담 감소

*위키*
[위키](https://github.com/THIP-TextHip/THIP-Web/wiki/%ED%94%BC%EB%93%9C-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EB%A1%9C%EB%94%A9-%EC%B5%9C%EC%A0%81%ED%99%94-%EB%B0%8F-CLS-%EC%99%84%ED%99%94)에서 자세한 내용 참고부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 피드, 메모리, 검색 페이지에 스켈레톤 로딩 UI 추가
  * 팔로우 목록에 향상된 로딩 상태 표시
  * 그룹 검색에 디바운싱된 검색 기능 추가

* **성능 개선**
  * 게시물 이미지 지연 로딩 및 비동기 로딩 최적화
  * 무한 스크롤 로직 개선

* **버그 수정**
  * 메모리 페이지 부족한 읽기 진도 오류 처리 개선
  * 피드 디테일 페이지 로딩 흐름 단순화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->