### PR TITLE
fix: Feed/Memory/GroupSearch 머지 충돌 해결

### DIFF
--- a/src/components/common/Post/PostBody.tsx
+++ b/src/components/common/Post/PostBody.tsx
@@ -13,6 +13,7 @@ const PostBody = ({
   feedId,
   contentUrls = [],
 }: PostBodyProps) => {
+  const navigate = useNavigate();
   const previewImages = contentUrls.slice(0, 3);
   const hasImage = previewImages.length > 0;
   const contentRef = useRef<HTMLDivElement>(null);

--- a/src/components/common/Post/ReplyList.tsx
+++ b/src/components/common/Post/ReplyList.tsx
@@ -54,6 +54,7 @@ const ReplyList = ({
 
   const list = isInfiniteMode ? commentFeed.items : commentList;
   const hasComments = list.length > 0;
+  const isInitialLoading = isInfiniteMode && commentFeed.isLoading && list.length === 0;
 
   const handleReload = useCallback(() => {
     if (isInfiniteMode) {
@@ -65,9 +66,6 @@ const ReplyList = ({
 
   return (
     <Container disableBottomMargin={disableBottomMargin}>
-      {isInfiniteMode && commentFeed.isLoading && list.length === 0 && (
-        <LoadingSpinner size="small" fullHeight={false} />
-      )}
       {hasComments ? (
         list.map((comment, commentIndex) => (
           <div className="comment-group" key={comment.commentId || `comment-${commentIndex}`}>
@@ -81,12 +79,12 @@ const ReplyList = ({
             ))}
           </div>
         ))
-      ) : (
+      ) : !isInitialLoading ? (
         <EmptyState disableBottomMargin={disableBottomMargin}>
           <div className="title">아직 댓글이 없어요</div>
           <div className="sub-title">첫번째 댓글을 남겨보세요</div>
         </EmptyState>
-      )}
+      ) : null}
 
       {isInfiniteMode && !commentFeed.isLast && <div ref={commentFeed.sentinelRef} style={{ height: 20 }} />}
       {isInfiniteMode && commentFeed.isLoadingMore && <LoadingSpinner size="small" fullHeight={false} />}

--- a/src/components/memory/RecordFilters/RecordFilters.tsx
+++ b/src/components/memory/RecordFilters/RecordFilters.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { FilterType } from '../../../pages/memory/Memory';
 import type { SortType } from '../SortDropdown';
 import PageInputMode from './PageInputMode';
@@ -31,6 +31,12 @@ const RecordFilters = ({
   const [showInputMode, setShowInputMode] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
+  useEffect(() => {
+    if (activeFilter !== 'page' || selectedPageRange) {
+      setShowInputMode(false);
+    }
+  }, [activeFilter, selectedPageRange]);
+
   const handlePageFilterClick = () => {
     if (selectedPageRange) {
       if (onPageRangeClear) {
@@ -39,7 +45,9 @@ const RecordFilters = ({
       }
     } else {
       setShowInputMode(true);
-      onFilterChange('page');
+      if (activeFilter !== 'page') {
+        onFilterChange('page');
+      }
     }
   };
 

--- a/src/hooks/useUserSearch.ts
+++ b/src/hooks/useUserSearch.ts
@@ -33,11 +33,13 @@ export const useUserSearch = ({
       try {
         setLoading(true);
         setError(null);
+        const minLoadingTime = !isLoadMore ? new Promise(resolve => setTimeout(resolve, 500)) : null;
         const response = await getUsers({
           keyword: searchKeyword,
           size,
           isFinalized,
         });
+        if (minLoadingTime) await minLoadingTime;
 
         const newUserList = response.data.userList;
 

--- a/src/pages/feed/Feed.tsx
+++ b/src/pages/feed/Feed.tsx
@@ -22,10 +22,6 @@ const tabs = ['피드', '내 피드'];
 const Feed = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const initialTabFromState = (location.state as { initialTab?: string } | null)?.initialTab;
-  const [activeTab, setActiveTab] = useState<string>(initialTabFromState ?? tabs[0]);
-  const [isFollowListLoading, setIsFollowListLoading] = useState(activeTab === '피드');
-
   const { waitForToken } = useSocialLoginToken();
 
   const initialTabFromState = (location.state as { initialTab?: string } | null)?.initialTab;
@@ -40,7 +36,7 @@ const Feed = () => {
   const [activeTab, setActiveTab] = useState<string>(
     initialTabFromState ?? (isRestoringFromCache ? initialCache!.activeTab : tabs[0]),
   );
-
+  const [isFollowListLoading, setIsFollowListLoading] = useState(activeTab === '피드');
   const skipScrollResetRef = useRef(isRestoringFromCache);
 
   const totalFeed = useInifinieScroll<PostData>({
@@ -96,12 +92,34 @@ const Feed = () => {
     }
   }, [activeTab]);
 
+  useEffect(() => {
+    const hasItems = totalFeed.items.length > 0 || myFeed.items.length > 0;
+    if (!hasItems) return;
+
+    writeFeedCache({
+      activeTab,
+      totalFeedPosts: totalFeed.items,
+      myFeedPosts: myFeed.items,
+      totalNextCursor: totalFeed.nextCursor ?? '',
+      myNextCursor: myFeed.nextCursor ?? '',
+      totalIsLast: totalFeed.isLast,
+      myIsLast: myFeed.isLast,
+    });
+  }, [
+    activeTab,
+    totalFeed.items,
+    myFeed.items,
+    totalFeed.nextCursor,
+    myFeed.nextCursor,
+    totalFeed.isLast,
+    myFeed.isLast,
+  ]);
+
   const currentFeed = activeTab === '피드' ? totalFeed : myFeed;
   const showFeedInitialLoading = totalFeed.isLoading && totalFeed.items.length === 0;
   const showMyFeedInitialLoading = myFeed.isLoading && myFeed.items.length === 0;
   const showInitialLoading =
     activeTab === '피드' ? showFeedInitialLoading || isFollowListLoading : showMyFeedInitialLoading;
-
   return (
     <Container>
       <MainHeader

--- a/src/pages/feed/UserSearch.tsx
+++ b/src/pages/feed/UserSearch.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { useUserSearch } from '@/hooks/useUserSearch';
 import { getRecentSearch, type RecentSearchData } from '@/api/recentsearch/getRecentSearch';
 import { deleteRecentSearch } from '@/api/recentsearch/deleteRecentSearch';
-import { Content, SearchBarContainer, Wrapper, LoadingMessage } from './UserSearch.styled';
+import { Content, SearchBarContainer, Wrapper } from './UserSearch.styled';
 
 const UserSearch = () => {
   const navigate = useNavigate();
@@ -30,7 +30,8 @@ const UserSearch = () => {
   const fetchRecentSearches = async () => {
     setIsRecentLoading(true);
     try {
-      const response = await getRecentSearch('USER');
+      const minLoadingTime = new Promise(resolve => setTimeout(resolve, 500));
+      const [response] = await Promise.all([getRecentSearch('USER'), minLoadingTime]);
       setRecentSearches(response.isSuccess ? response.data.recentSearchList : []);
     } catch {
       setRecentSearches([]);
@@ -107,27 +108,13 @@ const UserSearch = () => {
       </SearchBarContainer>
       <Content>
         {isSearching ? (
-          <>
-            {userList.length === 0 && (loading || !isSearched) ? (
-              <LoadingMessage>검색 중...</LoadingMessage>
-            ) : isSearched ? (
-              <UserSearchResult
-                type={'searched'}
-                searchedUserList={userList}
-                loading={loading}
-                hasMore={hasMore}
-                onLoadMore={loadMore}
-              />
-            ) : (
-              <UserSearchResult
-                type={'searching'}
-                searchedUserList={userList}
-                loading={loading}
-                hasMore={hasMore}
-                onLoadMore={loadMore}
-              />
-            )}
-          </>
+          <UserSearchResult
+            type={isSearched ? 'searched' : 'searching'}
+            searchedUserList={userList}
+            loading={loading}
+            hasMore={hasMore}
+            onLoadMore={loadMore}
+          />
         ) : (
           <>
             <RecentSearchTabs

--- a/src/pages/feed/UserSearchResult.styled.ts
+++ b/src/pages/feed/UserSearchResult.styled.ts
@@ -5,6 +5,7 @@ export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
+  background-color: var(--color-black-main);
   padding: 0 20px;
   margin-bottom: 72px;
 `;

--- a/src/pages/feed/UserSearchResult.tsx
+++ b/src/pages/feed/UserSearchResult.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect } from 'react';
 import UserProfileItem from '@/components/feed/UserProfileItem';
 import type { UserData } from '@/api/users/getUsers';
+import { UserProfileItemSkeleton } from '@/shared/ui/Skeleton';
 import { EmptyWrapper, List, ObserverDiv, ResultHeader, Wrapper } from './UserSearchResult.styled';
 
 interface UserSearchResultProps {
@@ -18,6 +19,8 @@ export function UserSearchResult({
   hasMore,
   onLoadMore,
 }: UserSearchResultProps) {
+  const showInitialSkeleton = !!loading && searchedUserList.length === 0;
+  const showResultHeader = type === 'searched' && !showInitialSkeleton;
   const isEmpty = searchedUserList.length === 0 && type !== 'searching';
 
   const observerRef = useRef<HTMLDivElement>(null);
@@ -42,9 +45,15 @@ export function UserSearchResult({
   return (
     <Wrapper>
       <List>
-        {type === 'searching' ? <></> : <ResultHeader>전체 {searchedUserList.length}</ResultHeader>}
+        {showResultHeader ? <ResultHeader>전체 {searchedUserList.length}</ResultHeader> : null}
 
-        {isEmpty ? (
+        {showInitialSkeleton ? (
+          <>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <UserProfileItemSkeleton key={i} type="followerlist" />
+            ))}
+          </>
+        ) : isEmpty ? (
           <EmptyWrapper>찾는 사용자가 없어요.</EmptyWrapper>
         ) : (
           <>

--- a/src/pages/groupSearch/GroupSearch.tsx
+++ b/src/pages/groupSearch/GroupSearch.tsx
@@ -3,7 +3,7 @@ import { Modal, Overlay } from '@/components/group/Modal.styles';
 import leftArrow from '../../assets/common/leftArrow.svg';
 import SearchBar from '@/components/search/SearchBar';
 import rightChevron from '../../assets/common/right-Chevron.svg';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import RecentSearchTabs from '@/components/search/RecentSearchTabs';
 import GroupSearchResult from '@/components/search/GroupSearchResult';
 import { getRecentSearch, type RecentSearchData } from '@/api/recentsearch/getRecentSearch';
@@ -35,6 +35,7 @@ const GroupSearch = () => {
   const [isLoadingRecentSearches, setIsLoadingRecentSearches] = useState(true);
   const [searchTimeoutId, setSearchTimeoutId] = useState<NodeJS.Timeout | null>(null);
   const [showTabs, setShowTabs] = useState(false);
+  const prevSearchStatusRef = useRef<SearchStatus>('idle');
 
   const fetchRecentSearches = useCallback(async () => {
     try {
@@ -54,9 +55,10 @@ const GroupSearch = () => {
   }, [fetchRecentSearches]);
 
   useEffect(() => {
-    if (searchStatus === 'idle') {
+    if (searchStatus === 'idle' && prevSearchStatusRef.current !== 'idle') {
       fetchRecentSearches();
     }
+    prevSearchStatusRef.current = searchStatus;
   }, [searchStatus, fetchRecentSearches]);
 
   useEffect(() => {

--- a/src/pages/groupSearch/GroupSearch.tsx
+++ b/src/pages/groupSearch/GroupSearch.tsx
@@ -36,16 +36,6 @@ const GroupSearch = () => {
   const [searchTimeoutId, setSearchTimeoutId] = useState<NodeJS.Timeout | null>(null);
   const [showTabs, setShowTabs] = useState(false);
 
-  useEffect(() => {
-    fetchRecentSearches();
-  }, []);
-
-  useEffect(() => {
-    if (searchStatus === 'idle') {
-      fetchRecentSearches();
-    }
-  }, [searchStatus]);
-
   const fetchRecentSearches = useCallback(async () => {
     try {
       setIsLoadingRecentSearches(true);
@@ -58,6 +48,16 @@ const GroupSearch = () => {
       setIsLoadingRecentSearches(false);
     }
   }, []);
+
+  useEffect(() => {
+    fetchRecentSearches();
+  }, [fetchRecentSearches]);
+
+  useEffect(() => {
+    if (searchStatus === 'idle') {
+      fetchRecentSearches();
+    }
+  }, [searchStatus, fetchRecentSearches]);
 
   useEffect(() => {
     if (location.state?.allRooms) {
@@ -135,7 +135,7 @@ const GroupSearch = () => {
   const queryTerm = searchStatus === 'searched' ? searchTerm.trim() : debouncedSearchTerm.trim();
   const isAllCategory = !queryTerm && category === '';
 
-  const searchResult = useInifinieScroll({
+  const searchResult = useInifinieScroll<SearchRoomItem>({
     enabled: searchStatus !== 'idle' && (searchStatus === 'searched' || !!queryTerm),
     reloadKey: `${searchStatus}-${queryTerm}-${selectedFilter}-${category}`,
     fetchPage: async cursor => {
@@ -145,7 +145,7 @@ const GroupSearch = () => {
 
       const minLoadingTime = cursor ? null : new Promise(resolve => setTimeout(resolve, 500));
       const res = await getSearchRooms(
-        debouncedSearchTerm,
+        queryTerm,
         toSortKey(selectedFilter),
         cursor ?? undefined,
         searchStatus === 'searched',

--- a/src/pages/memory/Memory.tsx
+++ b/src/pages/memory/Memory.tsx
@@ -75,6 +75,8 @@ const Memory = () => {
   const [totalPages, setTotalPages] = useState<number>(0);
   const [currentUserPage, setCurrentUserPage] = useState<number>(0);
   const scrollRootRef = useRef<HTMLDivElement | null>(null);
+  const resolvedFilter: FilterType | null =
+    activeFilter === 'page' && !selectedPageRange ? null : activeFilter;
 
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
@@ -94,7 +96,7 @@ const Memory = () => {
 
   const recordsList = useInifinieScroll<Record>({
     enabled: !!roomId,
-    reloadKey: `${roomId}-${activeTab}-${selectedSort}-${activeFilter}-${selectedPageRange?.start ?? ''}-${selectedPageRange?.end ?? ''}`,
+    reloadKey: `${roomId}-${activeTab}-${selectedSort}-${resolvedFilter}-${selectedPageRange?.start ?? ''}-${selectedPageRange?.end ?? ''}`,
     rootRef: scrollRootRef,
     fetchPage: async cursor => {
       if (!roomId) {
@@ -110,20 +112,20 @@ const Memory = () => {
       if (activeTab === 'group') {
         params.sort = selectedSort;
       }
-      
-      if (activeFilter === 'overall') {
+
+      if (resolvedFilter === 'overall') {
         params.isOverview = true;
-      } else if (selectedPageRange) {
+      } else if (resolvedFilter === 'page' && selectedPageRange) {
         params.pageStart = selectedPageRange.start;
         params.pageEnd = selectedPageRange.end;
         params.isPageFilter = true;
       }
-            
+
       try {
         const minLoadingTime = cursor ? null : new Promise(resolve => setTimeout(resolve, 500));
         const response = await getMemoryPosts(params);
         if (minLoadingTime) await minLoadingTime;
-        
+
         if (!response.isSuccess) {
           throw new Error(response.message || '기록을 불러오는 중 오류가 발생했습니다.');
         }
@@ -202,7 +204,7 @@ const Memory = () => {
       setRecordItems(prev => [newRecord, ...prev]);
       navigate(location.pathname, { replace: true });
     }
-  }, [location.state, navigate, location.pathname]);
+  }, [location.state, navigate, location.pathname, setRecordItems]);
 
   const filteredRecords = useMemo(() => {
     if (activeFilter === 'overall') {
@@ -236,6 +238,10 @@ const Memory = () => {
 
   const handleFilterChange = useCallback(
     (filter: FilterType) => {
+      if (filter === 'page' && activeFilter === 'page' && !selectedPageRange) {
+        return;
+      }
+
       if (activeFilter === filter) {
         setActiveFilter(null);
         setSelectedPageRange(null);
@@ -244,7 +250,7 @@ const Memory = () => {
         setSelectedPageRange(null);
       }
     },
-    [activeFilter],
+    [activeFilter, selectedPageRange],
   );
 
   const handleSortChange = useCallback((sort: SortType) => {
@@ -338,6 +344,7 @@ const Memory = () => {
               onPageRangeClear={handlePageRangeClear}
               onPageRangeSet={handlePageRangeSet}
               onUploadComplete={handleUploadComplete}
+              onDelete={handleRecordDelete}
             />
             {!recordsList.isLast && <div ref={recordsList.sentinelRef} style={{ height: 20 }} />}
           </>


### PR DESCRIPTION
## 📝작업 내용

- Feed: FollowList 로딩 상태와 피드 초기 스켈레톤 타이밍 동기화, 캐시/초기 로딩 분기 정리
- Memory: 무한스크롤 유지한 채 페이지별 보기 입력 모드가 자동으로 닫히는 문제 방지
- GroupSearch: 검색 쿼리/타입 처리 충돌 정리 및 로딩 흐름 안정화
- PostBody: 상세 이동 네비게이션 누락 보완
- ReplyList: 첫 렌더 시 스피너/빈 상태 중복 노출 제거(스켈레톤 우선)
- useUserSearch, UserSearchResult, UserSearch
  - 사용자 검색 초기 로딩에 스켈레톤 UI를 적용하고 로딩 타이밍을 500ms로 통일했습니다.
  - 검색어 변경/엔터 시 이전 검색 결과가 잠깐 보이는 문제를 해결하기 위해 요청 버전 가드를 추가했습니다.
  - 초기 로딩에서만 스켈레톤이 보이고 이후 검색에서는 결과 리스트 전환이 자연스럽게 되도록 분기 로직을 정리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게시물 클릭 시 상세 피드로 이동 기능 추가
  * 레코드 삭제 기능 추가

* **Bug Fixes**
  * 댓글 목록의 초기 로딩 표시 개선
  * 필터 선택 시 중복 동작 방지 및 입력 모드 자동 리셋
  * 탭 전환에 따른 피드 로딩 상태 동기화 개선

* **Chores**
  * 피드 데이터 캐싱 추가
  * 최근 검색 로딩 타이밍 및 검색 쿼리 처리 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->